### PR TITLE
fix(config): treat empty env vars as unset in loadConfig

### DIFF
--- a/src/commands/auth.test.ts
+++ b/src/commands/auth.test.ts
@@ -850,6 +850,21 @@ describe('runWhoami', () => {
     expect(printed).toEqual(sampleMe);
   });
 
+  it('dry-run: whitespace-only TESTSPRITE_API_URL falls through to prod default endpoint', async () => {
+    const { capture, deps } = makeCapture();
+    await runWhoami(
+      { profile: 'default', output: 'text', debug: false, dryRun: true },
+      {
+        ...deps,
+        env: { TESTSPRITE_API_URL: '   ' },
+        credentialsPath,
+        fetchImpl: makeFetch(meResponse()),
+      },
+    );
+    const out = capture.stdout.join('\n');
+    expect(out).toContain('endpoint: https://api.testsprite.com');
+  });
+
   it('L1788: text output includes the resolved endpoint URL', async () => {
     writeProfile(
       'default',

--- a/src/commands/auth.test.ts
+++ b/src/commands/auth.test.ts
@@ -858,7 +858,6 @@ describe('runWhoami', () => {
         ...deps,
         env: { TESTSPRITE_API_URL: '   ' },
         credentialsPath,
-        fetchImpl: makeFetch(meResponse()),
       },
     );
     const out = capture.stdout.join('\n');

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -17,7 +17,7 @@ import {
   readProfile,
   writeProfile,
 } from '../lib/credentials.js';
-import { loadConfig } from '../lib/config.js';
+import { loadConfig, normalizeEnvVar } from '../lib/config.js';
 import { emitDeprecationNotice } from '../lib/deprecate.js';
 import type { OutputMode } from '../lib/output.js';
 import { GLOBAL_OPTS_HINT, Output, resolveOutputMode } from '../lib/output.js';
@@ -85,7 +85,7 @@ export async function runConfigure(opts: ConfigureOptions, deps: AuthDeps = {}):
   // treated as unset. Without this, `''` (e.g. `export TESTSPRITE_API_URL=` in a
   // shell profile) is non-nullish and would short-circuit the `??` chains below to
   // an empty endpoint instead of falling through to the profile / prod default.
-  const envApiUrl = env.TESTSPRITE_API_URL?.trim() || undefined;
+  const envApiUrl = normalizeEnvVar(env.TESTSPRITE_API_URL);
 
   // Dry-run: do not prompt, do not read env, do not write credentials.
   // Print the canned success shape so an agent sees exactly the JSON it
@@ -208,7 +208,8 @@ export async function runWhoami(opts: CommonOptions, deps: AuthDeps = {}): Promi
   // displayed URL always matches where requests actually go (dogfood L1788).
   let resolvedEndpoint: string;
   if (opts.dryRun) {
-    resolvedEndpoint = opts.endpointUrl ?? env.TESTSPRITE_API_URL ?? 'https://api.testsprite.com';
+    resolvedEndpoint =
+      opts.endpointUrl ?? normalizeEnvVar(env.TESTSPRITE_API_URL) ?? 'https://api.testsprite.com';
   } else {
     const credentialsPath = deps.credentialsPath ?? defaultCredentialsPath();
     const config = loadConfig({

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,6 +15,7 @@ import {
   parseRequestTimeoutFlag,
   type CommonOptions as FactoryCommonOptions,
 } from '../lib/client-factory.js';
+import { normalizeEnvVar } from '../lib/config.js';
 import { emitDeprecationNotice } from '../lib/deprecate.js';
 import { CLIError } from '../lib/errors.js';
 import { GLOBAL_OPTS_HINT, Output, resolveOutputMode } from '../lib/output.js';
@@ -39,7 +40,7 @@ const DEFAULT_API_URL = 'https://api.testsprite.com';
  */
 function resolveReportedEndpoint(opts: InitOptions, deps: InitDeps): string {
   const env = deps.env ?? process.env;
-  const envApiUrl = env.TESTSPRITE_API_URL?.trim() || undefined;
+  const envApiUrl = normalizeEnvVar(env.TESTSPRITE_API_URL);
   let existing: string | undefined;
   try {
     existing = readProfile(opts.profile, { path: deps.credentialsPath })?.apiUrl;

--- a/src/lib/client-factory.test.ts
+++ b/src/lib/client-factory.test.ts
@@ -339,7 +339,6 @@ describe('makeHttpClient - API key validation', () => {
     ['smart dash', 'sk-user-abc\u2013def'],
     ['smart quote', 'sk-user-\u201cabc\u201d'],
     ['emoji', 'sk-user-abc\u{1f600}'],
-    ['whitespace-only', '   '],
   ])('rejects a malformed configured API key with %s before fetch/retry', (_label, apiKey) => {
     const fetchImpl = vi.fn();
     let caught: unknown;
@@ -361,6 +360,26 @@ describe('makeHttpClient - API key validation', () => {
     expect(apiErr.code).toBe('VALIDATION_ERROR');
     expect(apiErr.exitCode).toBe(5);
     expect(apiErr.nextAction).toContain('api-key');
+  });
+
+  it('treats a whitespace-only TESTSPRITE_API_KEY env var as unset (AUTH_REQUIRED)', () => {
+    const fetchImpl = vi.fn();
+    let caught: unknown;
+    try {
+      makeHttpClient(
+        { profile: 'default', output: 'json', debug: false, dryRun: false },
+        {
+          env: { TESTSPRITE_API_KEY: '   ' } as NodeJS.ProcessEnv,
+          credentialsPath: NO_CREDS_PATH,
+          fetchImpl,
+        },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(caught).toBeInstanceOf(ApiError);
+    expect((caught as ApiError).code).toBe('AUTH_REQUIRED');
   });
 });
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -81,6 +81,28 @@ describe('loadConfig', () => {
     const config = loadConfig({ profile: 'dev', env: {}, credentialsPath });
     expect(config.apiKey).toBe('sk-dev');
   });
+
+  it('treats empty / whitespace TESTSPRITE_API_URL as unset (falls through to profile)', () => {
+    writeProfile(
+      'default',
+      { apiKey: 'sk-file', apiUrl: 'https://api.example.com:8443' },
+      { path: credentialsPath },
+    );
+    const config = loadConfig({
+      env: { TESTSPRITE_API_URL: '   ' },
+      credentialsPath,
+    });
+    expect(config.apiUrl).toBe('https://api.example.com:8443');
+  });
+
+  it('treats empty / whitespace TESTSPRITE_API_KEY as unset (falls through to profile)', () => {
+    writeProfile('default', { apiKey: 'sk-file' }, { path: credentialsPath });
+    const config = loadConfig({
+      env: { TESTSPRITE_API_KEY: '' },
+      credentialsPath,
+    });
+    expect(config.apiKey).toBe('sk-file');
+  });
 });
 
 describe('defaultConfigPath', () => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -17,6 +17,11 @@ export interface LoadConfigOptions {
 
 const DEFAULT_API_URL = 'https://api.testsprite.com';
 
+/** Treat empty / whitespace-only env values as unset for `??` resolution chains. */
+export function normalizeEnvVar(value: string | undefined): string | undefined {
+  return value?.trim() || undefined;
+}
+
 export function defaultConfigPath(): string {
   return join(homedir(), '.testsprite', 'config');
 }
@@ -38,9 +43,15 @@ export function loadConfig(options: LoadConfigOptions = {}): Config {
   const credentialsPath = options.credentialsPath ?? defaultCredentialsPath();
   const fileEntry = readProfile(profile, { path: credentialsPath });
 
+  // Empty / whitespace-only env vars are treated as unset so they do not
+  // short-circuit the `??` chain (e.g. `export TESTSPRITE_API_URL=` in a shell
+  // profile). Matches the normalization in auth configure and init/setup.
+  const envApiUrl = normalizeEnvVar(env.TESTSPRITE_API_URL);
+  const envApiKey = normalizeEnvVar(env.TESTSPRITE_API_KEY);
+
   return {
-    apiUrl: options.endpointUrl ?? env.TESTSPRITE_API_URL ?? fileEntry?.apiUrl ?? DEFAULT_API_URL,
-    apiKey: env.TESTSPRITE_API_KEY ?? fileEntry?.apiKey,
+    apiUrl: options.endpointUrl ?? envApiUrl ?? fileEntry?.apiUrl ?? DEFAULT_API_URL,
+    apiKey: envApiKey ?? fileEntry?.apiKey,
     profile,
   };
 }


### PR DESCRIPTION
## Summary

When `TESTSPRITE_API_URL` or `TESTSPRITE_API_KEY` is set but empty/whitespace (e.g. `export TESTSPRITE_API_URL=` in a shell profile), runtime commands no longer resolve to a broken empty endpoint or ignore stored credentials. Matches the normalization already used in `auth configure` / `init`.

**Split from #8** per review - bundle re-commit work moved to a separate PR.

## Changes

- `normalizeEnvVar` exported from `loadConfig` and used for `TESTSPRITE_API_URL` / `TESTSPRITE_API_KEY`
- `auth configure` / `runWhoami` dry-run use the shared helper
- `init` endpoint reporting uses the shared helper

## Testing

- `npx vitest run src/lib/config.test.ts` - 11 passed
- `npx vitest run src/commands/auth.test.ts -t "whitespace|empty / whitespace"` - 4 passed
- `npm run typecheck` and `npm run lint` - pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Empty or whitespace-only environment values are now treated as unset, so API URL/API key fallback chains no longer stop at blank strings.
  - Dry-run auth/init flows now resolve to the correct default endpoint when the env URL is blank.
  - HTTP client behavior is corrected so blank API keys trigger the expected “auth required” outcome.

- **New Features**
  - Centralized environment-variable normalization is now used across configuration and command flows.

- **Tests**
  - Expanded coverage for blank API URL/API key handling in config, auth, and client creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->