### PR TITLE
ci(release): switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,17 +9,18 @@ jobs:
       contents: read
       id-token: write # npm provenance
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
+      # npm trusted publishing (OIDC) requires npm >= 11.5.1; Node 22 bundles npm 10.x
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run format:check
       - run: npm run test:coverage
       - run: npm run build
+      # Auth via npm trusted publishing (OIDC) — no token needed; provenance is implied
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

The `v0.1.1` release run ([27390225310](https://github.com/TestSprite/testsprite-cli/actions/runs/27390225310)) failed at `npm publish` with `ENEEDAUTH`: the workflow referenced `secrets.NPM_TOKEN`, but no such secret exists at the repo or org level.

Instead of provisioning a token, this switches auth to [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC), already configured on npmjs.com for this repo + `release.yaml`.

## Changes

- Drop `NODE_AUTH_TOKEN` env from the publish step — an empty token in `.npmrc` would shadow OIDC auth
- Add `npm install -g npm@latest` — trusted publishing requires npm ≥ 11.5.1, Node 22 bundles 10.x
- Bump `actions/checkout` and `actions/setup-node` to v5 ahead of the [June 16 Node 20 runner cutoff](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

No token, no expiry, no rotation; provenance comes from the OIDC flow.

## Note

`v0.1.1` was already published to npm manually (3 min before the CI attempt), so no tag re-push is needed — this fix takes effect from the next release tag onward.

