### PR TITLE
feat(agent): add kiro as an install target

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -113,14 +113,15 @@ testsprite agent install codex      # install into AGENTS.md for Codex (managed-
 testsprite agent install cursor     # .cursor/rules/testsprite-verify.mdc
 testsprite agent install cline      # .clinerules/testsprite-verify.md
 testsprite agent install antigravity  # .agents/skills/testsprite-verify/SKILL.md
-testsprite agent list               # list all 5 targets with status + mode + path
+testsprite agent install kiro       # .kiro/skills/testsprite-verify/SKILL.md
+testsprite agent list               # list all 6 targets with status + mode + path
 ```
 
-Supported targets: `claude` (GA), `codex` (experimental), `cursor` (experimental), `cline` (experimental), `antigravity` (experimental).
+Supported targets: `claude` (GA), `codex` (experimental), `cursor` (experimental), `cline` (experimental), `antigravity` (experimental), `kiro` (experimental).
 
 The `codex` target uses **managed-section mode** — it writes only a sentinel-delimited section inside your existing `AGENTS.md`, so your project instructions are never clobbered. Re-running without `--force` replaces the section in-place; user content outside the sentinels is always preserved.
 
-Re-running with `--force` on **own-file targets** (claude, cursor, cline, antigravity) backs up the existing file to `<path>.bak` first.
+Re-running with `--force` on **own-file targets** (claude, cursor, cline, antigravity, kiro) backs up the existing file to `<path>.bak` first.
 
 ## Command reference
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Prefer to configure each step by hand (or learn the surface offline with `--dry-
 |           | `test rerun`                                        | Cheap replay of one/many tests (FE verbatim; BE with deps); `--all --project <id>` reruns all tests                   |
 |           | `test wait`                                         | Block on a `runId` until terminal                                                                                     |
 |           | `test artifact get`                                 | Download the failure bundle for a specific `runId`                                                                    |
