### PR TITLE
fix(cli): validate --request-timeout flag and de-duplicate its parser

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import {
   emitDryRunBanner,
   makeHttpClient,
+  parseRequestTimeoutFlag,
   type CommonOptions as FactoryCommonOptions,
 } from '../lib/client-factory.js';
 import type { ErrorCode } from '../lib/errors.js';
@@ -325,19 +326,6 @@ function resolveCommonOptions(command: Command): CommonOptions {
     dryRun: globals.dryRun ?? false,
     requestTimeoutMs: parseRequestTimeoutFlag(globals.requestTimeout),
   };
-}
-
-/**
- * Parse the `--request-timeout <seconds>` flag value into milliseconds.
- * Returns `undefined` when the flag was not supplied (factory falls back to
- * the env var / default). Silently clamps out-of-range values — the
- * factory applies the same clamp so there is no double-clamp risk.
- */
-function parseRequestTimeoutFlag(raw: string | undefined): number | undefined {
-  if (raw === undefined) return undefined;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return undefined;
-  return Math.round(n * 1000); // seconds → milliseconds
 }
 
 function makeOutput(mode: OutputMode, deps: AuthDeps): Output {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,7 +11,10 @@
  */
 
 import { Command } from 'commander';
-import type { CommonOptions as FactoryCommonOptions } from '../lib/client-factory.js';
+import {
+  parseRequestTimeoutFlag,
+  type CommonOptions as FactoryCommonOptions,
+} from '../lib/client-factory.js';
 import { emitDeprecationNotice } from '../lib/deprecate.js';
 import { CLIError } from '../lib/errors.js';
 import { GLOBAL_OPTS_HINT, Output } from '../lib/output.js';
@@ -431,13 +434,6 @@ function resolveCommonOptions(command: Command): CommonOptions {
     dryRun: globals.dryRun ?? false,
     requestTimeoutMs: parseRequestTimeoutFlag(globals.requestTimeout),
   };
-}
-
-function parseRequestTimeoutFlag(raw: string | undefined): number | undefined {
-  if (raw === undefined) return undefined;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return undefined;
-  return Math.round(n * 1000);
 }
 
 const SETUP_DESCRIPTION =

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 import {
   emitDryRunBanner,
   makeHttpClient,
+  parseRequestTimeoutFlag,
   type CommonOptions as FactoryCommonOptions,
 } from '../lib/client-factory.js';
 import { ApiError } from '../lib/errors.js';
@@ -507,18 +508,6 @@ function resolveCommonOptions(command: Command): CommonOptions {
     dryRun: globals.dryRun ?? false,
     requestTimeoutMs: parseRequestTimeoutFlag(globals.requestTimeout),
   };
