### PR TITLE
fix(cli): validate profile names to prevent credentials-file corruption

### DIFF
--- a/src/lib/credentials.test.ts
+++ b/src/lib/credentials.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   DEFAULT_PROFILE,
+  assertValidProfileName,
   defaultCredentialsPath,
   deleteProfile,
   ensureRestrictiveMode,
@@ -13,6 +14,7 @@ import {
   serializeCredentials,
   writeProfile,
 } from './credentials.js';
+import { ApiError } from './errors.js';
 
 let tmpRoot: string;
 let credentialsPath: string;
@@ -166,5 +168,44 @@ describe('ensureRestrictiveMode', () => {
 describe('defaultCredentialsPath', () => {
   it('points at ~/.testsprite/credentials', () => {
     expect(defaultCredentialsPath().endsWith('/.testsprite/credentials')).toBe(true);
+  });
+});
+
+describe('assertValidProfileName / profile-name guard', () => {
+  it('accepts conventional profile names', () => {
+    for (const name of ['default', 'dev', 'prod', 'ci-staging', 'team.qa', 'a_b', 'P1']) {
+      expect(() => assertValidProfileName(name)).not.toThrow();
+    }
+  });
+
+  it('rejects names that would corrupt the INI file, with a VALIDATION_ERROR (exit 5)', () => {
+    // `prod]` -> `[prod]]` (unreadable); newline splits the header; padded
+    // names do not round-trip (the parser trims section names); empty is not a
+    // valid section.
+    for (const name of ['prod]', '[weird', 'a\nb', '  spaced  ', 'has space', '', 'a/b']) {
+      let caught: unknown;
+      try {
+        assertValidProfileName(name);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ApiError);
+      const apiErr = caught as ApiError;
+      expect(apiErr.code).toBe('VALIDATION_ERROR');
+      expect(apiErr.exitCode).toBe(5);
+      expect(apiErr.nextAction).toContain('profile');
+    }
+  });
+
+  it('writeProfile rejects a malformed name and does NOT create the file', () => {
+    expect(() => writeProfile('prod]', { apiKey: 'sk-1' }, { path: credentialsPath })).toThrow(
+      ApiError,
+    );
+    expect(existsSync(credentialsPath)).toBe(false);
+  });
+
+  it('readProfile and deleteProfile reject a malformed name', () => {
+    expect(() => readProfile('a\nb', { path: credentialsPath })).toThrow(ApiError);
+    expect(() => deleteProfile('a\nb', { path: credentialsPath })).toThrow(ApiError);
   });
 });

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -9,8 +9,42 @@ import {
 } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { localValidationError } from './errors.js';
 
 export const DEFAULT_PROFILE = 'default';
+
+/**
+ * Allowed profile-name characters. A profile name is written verbatim as an
+ * INI section header (`[name]`) in the credentials file, so any character that
+ * breaks that grammar must be rejected:
+ *   - `]` closes the header early — `prod]` serialises to `[prod]]`, which the
+ *     section regex cannot match, so the api_key/api_url lines that follow are
+ *     silently dropped on read (the credential never persists).
+ *   - CR/LF splits the header across lines, corrupting the file.
+ *   - leading/trailing whitespace does not round-trip — the parser trims
+ *     section names, so `[ prod ]` reads back as `prod`.
+ * A conservative allowlist (letters, digits, dot, underscore, hyphen) matches
+ * conventional profile names (`default`, `prod`, `ci-staging`, `team.qa`) and
+ * cannot corrupt the file.
+ */
+const PROFILE_NAME_RE = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Throw a typed VALIDATION_ERROR (exit 5) when `profile` is not a safe INI
+ * section name. Guards every credential read/write so a malformed `--profile`
+ * (or `TESTSPRITE_PROFILE`) value fails loudly instead of silently corrupting
+ * `~/.testsprite/credentials` or failing to persist a key written by `setup`.
+ */
+export function assertValidProfileName(profile: string): void {
+  if (!PROFILE_NAME_RE.test(profile)) {
+    throw localValidationError(
+      'profile',
+      'must contain only letters, digits, dot, underscore, or hyphen (no spaces, brackets, or newlines)',
+      undefined,
+      'flag',
+    );
+  }
+}
 
 export function defaultCredentialsPath(): string {
   return join(homedir(), '.testsprite', 'credentials');
@@ -99,6 +133,7 @@ export function readProfile(
   profile: string,
   options: CredentialsOptions = {},
 ): ProfileEntry | undefined {
+  assertValidProfileName(profile);
   const file = readCredentialsFile(options);
   return file[profile];
 }
@@ -108,6 +143,7 @@ export function writeProfile(
   entry: ProfileEntry,
   options: CredentialsOptions = {},
 ): void {
+  assertValidProfileName(profile);
   const path = resolvePath(options);
   const file = readCredentialsFile(options);
   file[profile] = { ...file[profile], ...entry };
@@ -115,6 +151,7 @@ export function writeProfile(
 }
 
 export function deleteProfile(profile: string, options: CredentialsOptions = {}): boolean {
+  assertValidProfileName(profile);
   const path = resolvePath(options);
   const file = readCredentialsFile(options);
   if (!(profile in file)) return false;

--- a/test/cli.subprocess.test.ts
+++ b/test/cli.subprocess.test.ts
@@ -499,6 +499,23 @@ describe('project list subprocess', () => {
   }, 30_000);
 });
 
+describe('a malformed --profile is rejected (exit 5), not silently corrupting credentials', () => {
+  // A profile name becomes an INI section header (`[name]`). `prod]` would
+  // serialise to `[prod]]`, which the parser cannot read back — `setup` would
+  // report success while the key silently fails to persist. The guard fires on
+  // any credential read/write path.
+  it('exits 5 with a VALIDATION_ERROR naming the profile flag', async () => {
+    const result = await runCli(['--output', 'json', '--profile', 'prod]', 'project', 'list'], {
+      TESTSPRITE_API_KEY: 'sk-subproc',
+      TESTSPRITE_API_URL: baseUrl,
+    });
+    expect(result.exitCode).toBe(5);
+    const parsed = JSON.parse(result.stderr) as { error: { code: string; nextAction: string } };
+    expect(parsed.error.code).toBe('VALIDATION_ERROR');
+    expect(parsed.error.nextAction).toContain('profile');
+  }, 30_000);
+});
+
 describe('project get subprocess', () => {
   it('--output json returns the §6.1 Project shape', async () => {
     const result = await runCli(['--output', 'json', 'project', 'get', 'project_subproc'], {


### PR DESCRIPTION
Fixes #20

#### Describe the changes you have made in this PR -

A profile name (`--profile` / `TESTSPRITE_PROFILE`) is written verbatim as an INI section header (`[name]`) in `~/.testsprite/credentials`, but was never validated. A name containing the characters that break that grammar silently corrupted the file:

- `--profile "prod]"` → serialises to `[prod]]`, which the section regex cannot match, so the `api_key`/`api_url` lines that follow are **dropped on read**. `setup` reports success while the credential never persists.
- a newline in the name splits the header across two lines.
- leading/trailing whitespace doesn't round-trip (the parser trims section names, so `[ prod ]` reads back as `prod`).

Changes:
- Add `assertValidProfileName` in `credentials.ts` — a conservative allowlist (letters, digits, dot, underscore, hyphen) that covers conventional names (`default`, `prod`, `ci-staging`, `team.qa`) and cannot corrupt the INI file.
- Call it from every profile-keyed entry point: `readProfile`, `writeProfile`, `deleteProfile`. A malformed name now throws a typed `VALIDATION_ERROR` (exit 5) **before any file write**.
- Add unit coverage for the guard and the three entry points, plus a subprocess regression.

### Demo/Screenshot for feature changes and bug fixes -

Before (main) — the round-trip silently drops the credential (`prod]` → no readable profile):

    <img width="1170" height="426" alt="image" src="https://github.com/user-attachments/assets/174b9c2e-2acd-4540-86e4-7b9e58047524" />

After (this branch) — rejected up front; valid names unaffected:

<img width="1042" height="338" alt="image" src="https://github.com/user-attachments/assets/8d7427cf-b408-413f-917a-0b7432b3fcb7" />
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Problem: the profile name is interpolated straight into an INI section header during serialization (`[${section}]`), but the parser only accepts `^\[([^\]]+)\]$` and trims the captured name. So any name containing `]`, a newline, or surrounding whitespace either fails to match (dropping the section and its key/url lines) or doesn't round-trip — and `setup` reports success regardless, leaving the user with credentials that can't be read back.

Alternatives considered:
1. Escape/quote profile names in the INI writer and teach the parser to unescape. Rejected: it complicates the file format, and there's no value in supporting exotic profile names — they're short identifiers.
2. Validate only at write time (`writeProfile`). Rejected: reading with a malformed name should also fail clearly rather than silently returning "no profile", so the guard belongs on the read path too.
3. (chosen) A small allowlist validator called from all three profile-keyed entry points (`readProfile` / `writeProfile` / `deleteProfile`), throwing the same typed `VALIDATION_ERROR` (exit 5) used elsewhere. This catches the bad name on every credential flow (setup, status, logout, and any command that resolves config) before a write can corrupt the file.

Key function: `assertValidProfileName(profile)` tests against `^[A-Za-z0-9._-]+$` and throws `localValidationError('profile', …, 'flag')` otherwise. Placed in `credentials.ts` next to the parse/serialize logic that defines the constraint (no import cycle — `errors.ts` does not import `credentials.ts`).

Edge cases handled/tested: accepts `default`, `prod`, `ci-staging`, `team.qa`, `a_b`, `P1`; rejects `prod]`, `[weird`, embedded newline, whitespace-padded, names with spaces or `/`, and the empty string; `writeProfile` rejects before creating the file (verified the file is not created).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