-| **Agent** | `agent install` / `agent list`                      | Add or list coding-agent targets (pure-local): `claude`, `codex`, `cursor`, `cline`, `antigravity`                    |
+| **Agent** | `agent install` / `agent list`                      | Add or list coding-agent targets (pure-local): `claude`, `codex`, `cursor`, `cline`, `antigravity`, `kiro`            |
 
 > The earlier command names — `init`, `auth configure`, `auth whoami`, `auth logout` — still work as hidden, deprecated aliases (each prints a one-line notice pointing at the new name), so existing scripts keep running. `auth configure` now runs the full `setup` (it also installs the skill).
 

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -741,6 +741,7 @@ describe('runList', () => {
     expect(out).toContain('cursor');
     expect(out).toContain('cline');
     expect(out).toContain('antigravity');
+    expect(out).toContain('kiro');
     expect(out).toContain('codex');
     expect(out).toContain('ga');
     expect(out).toContain('experimental');
@@ -749,6 +750,7 @@ describe('runList', () => {
     expect(out).toContain(TARGETS.cursor.path);
     expect(out).toContain(TARGETS.cline.path);
     expect(out).toContain(TARGETS.antigravity.path);
+    expect(out).toContain(TARGETS.kiro.path);
     expect(out).toContain(TARGETS.codex.path);
   });
 
@@ -759,13 +761,14 @@ describe('runList', () => {
 
     const json = JSON.parse(capture.stdout.join('\n')) as ListResult[];
     expect(Array.isArray(json)).toBe(true);
-    // 5 targets × 2 default skills = 10 rows
-    expect(json).toHaveLength(10);
+    // 6 targets × 2 default skills = 12 rows
+    expect(json).toHaveLength(12);
     const targets = json.map(r => r.target);
     expect(targets).toContain('claude');
     expect(targets).toContain('cursor');
     expect(targets).toContain('cline');
     expect(targets).toContain('antigravity');
+    expect(targets).toContain('kiro');
     expect(targets).toContain('codex');
     // skill field present on each row
     const skills = json.map(r => r.skill);
@@ -905,11 +908,11 @@ describe('createAgentCommand wiring', () => {
 });
 
 // ---------------------------------------------------------------------------
-// All four own-file targets installed at once
+// All five own-file targets installed at once
 // ---------------------------------------------------------------------------
 
-describe('runInstall — all four own-file targets', () => {
-  it('installs all four own-file targets in one invocation', async () => {
+describe('runInstall — all five own-file targets', () => {
+  it('installs all five own-file targets in one invocation', async () => {
     const { store, fs: agentFs } = makeMemFs();
     const { capture, deps } = makeCapture();
 
@@ -919,7 +922,7 @@ describe('runInstall — all four own-file targets', () => {
         output: 'text',
         debug: false,
         dryRun: false,
-        target: ['claude', 'cursor', 'cline', 'antigravity'],
+        target: ['claude', 'cursor', 'cline', 'antigravity', 'kiro'],
         skills: ['testsprite-verify'],
         force: false,
       },
@@ -937,11 +940,11 @@ describe('runInstall — all four own-file targets', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Dry-run for all four own-file targets
+// Dry-run for all five own-file targets
 // ---------------------------------------------------------------------------
 
 describe('runInstall — dry-run all own-file targets', () => {
-  it('writes nothing for any of the four own-file targets (default 2 skills = 8 would-write lines)', async () => {
+  it('writes nothing for any of the five own-file targets (default 2 skills = 10 would-write lines)', async () => {
     const { store, fs: agentFs } = makeMemFs();
     const { capture, deps } = makeCapture();
 
@@ -951,7 +954,7 @@ describe('runInstall — dry-run all own-file targets', () => {
         output: 'text',
         debug: false,
         dryRun: true,
-        target: ['claude', 'cursor', 'cline', 'antigravity'],
+        target: ['claude', 'cursor', 'cline', 'antigravity', 'kiro'],
         force: false,
       },
       { cwd: CWD, fs: agentFs, ...deps },
@@ -961,9 +964,9 @@ describe('runInstall — dry-run all own-file targets', () => {
     const stderrOut = capture.stderr.join('\n');
     // Banner appears once
     expect(stderrOut).toContain('[dry-run] no files written');
-    // 4 targets × 2 default skills = 8 would-write lines
+    // 5 targets × 2 default skills = 10 would-write lines
     const wouldWriteLines = stderrOut.split('\n').filter(l => l.includes('would write'));
-    expect(wouldWriteLines.length).toBe(8);
+    expect(wouldWriteLines.length).toBe(10);
   });
 });
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -809,7 +809,7 @@ export function createAgentCommand(deps: AgentDeps = {}): Command {
     )
     .option(
       '--target <t>',
-      'Agent target(s): claude, cursor, cline, antigravity, codex (comma-separated or repeated)',
+      'Agent target(s): claude, cursor, cline, antigravity, kiro, codex (comma-separated or repeated)',
       collect,
       [],
     )

--- a/src/lib/agent-targets.test.ts
+++ b/src/lib/agent-targets.test.ts
@@ -74,19 +74,20 @@ testsprite test artifact get <run-id> --out ./out/
 // ---------------------------------------------------------------------------
 
 describe('TARGETS', () => {
-  it('has all five required keys', () => {
+  it('has all six required keys', () => {
     const keys = Object.keys(TARGETS).sort();
-    expect(keys).toEqual(['antigravity', 'claude', 'cline', 'codex', 'cursor']);
+    expect(keys).toEqual(['antigravity', 'claude', 'cline', 'codex', 'cursor', 'kiro']);
   });
 
   it('claude is GA', () => {
     expect(TARGETS.claude.status).toBe('ga');
   });
 
-  it('cursor, cline, antigravity, and codex are experimental', () => {
+  it('cursor, cline, antigravity, kiro, and codex are experimental', () => {
     expect(TARGETS.cursor.status).toBe('experimental');
     expect(TARGETS.cline.status).toBe('experimental');
     expect(TARGETS.antigravity.status).toBe('experimental');
+    expect(TARGETS.kiro.status).toBe('experimental');
     expect(TARGETS.codex.status).toBe('experimental');
   });
 
@@ -102,6 +103,7 @@ describe('TARGETS', () => {
     expect(TARGETS.antigravity.mode).toBe('own-file');
     expect(TARGETS.cursor.mode).toBe('own-file');
     expect(TARGETS.cline.mode).toBe('own-file');
+    expect(TARGETS.kiro.mode).toBe('own-file');
   });
 
   it('codex target has mode managed-section', () => {
@@ -200,6 +202,22 @@ describe('renderForTarget("antigravity")', () => {
   });
 });
 
+describe('renderForTarget("kiro")', () => {
+  const result = renderForTarget('kiro', 'testsprite-verify', STUB_BODY);
+
+  it('returns the correct path', () => {
+    expect(result.path).toBe('.kiro/skills/testsprite-verify/SKILL.md');
+  });
+
+  it('frontmatter contains name: testsprite-verify', () => {
+    expect(result.content).toContain('name: testsprite-verify');
+  });
+
+  it('frontmatter contains description:', () => {
+    expect(result.content).toContain(`description: ${SKILL_DESCRIPTION}`);
+  });
+});
+
 describe('renderForTarget("claude") vs renderForTarget("antigravity")', () => {
   it('produce the same frontmatter lines (name + description)', () => {
     const claude = renderForTarget('claude', 'testsprite-verify', STUB_BODY);
@@ -274,11 +292,12 @@ describe('renderForTarget("cline")', () => {
 // ---------------------------------------------------------------------------
 
 describe('content integrity — own-file targets', () => {
-  const ownFileTargets: Array<'claude' | 'cursor' | 'cline' | 'antigravity'> = [
+  const ownFileTargets: Array<'claude' | 'cursor' | 'cline' | 'antigravity' | 'kiro'> = [
     'claude',
     'cursor',
     'cline',
     'antigravity',
+    'kiro',
   ];
 
   // Use the real body for these checks, since we're guarding against trimming.

--- a/src/lib/agent-targets.ts
+++ b/src/lib/agent-targets.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 
-export type AgentTarget = 'claude' | 'cursor' | 'cline' | 'antigravity' | 'codex';
+export type AgentTarget = 'claude' | 'cursor' | 'cline' | 'antigravity' | 'codex' | 'kiro';
 
 export interface TargetSpec {
   status: 'ga' | 'experimental';
@@ -140,6 +140,8 @@ export function pathFor(target: AgentTarget, skill: string): string {
       return `.cursor/rules/${skill}.mdc`;
     case 'cline':
       return `.clinerules/${skill}.md`;
+    case 'kiro':
+      return `.kiro/skills/${skill}/SKILL.md`;
     case 'codex':
       return 'AGENTS.md';
   }
@@ -169,6 +171,14 @@ export const TARGETS: Record<AgentTarget, TargetSpec> = {
     path: pathFor('cline', SKILL_NAME),
     mode: 'own-file',
     wrap: (_name, _description, body) => body,
+  },
+  kiro: {
+    status: 'experimental',
+    path: pathFor('kiro', SKILL_NAME),
+    mode: 'own-file',
+    // kiro reads SKILL.md files with name/description frontmatter, same as
+    // claude/antigravity, so it shares the wrapSkill wrapper.
+    wrap: wrapSkill,
   },
   /**
    * codex target — managed-section mode.

--- a/test/__snapshots__/help.snapshot.test.ts.snap
+++ b/test/__snapshots__/help.snapshot.test.ts.snap
@@ -25,8 +25,8 @@ Write the TestSprite agent skills (verification loop + first-run onboarding)
 into a project for a coding agent
 
 Options:
-  --target <t>    Agent target(s): claude, cursor, cline, antigravity, codex
-                  (comma-separated or repeated) (default: [])
+  --target <t>    Agent target(s): claude, cursor, cline, antigravity, kiro,
+                  codex (comma-separated or repeated) (default: [])
   --skill <name>  Skill(s) to install: testsprite-verify, testsprite-onboard
                   (comma-separated or repeated; default: all) (default: [])
   --dir <path>    Project root to write into (default: cwd)
@@ -112,7 +112,8 @@ Options:
   --from-env        Read TESTSPRITE_API_KEY from the environment instead of
                     prompting (default: false)
   --agent <target>  Coding-agent target to install: claude, antigravity,
-                    cursor, cline, codex (default: claude) (default: "claude")
+                    cursor, cline, kiro, codex (default: claude) (default:
+                    "claude")
   --no-agent        Skip the agent skill install (configure credentials only)
   --force           Overwrite an existing skill file (a .bak backup is kept)
   --dir <path>      Project root for the skill install (default: current

--- a/test/e2e/agent-install.e2e.test.ts
+++ b/test/e2e/agent-install.e2e.test.ts
@@ -430,13 +430,13 @@ describe('dry-run', () => {
 // ---------------------------------------------------------------------------
 
 describe('multi-target install', () => {
-  it('--target=claude,cursor,cline,antigravity,codex writes all targets + skills, exit 0', () => {
+  it('--target=claude,cursor,cline,antigravity,kiro,codex writes all targets + skills, exit 0', () => {
     const tmpDir = freshTmpDir();
 
     const result = runCli([
       'agent',
       'install',
-      '--target=claude,cursor,cline,antigravity,codex',
+      '--target=claude,cursor,cline,antigravity,kiro,codex',
       '--dir',
       tmpDir,
       '--output',
@@ -449,7 +449,7 @@ describe('multi-target install', () => {
       action: string;
       path: string;
     }>;
-    const allTargets: AgentTarget[] = ['claude', 'cursor', 'cline', 'antigravity', 'codex'];
+    const allTargets: AgentTarget[] = ['claude', 'cursor', 'cline', 'antigravity', 'kiro', 'codex'];
 
     for (const target of allTargets) {
       if (TARGETS[target].mode === 'managed-section') {
@@ -819,7 +819,14 @@ describe('agent list', () => {
 // ---------------------------------------------------------------------------
 describe('matrix coverage guard', () => {
   it('TARGETS matches the documented, e2e-covered set (update this list when adding a target)', () => {
-    expect(Object.keys(TARGETS)).toEqual(['claude', 'antigravity', 'cursor', 'cline', 'codex']);
+    expect(Object.keys(TARGETS)).toEqual([
+      'claude',
+      'antigravity',
+      'cursor',
+      'cline',
+      'kiro',
+      'codex',
+    ]);
   });
 
   it('SKILLS matches the documented, e2e-covered set (update this list when adding a skill)', () => {

--- a/test/e2e/setup.e2e.test.ts
+++ b/test/e2e/setup.e2e.test.ts
@@ -222,7 +222,14 @@ describe('deprecated `init` alias', () => {
 
 describe('matrix coverage guard', () => {
   it('TARGETS matches the documented set (update this list when adding a target)', () => {
-    expect(Object.keys(TARGETS)).toEqual(['claude', 'antigravity', 'cursor', 'cline', 'codex']);
+    expect(Object.keys(TARGETS)).toEqual([
+      'claude',
+      'antigravity',
+      'cursor',
+      'cline',
+      'kiro',
+      'codex',
+    ]);
   });
 });
 


### PR DESCRIPTION
Closes #170

Adds **kiro** as a new agent install target.

## Changes

- Added `kiro` to the `AgentTarget` type union
- Added kiro entry to `TARGETS` map:
 - path: `.kiro/skills/testsprite-verify/SKILL.md`
 - mode: `own-file`
 - status: `experimental`
 - wrap: `wrapSkill` (same frontmatter as claude/antigravity)
- Updated test coverage (68 tests passing in agent-targets.test.ts)
- Updated DOCUMENTATION.md with kiro install example
- Updated README.md supported targets list

## Testing

- `npm run lint:fix` - clean
- `npm run format` - clean
- `npm run typecheck` - clean
- `npm test` (agent-targets.test.ts) - 68/68 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `kiro` as a supported coding-agent target (own-file, experimental) in `agent install` and `agent list`.
  * Expanded `--force` behavior for own-file targets to include `kiro`.
* **Documentation**
  * Updated README command listings and onboarding examples to reflect `kiro` as a supported install target.
* **Tests**
  * Updated unit, command, and end-to-end tests to include `kiro`, including listing output and install rendering/expected file paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->