### PR TITLE
fix(cli): reject a malformed --endpoint-url with a clear VALIDATION_ERROR

### DIFF
--- a/src/lib/client-factory.test.ts
+++ b/src/lib/client-factory.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   DRY_RUN_API_KEY,
   DRY_RUN_BANNER,
+  assertValidEndpointUrl,
   emitDryRunBanner,
   makeHttpClient,
   resetDryRunBannerForTesting,
@@ -12,6 +13,7 @@ import {
   REQUEST_TIMEOUT_MAX_MS,
   REQUEST_TIMEOUT_MIN_MS,
 } from './http.js';
+import { ApiError } from './errors.js';
 
 const NO_CREDS_PATH = '/tmp/testsprite-cli-test-no-such-file-1234.ini';
 
@@ -282,5 +284,90 @@ describe('makeHttpClient — real path (regression)', () => {
       ),
     ).toThrow();
     expect(stderrLines).not.toContain(DRY_RUN_BANNER);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertValidEndpointUrl — endpoint syntax guard (NOT an SSRF guard)
+// ---------------------------------------------------------------------------
+
+describe('assertValidEndpointUrl', () => {
+  it('accepts http(s) URLs, including private / localhost hosts (self-hosted, dev, mock)', () => {
+    for (const url of [
+      'https://api.testsprite.com',
+      'http://localhost:3000',
+      'http://127.0.0.1:8787',
+      'https://testsprite.internal.example.com/api/cli/v1',
+    ]) {
+      expect(() => assertValidEndpointUrl(url)).not.toThrow();
+    }
+  });
+
+  it('rejects an unparseable URL with a VALIDATION_ERROR (exit 5)', () => {
+    let caught: unknown;
+    try {
+      assertValidEndpointUrl('not a url');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ApiError);
+    const apiErr = caught as ApiError;
+    expect(apiErr.code).toBe('VALIDATION_ERROR');
+    expect(apiErr.exitCode).toBe(5);
+    expect(apiErr.nextAction).toContain('endpoint-url');
+  });
+
+  it('rejects a missing scheme (parses as a bogus scheme) and a non-http(s) scheme', () => {
+    // `new URL('localhost:3000')` does not throw — it parses with protocol
+    // `localhost:`. Without the scheme check this would sail through and later
+    // fail as a retried "fetch failed".
+    for (const url of ['localhost:3000', 'ftp://example.com', 'file:///etc/hosts']) {
+      let caught: unknown;
+      try {
+        assertValidEndpointUrl(url);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ApiError);
+      expect((caught as ApiError).code).toBe('VALIDATION_ERROR');
+      expect((caught as ApiError).exitCode).toBe(5);
+    }
+  });
+});
+
+describe('makeHttpClient — endpoint validation', () => {
+  afterEach(() => {
+    resetDryRunBannerForTesting();
+  });
+
+  it('throws a VALIDATION_ERROR (exit 5) on a malformed --endpoint-url under --dry-run', () => {
+    let caught: unknown;
+    try {
+      makeHttpClient(
+        { profile: 'default', output: 'json', debug: false, dryRun: true, endpointUrl: 'ftp://x' },
+        { env: {} as NodeJS.ProcessEnv, credentialsPath: NO_CREDS_PATH, stderr: () => {} },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ApiError);
+    expect((caught as ApiError).exitCode).toBe(5);
+  });
+
+  it('rejects a malformed endpoint before the auth check on the real path', () => {
+    // No API key is configured, but the malformed endpoint is reported first
+    // (a deterministic config error) — exit 5, not exit 3.
+    let caught: unknown;
+    try {
+      makeHttpClient(
+        { profile: 'default', output: 'json', debug: false, dryRun: false, endpointUrl: 'nope' },
+        { env: {} as NodeJS.ProcessEnv, credentialsPath: NO_CREDS_PATH, stderr: () => {} },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ApiError);
+    expect((caught as ApiError).code).toBe('VALIDATION_ERROR');
+    expect((caught as ApiError).exitCode).toBe(5);
   });
 });

--- a/src/lib/client-factory.ts
+++ b/src/lib/client-factory.ts
@@ -15,7 +15,7 @@
  */
 import { loadConfig } from './config.js';
 import { defaultCredentialsPath } from './credentials.js';
-import { ApiError } from './errors.js';
+import { ApiError, localValidationError } from './errors.js';
 import { facadeBaseUrl } from './facade.js';
 import type { DebugEvent, FetchImpl } from './http.js';
 import {
@@ -139,15 +139,61 @@ function clampRequestTimeout(ms: number): number {
   return Math.min(Math.max(Math.round(ms), REQUEST_TIMEOUT_MIN_MS), REQUEST_TIMEOUT_MAX_MS);
 }
 
+/**
+ * Validate that the resolved API endpoint is a syntactically valid http(s)
+ * URL before it is used to build requests.
+ *
+ * Unlike the `--target-url` guard in `target-url.ts`, this deliberately does
+ * NOT reject localhost or private addresses: the API endpoint legitimately
+ * points at a self-hosted, local-dev, or mock backend on a private host. It
+ * only catches a malformed value (unparseable, or a non-http(s) scheme) so the
+ * operator gets a fast, actionable VALIDATION_ERROR (exit 5) instead of an
+ * opaque `Invalid URL` (exit 1, a raw `new URL()` throw) or a misleading
+ * `fetch failed / Service temporarily unavailable` emitted only after a full
+ * retry-and-backoff cycle.
+ *
+ * The value can originate from `--endpoint-url`, `TESTSPRITE_API_URL`, or the
+ * credentials file `api_url`, so the message names all three rather than
+ * assuming the flag.
+ */
+export function assertValidEndpointUrl(rawUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw localValidationError(
+      'endpoint-url',
+      `"${rawUrl}" is not a valid URL — provide an http(s) URL (e.g. https://api.testsprite.com) ` +
+        `via --endpoint-url, TESTSPRITE_API_URL, or the credentials file`,
+      undefined,
+      'field',
+    );
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw localValidationError(
+      'endpoint-url',
+      `scheme "${parsed.protocol.replace(/:$/, '')}" is not supported — use http or https ` +
+        `(e.g. https://api.testsprite.com)`,
+      undefined,
+      'field',
+    );
+  }
+}
+
 export function makeHttpClient(opts: CommonOptions, deps: ClientFactoryDeps = {}): HttpClient {
   const stderr = deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
   const env = deps.env ?? process.env;
   const requestTimeoutMs = resolveRequestTimeoutMs(opts, env);
 
   if (opts.dryRun) {
+    const dryRunEndpoint = opts.endpointUrl ?? DRY_RUN_DEFAULT_ENDPOINT;
+    // Validate even under --dry-run so a typo in --endpoint-url is caught
+    // offline (no creds, no network). Validate BEFORE the banner so a rejected
+    // endpoint doesn't first announce a "sample response".
+    assertValidEndpointUrl(dryRunEndpoint);
     emitDryRunBanner(stderr);
     return new HttpClient({
-      baseUrl: facadeBaseUrl(opts.endpointUrl ?? DRY_RUN_DEFAULT_ENDPOINT),
+      baseUrl: facadeBaseUrl(dryRunEndpoint),
       apiKey: DRY_RUN_API_KEY,
       fetchImpl: deps.fetchImpl ?? createDryRunFetch(),
       onDebug: opts.debug ? (event: DebugEvent) => stderr(formatDryRunDebug(event)) : undefined,
@@ -163,6 +209,10 @@ export function makeHttpClient(opts: CommonOptions, deps: ClientFactoryDeps = {}
     env,
     credentialsPath,
   });
+  // Catch a malformed endpoint (from --endpoint-url / TESTSPRITE_API_URL /
+  // credentials) before the auth check so a config typo surfaces as a clear
+  // VALIDATION_ERROR rather than an opaque URL throw or a retried "fetch failed".
+  assertValidEndpointUrl(config.apiUrl);
   if (!config.apiKey) throw ApiError.authRequired();
   return new HttpClient({
     baseUrl: facadeBaseUrl(config.apiUrl),

--- a/test/cli.subprocess.test.ts
+++ b/test/cli.subprocess.test.ts
@@ -499,6 +499,35 @@ describe('project list subprocess', () => {
   }, 30_000);
 });
 
+describe('malformed --endpoint-url is rejected (exit 5), not retried as a network error', () => {
+  // Previously: a malformed endpoint surfaced either as an opaque `Invalid URL`
+  // (exit 1) or, for a missing/wrong scheme, as a `fetch failed` UNAVAILABLE
+  // only after a full retry-and-backoff cycle. Both are misleading config
+  // errors. Validation throws before any fetch, so no network is hit here even
+  // though a (dummy) key is configured.
+
+  it('an unparseable endpoint exits 5 with a VALIDATION_ERROR naming endpoint-url', async () => {
+    const result = await runCli(
+      ['--output', 'json', '--endpoint-url', 'not a url', 'project', 'list'],
+      { TESTSPRITE_API_KEY: 'sk-subproc' },
+    );
+    expect(result.exitCode).toBe(5);
+    const parsed = JSON.parse(result.stderr) as { error: { code: string; nextAction: string } };
+    expect(parsed.error.code).toBe('VALIDATION_ERROR');
+    expect(parsed.error.nextAction).toContain('endpoint-url');
+  }, 30_000);
+
+  it('a non-http(s) scheme exits 5 instead of being retried as a network failure', async () => {
+    const result = await runCli(
+      ['--output', 'json', '--endpoint-url', 'ftp://example.com', 'project', 'list'],
+      { TESTSPRITE_API_KEY: 'sk-subproc' },
+    );
+    expect(result.exitCode).toBe(5);
+    const parsed = JSON.parse(result.stderr) as { error: { code: string } };
+    expect(parsed.error.code).toBe('VALIDATION_ERROR');
+  }, 30_000);
+});
+
 describe('project get subprocess', () => {
   it('--output json returns the §6.1 Project shape', async () => {
     const result = await runCli(['--output', 'json', 'project', 'get', 'project_subproc'], {


### PR DESCRIPTION
Fixes #18

#### Describe the changes you have made in this PR -

A malformed API endpoint was not validated, so it failed in a way that didn't point at the real (config) problem:

- `--endpoint-url "not a url"` → `Error: Invalid URL` (exit 1) — a raw `new URL()` throw with no guidance.
- `--endpoint-url "localhost:3000"` (missing scheme — `new URL()` parses it as scheme `localhost:`) and `--endpoint-url "ftp://x.com"` (wrong scheme) → `fetch failed` / `Service temporarily unavailable`, emitted only **after a full retry-and-backoff cycle** — it looks like a network outage, not a typo.

The endpoint can come from `--endpoint-url`, `TESTSPRITE_API_URL`, or the credentials file `api_url`.

Changes:
- Add `assertValidEndpointUrl(rawUrl)` in `client-factory.ts` and run it in both the real and dry-run paths of `makeHttpClient`, on the resolved endpoint — so all three sources are covered. A malformed value now throws a typed `VALIDATION_ERROR` (exit 5) with an actionable message, before any fetch/retry.
- Validate before emitting the dry-run banner so a rejected endpoint doesn't first announce a "sample response".
- **Deliberately not an SSRF guard.** Unlike the `--target-url` check in `target-url.ts`, this does **not** reject localhost or private hosts: the API endpoint legitimately points at self-hosted, local-dev, or mock backends (the test suite itself targets `http://localhost`). Only unparseable values or non-http(s) schemes are rejected, so existing self-hosted/CI configs are unaffected.
- Add unit coverage for `assertValidEndpointUrl` and both `makeHttpClient` paths, plus subprocess regressions.

### Demo/Screenshot for feature changes and bug fixes -

Before (main) — opaque / misleading:

    
<img width="1511" height="404" alt="image" src="https://github.com/user-attachments/assets/16016e78-db42-40ec-b4c6-9d52a2f57019" />


After (this branch) — fast, actionable config error:

<img width="1471" height="815" alt="image" src="https://github.com/user-attachments/assets/6b53b548-40c7-4a25-8344-6fc3eb27bd0f" />


Tests:

   <img width="1488" height="835" alt="image" src="https://github.com/user-attachments/assets/66126914-fdf8-44f7-b487-1e712987d543" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Problem: a typo in the API endpoint is a config error, but the CLI surfaced it as either a bare `Invalid URL` (an unhandled `new URL()` throw → generic exit 1) or, for a missing/wrong scheme, as a `fetch failed` UNAVAILABLE after burning a retry cycle. Neither tells the user their endpoint is malformed.

Alternatives considered:
1. Reuse `assertNotLocal` from `target-url.ts`. Rejected: that guard rejects localhost / RFC1918 hosts (it's an SSRF guard for the *test target*), but the API *endpoint* legitimately points at private/self-hosted/mock backends — reusing it would break self-hosted users and the project's own localhost test backend.
2. Validate only the `--endpoint-url` flag in each command's `resolveCommonOptions`. Rejected: it would miss `TESTSPRITE_API_URL` and the credentials-file `api_url`, and duplicate the check across files.
3. (chosen) One `assertValidEndpointUrl` at the single chokepoint where the endpoint becomes a base URL (`makeHttpClient`), validating the resolved value so all three sources are covered in both the real and dry-run paths.

Key function: `assertValidEndpointUrl(rawUrl)` — parses with `new URL()`; an unparseable value or a non-`http:`/`https:` scheme throws `localValidationError('endpoint-url', …, 'field')` (the typed VALIDATION_ERROR used elsewhere, exit 5). It is intentionally syntax-only (no host-class checks). In `makeHttpClient` it runs before the auth check (so a config typo is reported even without a key) and, in dry-run, before the banner.

Edge cases handled/tested: valid http/https including `localhost`, `127.0.0.1`, and internal hostnames pass; `"not a url"` (unparseable) throws; `"localhost:3000"` (parses as a bogus scheme) and `ftp://`/`file://` throw; validation happens before any network call, so no retry cycle is wasted.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
