### PR TITLE
chore(release): v0.1.1 — README launch-video patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@testsprite/testsprite-cli` are documented here. The for
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-12
+
+### Changed
+
+- README: point the launch video at the updated public asset. Docs-only release — no code changes.
+
 ## [0.1.0] - 2026-06-10
 
 ### Added
@@ -106,5 +112,6 @@ All notable changes to `@testsprite/testsprite-cli` are documented here. The for
 
 - Commander `help [command]` exits 0 (previously exited 5 on `test help` / `project help`).
 
-[Unreleased]: https://github.com/TestSprite/testsprite-cli/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/TestSprite/testsprite-cli/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/TestSprite/testsprite-cli/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/TestSprite/testsprite-cli/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -34,11 +34,7 @@ AI ships code in minutes — verifying it hasn't. `testsprite` opens your live a
 
 </div>
 
-
-
 https://github.com/user-attachments/assets/eca90a91-93ef-49f6-8d13-86b4eb25f4cf
-
-
 
 <p align="center"><sub><b>▶ Watch the launch video</b> — the three hard limits every coding agent hits, and the loop that breaks them (4 min).</sub></p>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@testsprite/testsprite-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@testsprite/testsprite-cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testsprite/testsprite-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Official TestSprite command-line interface",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What

Docs-only patch release. The npm `0.1.0` package was published before the README launch video was updated on `main` (commit 941cc368), so the npm page still embeds the old video. npm READMEs are immutable per version — shipping `0.1.1` to refresh it.

- Prettier-clean the README video block — fixes the `format:check` failure currently breaking CI on `main`
- Bump version `0.1.0` → `0.1.1`
- CHANGELOG: add `[0.1.1]` docs-only entry

## Verification

Full release-workflow check chain run locally: `lint` / `typecheck` / `format:check` / `test:coverage` (87.76% statements) / `build` — all green. Packed tarball README verified to contain the new launch-video asset only; file list identical to the published 0.1.0 tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)