### PR TITLE
fix(cli): validate --output uniformly across all command groups

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -4,7 +4,7 @@ import { Command } from 'commander';
 import type { CommonOptions as FactoryCommonOptions } from '../lib/client-factory.js';
 import { CLIError, localValidationError } from '../lib/errors.js';
 import type { OutputMode } from '../lib/output.js';
-import { GLOBAL_OPTS_HINT, Output } from '../lib/output.js';
+import { GLOBAL_OPTS_HINT, Output, resolveOutputMode } from '../lib/output.js';
 import { promptText } from '../lib/prompt.js';
 import {
   type AgentTarget,
@@ -852,7 +852,7 @@ function resolveCommonOptions(command: Command): CommonOptions {
   const globals = command.optsWithGlobals() as Partial<CommonOptions>;
   return {
     profile: globals.profile ?? 'default',
-    output: globals.output ?? 'text',
+    output: resolveOutputMode(globals.output),
     endpointUrl: globals.endpointUrl,
     debug: globals.debug ?? false,
     verbose: globals.verbose ?? false,

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -18,7 +18,7 @@ import {
 import { loadConfig } from '../lib/config.js';
 import { emitDeprecationNotice } from '../lib/deprecate.js';
 import type { OutputMode } from '../lib/output.js';
-import { GLOBAL_OPTS_HINT, Output } from '../lib/output.js';
+import { GLOBAL_OPTS_HINT, Output, resolveOutputMode } from '../lib/output.js';
 import { promptSecret } from '../lib/prompt.js';
 
 export interface MeResponse {
@@ -318,7 +318,7 @@ function resolveCommonOptions(command: Command): CommonOptions {
   };
   return {
     profile: globals.profile ?? 'default',
-    output: globals.output ?? 'text',
+    output: resolveOutputMode(globals.output),
     endpointUrl: globals.endpointUrl,
     debug: globals.debug ?? false,
     verbose: globals.verbose ?? false,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -14,7 +14,7 @@ import { Command } from 'commander';
 import type { CommonOptions as FactoryCommonOptions } from '../lib/client-factory.js';
 import { emitDeprecationNotice } from '../lib/deprecate.js';
 import { CLIError } from '../lib/errors.js';
-import { GLOBAL_OPTS_HINT, Output } from '../lib/output.js';
+import { GLOBAL_OPTS_HINT, Output, resolveOutputMode } from '../lib/output.js';
 import type { AuthDeps, MeResponse } from './auth.js';
 import { runConfigure, runWhoami } from './auth.js';
 import type { AgentDeps, AgentFs, InstallResult } from './agent.js';
@@ -424,7 +424,7 @@ function resolveCommonOptions(command: Command): CommonOptions {
   };
   return {
     profile: globals.profile ?? 'default',
-    output: globals.output ?? 'text',
+    output: resolveOutputMode(globals.output),
     endpointUrl: globals.endpointUrl,
     debug: globals.debug ?? false,
     verbose: globals.verbose ?? false,

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -9,7 +9,7 @@ import {
 import { ApiError } from '../lib/errors.js';
 import type { FetchImpl } from '../lib/http.js';
 import type { HttpClient } from '../lib/http.js';
-import { GLOBAL_OPTS_HINT, Output, type OutputMode } from '../lib/output.js';
+import { GLOBAL_OPTS_HINT, Output, resolveOutputMode, type OutputMode } from '../lib/output.js';
 import { assertNotLocal } from '../lib/target-url.js';
 import { assertIdempotencyKey } from '../lib/validate.js';
 import {
@@ -494,13 +494,9 @@ function resolveCommonOptions(command: Command): CommonOptions {
     requestTimeout?: string;
   };
   // P2-8: validate --output before allowing silent fallback to 'text'.
-  const rawOutput = globals.output;
-  if (rawOutput !== undefined && rawOutput !== 'json' && rawOutput !== 'text') {
-    throw localValidationError('--output must be one of: json, text');
-  }
   return {
     profile: globals.profile ?? 'default',
-    output: (globals.output as OutputMode | undefined) ?? 'text',
+    output: resolveOutputMode(globals.output),
     endpointUrl: globals.endpointUrl,
     debug: globals.debug ?? false,
     verbose: globals.verbose ?? false,

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -34,7 +34,7 @@ import {
 import { REQUEST_TIMEOUT_DEFAULT_MS, REQUEST_TIMEOUT_MAX_MS } from '../lib/http.js';
 import type { FetchImpl } from '../lib/http.js';
 import type { HttpClient } from '../lib/http.js';
-import { GLOBAL_OPTS_HINT, Output, type OutputMode } from '../lib/output.js';
+import { GLOBAL_OPTS_HINT, Output, resolveOutputMode, type OutputMode } from '../lib/output.js';
 import {
   fetchSinglePage,
   paginate,
@@ -7806,13 +7806,9 @@ function resolveCommonOptions(command: Command): CommonOptions {
   // P2-8: validate --output before allowing silent fallback to 'text'.
   // An invalid value (e.g. `--output yaml`) must exit 5 with a clear error
   // rather than silently treating the request as text mode.
-  const rawOutput = globals.output;
-  if (rawOutput !== undefined && rawOutput !== 'json' && rawOutput !== 'text') {
-    throw localValidationError('output', 'must be one of: json, text', ['json', 'text']);
-  }
   return {
     profile: globals.profile ?? 'default',
-    output: (globals.output as OutputMode | undefined) ?? 'text',
+    output: resolveOutputMode(globals.output),
     dryRun: globals.dryRun ?? false,
     endpointUrl: globals.endpointUrl,
     debug: globals.debug ?? false,

--- a/src/commands/usage.ts
+++ b/src/commands/usage.ts
@@ -22,7 +22,7 @@ import {
 import { loadConfig } from '../lib/config.js';
 import { resolvePortalBase } from '../lib/facade.js';
 import type { FetchImpl } from '../lib/http.js';
-import { GLOBAL_OPTS_HINT, Output, type OutputMode } from '../lib/output.js';
+import { GLOBAL_OPTS_HINT, Output, resolveOutputMode, type OutputMode } from '../lib/output.js';
 
 /**
  * Usage/balance response from `/me` (when the backend supplies it) or a future
@@ -216,7 +216,7 @@ function resolveCommonOptions(command: Command): CommonOptions {
   };
   return {
     profile: globals.profile ?? 'default',
-    output: globals.output ?? 'text',
+    output: resolveOutputMode(globals.output),
     endpointUrl: globals.endpointUrl,
     debug: globals.debug ?? false,
     verbose: globals.verbose ?? false,

--- a/src/lib/output.test.ts
+++ b/src/lib/output.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Output, isOutputMode } from './output.js';
+import { Output, isOutputMode, resolveOutputMode } from './output.js';
+import { ApiError } from './errors.js';
 
 describe('isOutputMode', () => {
   it('accepts json and text', () => {
@@ -12,6 +13,36 @@ describe('isOutputMode', () => {
     expect(isOutputMode(undefined)).toBe(false);
     expect(isOutputMode(null)).toBe(false);
     expect(isOutputMode(42)).toBe(false);
+  });
+});
+
+describe('resolveOutputMode', () => {
+  it('returns the mode verbatim for valid values', () => {
+    expect(resolveOutputMode('json')).toBe('json');
+    expect(resolveOutputMode('text')).toBe('text');
+  });
+
+  it('defaults to text when the flag is omitted (undefined)', () => {
+    expect(resolveOutputMode(undefined)).toBe('text');
+  });
+
+  it('throws a typed VALIDATION_ERROR (exit 5) instead of silently falling back to text', () => {
+    // The footgun this guards against: an agent that asks for `--output json`
+    // but mistypes it would otherwise receive a text payload and fail to parse
+    // it as JSON with no signal. Every command group must reject, not coerce.
+    for (const bad of ['josn', 'yaml', 'JSON', 'Text', '']) {
+      let caught: unknown;
+      try {
+        resolveOutputMode(bad);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ApiError);
+      const apiErr = caught as ApiError;
+      expect(apiErr.code).toBe('VALIDATION_ERROR');
+      expect(apiErr.exitCode).toBe(5);
+      expect(apiErr.nextAction).toContain('must be one of: json, text');
+    }
   });
 });
 

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,3 +1,5 @@
+import { localValidationError } from './errors.js';
+
 export type OutputMode = 'json' | 'text';
 
 /**
@@ -11,6 +13,26 @@ export const GLOBAL_OPTS_HINT =
 
 export function isOutputMode(value: unknown): value is OutputMode {
   return value === 'json' || value === 'text';
+}
+
+/**
+ * Resolve a raw `--output` flag value to a concrete {@link OutputMode}.
+ *
+ * `undefined` (flag omitted) resolves to the default `'text'`. Any other
+ * value that is not `'json'` or `'text'` throws a typed VALIDATION_ERROR
+ * (exit 5) with an actionable message.
+ *
+ * The alternative — silently falling back to `'text'` — is a footgun for the
+ * CLI's primary consumer (coding agents): a caller that asks for
+ * `--output json` but mistypes it (`--output josn`) would otherwise receive a
+ * human-readable text payload and fail to parse it as JSON, with no signal as
+ * to why. Every command group routes its global-option resolution through this
+ * helper so the validation is uniform.
+ */
+export function resolveOutputMode(raw: unknown): OutputMode {
+  if (raw === undefined) return 'text';
+  if (isOutputMode(raw)) return raw;
+  throw localValidationError('output', 'must be one of: json, text', ['json', 'text']);
 }
 
 export interface OutputStreams {

--- a/test/cli.subprocess.test.ts
+++ b/test/cli.subprocess.test.ts
@@ -530,6 +530,33 @@ describe('malformed --endpoint-url is rejected (exit 5), not retried as a networ
   }, 30_000);
 });
 
+describe('invalid --output is rejected uniformly (exit 5)', () => {
+  // Regression: previously only `test` and `project` validated `--output`;
+  // `auth`, `usage`, `agent`, and `init` silently coerced an unknown value to
+  // text mode. An agent that asked for `--output json` but mistyped it then
+  // received a text payload it could not parse, with no signal as to why. Every
+  // command group now routes through resolveOutputMode (exit 5 on bad input).
+
+  // Note: when `--output` itself is the invalid value, the requested mode is
+  // unusable for the error envelope, so it is rendered in text mode (the catch
+  // block in index.ts falls back to text for an unrecognised --output).
+
+  it('agent list --output josn exits 5 with an actionable message (offline command)', async () => {
+    const result = await runCli(['--output', 'josn', 'agent', 'list'], {});
+    expect(result.exitCode).toBe(5);
+    expect(result.stderr).toContain('must be one of: json, text');
+  }, 30_000);
+
+  it('auth status --output yaml exits 5 before any network call', async () => {
+    const result = await runCli(['--output', 'yaml', 'auth', 'status'], {
+      TESTSPRITE_API_KEY: 'sk-subproc',
+      TESTSPRITE_API_URL: baseUrl,
+    });
+    expect(result.exitCode).toBe(5);
+    expect(result.stderr).toContain('must be one of: json, text');
+  }, 30_000);
+});
+
 describe('a malformed --profile is rejected (exit 5), not silently corrupting credentials', () => {
   // A profile name becomes an INI section header (`[name]`). `prod]` would
   // serialise to `[prod]]`, which the parser cannot read back — `setup` would


### PR DESCRIPTION
Fixes #13

#### Describe the changes you have made in this PR -

The global `--output` flag was validated inconsistently across command groups. `test` and `project` rejected an unrecognised value with a typed `VALIDATION_ERROR` (exit 5), but `auth`, `usage`, `agent`, and `init` resolved it with `globals.output ?? 'text'` — silently coercing anything that isn't `json`/`text` to **text mode** and exiting `0`.

For the CLI's primary consumer (a coding agent), that's a footgun: a request for `--output json` with a typo (`--output josn`) returned a human-readable text payload, so the agent's downstream `JSON.parse` failed with no signal as to why. The two commands that *did* validate also used different wording.

Changes:
- Add a single `resolveOutputMode(raw)` helper in `src/lib/output.ts`. It returns `'text'` for an omitted flag and throws `localValidationError('output', 'must be one of: json, text', ['json', 'text'])` for any other value.
- Route every command group's `resolveCommonOptions` (`auth`, `usage`, `agent`, `init`, `project`, `test`) through it — closing the validation gap on the four unvalidated groups and unifying the error wording on the canonical `test`-style message.
- Add unit tests for `resolveOutputMode` and an end-to-end subprocess regression for two previously-unvalidated groups (`agent list`, `auth status`).

Note: when `--output` itself is the invalid value, the error envelope is rendered in text mode (the requested mode is unusable) — unchanged from the existing `test`/`project` behaviour.

### Demo/Screenshot for feature changes and bug fixes -

Before (main) — invalid value silently coerced to text, exit 0:

<img width="1495" height="377" alt="Screenshot 2026-06-24 at 00 15 33" src="https://github.com/user-attachments/assets/c1b07617-ffdd-480c-b178-a68afc7645e3" />

After (this branch) — rejected with an actionable message; valid values unaffected:

<img width="738" height="94" alt="image" src="https://github.com/user-attachments/assets/e660881b-b724-45a2-a614-7f45aae4f48c" />


Tests:
<img width="1506" height="536" alt="Screenshot 2026-06-23 at 23 53 07" src="https://github.com/user-attachments/assets/b55dde39-047d-461a-afc7-6c44e0821663" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Problem: the global `--output` flag is the contract every machine consumer depends on, but four of the six command groups silently fell back to text on an unrecognised value instead of failing. An agent that mistyped `--output json` got text back and broke on parse, with no error to point at the cause.

Alternatives considered:
1. Use Commander's `.choices(['json','text'])` on the root option. Rejected: it would change the error path (Commander's own error rendering / exit codes) rather than the project's typed `VALIDATION_ERROR` envelope, and the flag is read in each command via `optsWithGlobals()` — the existing `test`/`project` code already validates inside `resolveCommonOptions`, so matching that is lower-risk and consistent.
2. Inline the same check in each of the four missing command files. Rejected: that perpetuates the duplication and the wording drift (the existing two copies already disagreed).
3. (chosen) Extract one `resolveOutputMode` helper and route all six command groups through it. Fixes the gap and unifies wording in one place.

Key function: `resolveOutputMode(raw)` — `undefined` → `'text'` (flag omitted); `'json'`/`'text'` → returned verbatim; anything else throws the typed `VALIDATION_ERROR` (exit 5) used everywhere else in the CLI. It lives in `output.ts` (no import cycle: `output.ts` → `errors.ts` → `facade.ts`, none of which import `output.ts`).

Edge cases handled/tested: omitted flag defaults to text; `json`/`text` pass through; `josn`/`yaml`/`JSON`/`Text`/empty string all throw exit 5; the error itself renders in text mode because the requested mode is unusable.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized how the CLI resolves the effective `--output` mode across commands, including the default when the option is omitted.
  * Invalid `--output` values are now rejected uniformly with a clear validation error (no more silent fallback).

* **Tests**
  * Added unit coverage for `resolveOutputMode`, including defaulting and validation/error details.
  * Added subprocess regression tests to confirm the CLI exits with code `5` and shows the actionable “must be one of: json, text” message for invalid `--output`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->