-}
-
-/**
- * Parse the `--request-timeout <seconds>` flag value into milliseconds.
- * Returns `undefined` when the flag was not supplied (factory falls back to
- * the env var / default). Silently clamps out-of-range values.
- */
-function parseRequestTimeoutFlag(raw: string | undefined): number | undefined {
-  if (raw === undefined) return undefined;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return undefined;
-  return Math.round(n * 1000); // seconds → milliseconds
 }
 
 function makeClient(opts: CommonOptions, deps: ProjectDeps): HttpClient {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -6,6 +6,7 @@ import { Command } from 'commander';
 import {
   emitDryRunBanner,
   makeHttpClient,
+  parseRequestTimeoutFlag,
   type CommonOptions as FactoryCommonOptions,
 } from '../lib/client-factory.js';
 import {
@@ -7819,18 +7820,6 @@ function resolveCommonOptions(command: Command): CommonOptions {
     verbose: globals.verbose ?? false,
     requestTimeoutMs: parseRequestTimeoutFlag(globals.requestTimeout),
   };
-}
-
-/**
- * Parse the `--request-timeout <seconds>` flag value into milliseconds.
- * Returns `undefined` when the flag was not supplied (factory falls back to
- * the env var / default). Silently clamps out-of-range values.
- */
-function parseRequestTimeoutFlag(raw: string | undefined): number | undefined {
-  if (raw === undefined) return undefined;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return undefined;
-  return Math.round(n * 1000); // seconds → milliseconds
 }
 
 /** D4: headroom added on top of `--timeout` when deriving the per-request window under `--wait`. */

--- a/src/commands/usage.ts
+++ b/src/commands/usage.ts
@@ -17,6 +17,7 @@ import { Command } from 'commander';
 import {
   emitDryRunBanner,
   makeHttpClient,
+  parseRequestTimeoutFlag,
   type CommonOptions as FactoryCommonOptions,
 } from '../lib/client-factory.js';
 import { loadConfig } from '../lib/config.js';
@@ -223,13 +224,6 @@ function resolveCommonOptions(command: Command): CommonOptions {
     dryRun: globals.dryRun ?? false,
     requestTimeoutMs: parseRequestTimeoutFlag(globals.requestTimeout),
   };
-}
-
-function parseRequestTimeoutFlag(raw: string | undefined): number | undefined {
-  if (raw === undefined) return undefined;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return undefined;
-  return Math.round(n * 1000);
 }
 
 function makeOutput(mode: OutputMode, deps: UsageDeps): Output {

--- a/src/lib/client-factory.test.ts
+++ b/src/lib/client-factory.test.ts
@@ -5,6 +5,7 @@ import {
   assertValidEndpointUrl,
   emitDryRunBanner,
   makeHttpClient,
+  parseRequestTimeoutFlag,
   resetDryRunBannerForTesting,
   resolveRequestTimeoutMs,
 } from './client-factory.js';
@@ -211,6 +212,45 @@ describe('resolveRequestTimeoutMs', () => {
   it('accepts a valid env var within range', () => {
     expect(resolveRequestTimeoutMs({}, { TESTSPRITE_REQUEST_TIMEOUT_MS: '5000' })).toBe(5_000);
   });
+});
+
+// ---------------------------------------------------------------------------
+// parseRequestTimeoutFlag — strict flag parsing (seconds → ms)
+// ---------------------------------------------------------------------------
+
+describe('parseRequestTimeoutFlag', () => {
+  it('returns undefined when the flag is omitted (factory falls back to env/default)', () => {
+    expect(parseRequestTimeoutFlag(undefined)).toBeUndefined();
+  });
+
+  it('converts a positive number of seconds to milliseconds', () => {
+    expect(parseRequestTimeoutFlag('30')).toBe(30_000);
+    expect(parseRequestTimeoutFlag('1')).toBe(1_000);
+    expect(parseRequestTimeoutFlag('2.5')).toBe(2_500);
+  });
+
+  it('does NOT reject positive out-of-range values — resolveRequestTimeoutMs clamps them', () => {
+    // 700s is above the 600s cap, but parsing succeeds; the clamp lives in
+    // resolveRequestTimeoutMs so a large script-supplied value still works.
+    expect(parseRequestTimeoutFlag('700')).toBe(700_000);
+  });
+
+  it.each(['abc', '30s', '0', '-5', 'NaN', 'Infinity', ''])(
+    'throws a VALIDATION_ERROR (exit 5) on the invalid flag value %j',
+    bad => {
+      let caught: unknown;
+      try {
+        parseRequestTimeoutFlag(bad);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ApiError);
+      const apiErr = caught as ApiError;
+      expect(apiErr.code).toBe('VALIDATION_ERROR');
+      expect(apiErr.exitCode).toBe(5);
+      expect(apiErr.nextAction).toContain('request-timeout');
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/client-factory.ts
+++ b/src/lib/client-factory.ts
@@ -180,6 +180,43 @@ export function assertValidEndpointUrl(rawUrl: string): void {
   }
 }
 
+/**
+ * Parse the `--request-timeout <seconds>` flag value into milliseconds.
+ *
+ * Returns `undefined` when the flag was omitted (the factory then falls back to
+ * the `TESTSPRITE_REQUEST_TIMEOUT_MS` env var, else the 120s default).
+ *
+ * A supplied-but-invalid value (non-numeric, zero, or negative) throws a typed
+ * VALIDATION_ERROR (exit 5) rather than being silently dropped. An explicit
+ * `--request-timeout 30s` typo previously resolved to `undefined` and the
+ * command ran with the default 120s deadline — the operator believed they had
+ * set a timeout but had not, with no signal. Failing loudly here is consistent
+ * with every other validated flag (`--page-size`, `--output`, `--type`).
+ *
+ * Out-of-range but positive values are intentionally NOT rejected — they flow
+ * through to {@link resolveRequestTimeoutMs}, which clamps to
+ * `[REQUEST_TIMEOUT_MIN_MS, REQUEST_TIMEOUT_MAX_MS]`. The env-var path stays
+ * lenient by design (a stray global env var should not hard-fail every
+ * command); only the explicit per-invocation flag is strict.
+ *
+ * This single definition replaces five byte-identical copies that previously
+ * lived in `auth`, `project`, `usage`, `init`, and `test` — drift between them
+ * would have silently changed timeout behaviour depending on the command.
+ */
+export function parseRequestTimeoutFlag(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    // Surface the offending value in the message (same as assertValidEndpointUrl)
+    // so the operator sees exactly what they typed.
+    throw localValidationError(
+      'request-timeout',
+      `"${raw}" is not valid — must be a positive number of seconds`,
+    );
+  }
+  return Math.round(n * 1000); // seconds → milliseconds
+}
+
 export function makeHttpClient(opts: CommonOptions, deps: ClientFactoryDeps = {}): HttpClient {
   const stderr = deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
   const env = deps.env ?? process.env;

--- a/test/cli.subprocess.test.ts
+++ b/test/cli.subprocess.test.ts
@@ -499,6 +499,24 @@ describe('project list subprocess', () => {
     const parsed = JSON.parse(result.stderr) as { error: { code: string } };
     expect(parsed.error.code).toBe('VALIDATION_ERROR');
   }, 30_000);
+
+  it('--request-timeout 30s exits 5 (VALIDATION_ERROR), not a silent fallback to 120s', async () => {
+    // Previously an invalid flag value resolved to `undefined` and the command
+    // silently ran with the default 120s deadline — the operator believed they
+    // had set a timeout but had not. Now the explicit flag is validated like
+    // every other flag.
+    const result = await runCli(
+      ['--output', 'json', '--request-timeout', '30s', 'project', 'list'],
+      {
+        TESTSPRITE_API_KEY: 'sk-subproc',
+        TESTSPRITE_API_URL: baseUrl,
+      },
+    );
+    expect(result.exitCode).toBe(5);
+    const parsed = JSON.parse(result.stderr) as { error: { code: string; nextAction: string } };
+    expect(parsed.error.code).toBe('VALIDATION_ERROR');
+    expect(parsed.error.nextAction).toContain('request-timeout');
+  }, 30_000);
 });
 
 describe('malformed --endpoint-url is rejected (exit 5), not retried as a network error', () => {


### PR DESCRIPTION
Fixes #16

#### Describe the changes you have made in this PR -

Two related problems with the global `--request-timeout <seconds>` flag:

1. **Invalid values were silently dropped.** `parseRequestTimeoutFlag` returned `undefined` for any non-numeric / zero / negative input, and `undefined` is indistinguishable from "flag omitted" — so the command fell back to `TESTSPRITE_REQUEST_TIMEOUT_MS` or the 120s default. A natural typo like `--request-timeout 30s` (meaning "30 seconds") ran with the **default 120s deadline** while the operator believed they had set 30s, with no error. Every other validated flag (`--page-size`, `--output`, `--type`) exits 5 on bad input; this one was the exception.

2. **The parser was duplicated five times.** The identical `parseRequestTimeoutFlag` body lived in `auth.ts`, `project.ts`, `usage.ts`, `init.ts`, and `test.ts`. Drift between copies would silently change timeout behaviour depending on the command.

Changes:
- Hoist one `parseRequestTimeoutFlag` into `src/lib/client-factory.ts`, co-located with `resolveRequestTimeoutMs` and the `REQUEST_TIMEOUT_*` constants; the five command files import it.
- Make the **flag** strict: a non-numeric / zero / negative value throws a typed `VALIDATION_ERROR` (exit 5).
- Preserve intentional leniency where it exists: positive out-of-range values still flow through to `resolveRequestTimeoutMs`, which already clamps to `[1s, 600s]`; the `TESTSPRITE_REQUEST_TIMEOUT_MS` **env-var** path stays lenient (its existing tests assert non-numeric/zero/negative env vars fall back to the default) — a stray global env var should not hard-fail every command.
- Add unit coverage for `parseRequestTimeoutFlag` and a subprocess regression that `--request-timeout 30s` exits 5 instead of silently using 120s.

### Demo/Screenshot for feature changes and bug fixes -

Before (main) — the invalid flag is ignored and execution proceeds past validation (here reaching the auth step), so it would have silently run with the default 120s:

<img width="1474" height="468" alt="image" src="https://github.com/user-attachments/assets/ad95dc0f-7d73-4f34-b678-e4da94519e72" />

After (this branch) — the flag is validated up front; valid values still proceed:


  <img width="1506" height="381" alt="image" src="https://github.com/user-attachments/assets/b6580d08-3fa8-4fac-9d1c-ec1bce229f72" />

Tests:

<img width="1506" height="536" alt="image" src="https://github.com/user-attachments/assets/5804a11d-b838-4400-9819-82e82318dce3" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Problem: an explicit `--request-timeout` value that didn't parse was silently discarded, so the operator's chosen deadline was ignored without any signal — and the parser was copy-pasted into five files.

Alternatives considered:
1. Keep the lenient behaviour and just de-duplicate. Rejected: that leaves the real footgun (a typo silently runs at 120s) in place.
2. Make both the flag and the env var strict. Rejected: the env-var leniency is intentional and pinned by `resolveRequestTimeoutMs` tests — a globally-set `TESTSPRITE_REQUEST_TIMEOUT_MS` should not hard-fail every single command. Only the explicit per-invocation flag should fail loudly.
3. (chosen) One shared parser, strict on the flag, lenient on the env var, with out-of-range positives still clamped downstream.

Key function: `parseRequestTimeoutFlag(raw)` — `undefined` → `undefined` (flag omitted, factory falls back to env/default); a positive number → seconds×1000 ms (including out-of-range values, which `resolveRequestTimeoutMs` clamps to `[1s, 600s]`); non-numeric / zero / negative → throws the typed `VALIDATION_ERROR` (exit 5). Placed in `client-factory.ts` next to the related timeout logic so the flag, env, and default resolution all live together.

Edge cases handled/tested: omitted flag; positive seconds (incl. fractional like `2.5`); positive out-of-range (`700` parses to 700000, clamped later, not rejected); `abc`, `30s`, `0`, `-5`, `NaN`, `Infinity`, and empty string each throw exit 5; subprocess test confirms the CLI exit code is 5, not a silent fall-back.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `--request-timeout` handling: invalid or non-positive values now fail immediately with a `VALIDATION_ERROR` (exit code 5) instead of silently falling back to defaults.
  * Standardized request-timeout parsing across multiple CLI commands, including `--wait` behavior.

* **Tests**
  * Added unit tests for request-timeout parsing (valid conversions, omitted flag, and invalid inputs with expected error details).
  * Added a subprocess end-to-end test verifying the CLI rejects `--request-timeout 30s` in JSON mode with the correct error envelope and next action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->