### PR TITLE
fix(cli): emit JSON error envelopes for argument-parse errors under --output json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { createProjectCommand } from './commands/project.js';
 import { createTestCommand } from './commands/test.js';
 import { createUsageCommand } from './commands/usage.js';
 import { ApiError, CLIError, RequestTimeoutError } from './lib/errors.js';
-import { Output, isOutputMode } from './lib/output.js';
+import { Output, isOutputMode, type OutputMode } from './lib/output.js';
 import { rephraseUnknownOption } from './lib/render-error.js';
 import { maybeEmitSkillNudge } from './lib/skill-nudge.js';
 import { VERSION } from './version.js';
@@ -91,12 +91,49 @@ function applyExitOverrideDeep(cmd: Command): void {
 }
 applyExitOverrideDeep(program);
 
-program.configureOutput({
-  outputError(str, write) {
-    const rephrased = rephraseUnknownOption(str);
-    write(rephrased !== null ? `${rephrased}\n` : str);
-  },
-});
+/**
+ * Resolve the requested `--output` mode directly from argv.
+ *
+ * We cannot rely on `program.opts()` for this: a parse error can be thrown
+ * before Commander binds the global `--output` option (e.g. an unknown command,
+ * or `--output` placed after the failing token), yet the error renderer below
+ * runs at exactly that point. Scanning argv is order-independent and always
+ * reflects what the caller asked for.
+ */
+function outputModeFromArgv(argv: readonly string[]): OutputMode {
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--') break; // end-of-options marker
+    if (a === '--output') return isOutputMode(argv[i + 1]) ? (argv[i + 1] as OutputMode) : 'text';
+    if (a?.startsWith('--output=')) {
+      const v = a.slice('--output='.length);
+      return isOutputMode(v) ? v : 'text';
+    }
+  }
+  return 'text';
+}
+const requestedMode = outputModeFromArgv(process.argv.slice(2));
+
+// Commander writes parse errors (unknown option/command, missing argument,
+// excess arguments) via `outputError` BEFORE throwing the CommanderError our
+// catch block sees. In `--output json` mode we suppress that plain-text write
+// and let the catch emit a JSON envelope instead, so EVERY error path honors
+// the JSON contract a machine consumer relies on. Text mode keeps the friendly
+// rephrasing. Applied to every command in the tree because subcommands do not
+// inherit the root's output configuration.
+function configureErrorOutput(cmd: Command): void {
+  cmd.configureOutput({
+    outputError(str, write) {
+      if (requestedMode === 'json') return; // the catch block emits a JSON envelope
+      const rephrased = rephraseUnknownOption(str);
+      write(rephrased !== null ? `${rephrased}\n` : str);
+    },
+  });
+  for (const child of cmd.commands) {
+    configureErrorOutput(child);
+  }
+}
+configureErrorOutput(program);
 
 /**
  * Render a leaf command's full path (group + leaf), e.g. `test run` /
@@ -212,6 +249,22 @@ try {
       err.code === 'commander.version'
     ) {
       process.exit(0);
+    }
+    // JSON mode: the plain-text write was suppressed in `configureErrorOutput`,
+    // so emit a structured envelope here. Parse errors are the VALIDATION_ERROR
+    // family (exit 5). `err.message` is the bare reason (e.g. "unknown option
+    // '--foo'"); strip any leading "error: " Commander may have prefixed.
+    if (requestedMode === 'json') {
+      const envelope = {
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: err.message.replace(/^error:\s*/i, ''),
+          nextAction: 'Run `testsprite --help`, or `testsprite <command> --help`, for usage.',
+          requestId: 'local',
+          details: { commanderCode: err.code },
+        },
+      };
+      process.stderr.write(`${JSON.stringify(envelope, null, 2)}\n`);
     }
     process.exit(5);
   }

--- a/test/cli.subprocess.test.ts
+++ b/test/cli.subprocess.test.ts
@@ -499,6 +499,59 @@ describe('project list subprocess', () => {
   }, 30_000);
 });
 
+describe('--output json honors the JSON contract for argument-parse errors too', () => {
+  // Previously Commander parse errors (unknown command/option, missing
+  // argument) printed plain text even under --output json, so a machine
+  // consumer that JSON.parse()'d stderr crashed on a malformed invocation.
+  // Now every error path emits a structured envelope.
+
+  it('unknown command emits a JSON VALIDATION_ERROR envelope (exit 5)', async () => {
+    const result = await runCli(['--output', 'json', 'frobnicate'], {});
+    expect(result.exitCode).toBe(5);
+    const parsed = JSON.parse(result.stderr) as {
+      error: { code: string; message: string; details: { commanderCode: string } };
+    };
+    expect(parsed.error.code).toBe('VALIDATION_ERROR');
+    expect(parsed.error.message).toContain('frobnicate');
+    expect(parsed.error.details.commanderCode).toBe('commander.unknownCommand');
+  }, 30_000);
+
+  it('unknown option on a subcommand emits JSON (deep config, not just the root)', async () => {
+    const result = await runCli(['--output', 'json', 'project', 'list', '--bogus'], {});
+    expect(result.exitCode).toBe(5);
+    const parsed = JSON.parse(result.stderr) as { error: { code: string } };
+    expect(parsed.error.code).toBe('VALIDATION_ERROR');
+  }, 30_000);
+
+  it('missing required argument on a nested subcommand emits JSON', async () => {
+    const result = await runCli(['--output', 'json', 'test', 'code', 'get'], {});
+    expect(result.exitCode).toBe(5);
+    const parsed = JSON.parse(result.stderr) as { error: { message: string } };
+    expect(parsed.error.message).toContain('test-id');
+  }, 30_000);
+
+  it('resolves --output even when it follows the failing token', async () => {
+    // The mode is scanned from argv, so json applies even though Commander
+    // errors on the unknown command before it would bind the global flag.
+    const result = await runCli(['frobnicate', '--output', 'json'], {});
+    expect(result.exitCode).toBe(5);
+    expect(() => JSON.parse(result.stderr)).not.toThrow();
+  }, 30_000);
+
+  it('text mode (no --output) still prints the plain-text parse error', async () => {
+    const result = await runCli(['frobnicate'], {});
+    expect(result.exitCode).toBe(5);
+    expect(result.stderr).toContain("unknown command 'frobnicate'");
+    expect(result.stderr.trimStart().startsWith('{')).toBe(false);
+  }, 30_000);
+
+  it('--help still exits 0 with human-readable text under --output json', async () => {
+    const result = await runCli(['--output', 'json', '--help'], {});
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Usage: testsprite');
+  }, 30_000);
+});
+
 describe('project get subprocess', () => {
   it('--output json returns the §6.1 Project shape', async () => {
     const result = await runCli(['--output', 'json', 'project', 'get', 'project_subproc'], {


### PR DESCRIPTION
Fixes #24

#### Describe the changes you have made in this PR -

`--output json` is the contract a machine consumer (CI, coding agent) relies on: on failure, `JSON.parse(stderr)`. That held for any error that reached a command action, but **not** for Commander's own argument-parse errors — unknown command, unknown option, missing/excess argument — which printed plain text even under `--output json`. A single malformed invocation crashed any consumer parsing stderr as JSON.

Changes:
- Resolve the requested `--output` mode directly from argv. A parse error can be thrown before Commander binds the global `--output` option (e.g. an unknown command, or `--output` placed after the failing token), so scanning argv is the only order-independent way to know what the caller asked for.
- In JSON mode, suppress Commander's plain-text `outputError` write and emit a structured `VALIDATION_ERROR` envelope (exit 5 — same family and exit code as before) from the central catch, carrying the message and the `commanderCode` in `details`.
- Apply the output configuration to **every command in the tree** — subcommands do not inherit the root's, so a one-line root config would miss `project list --bogus` / `test code get`.
- Text mode is unchanged: the friendly global-flag rephrasing and Commander's "Did you mean …?" hints still print. `--help` / `--version` still exit 0 with human-readable text.

### Demo/Screenshot for feature changes and bug fixes -

Before (main) — plain text breaks `JSON.parse`:

    $ testsprite --output json frobnicate
    error: unknown command 'frobnicate'
    $ testsprite --output json project list --bogus
    error: unknown option '--bogus'
    $ testsprite --output json test code get
    error: missing required argument 'test-id'

After (this branch) — structured envelopes:

    $ testsprite --output json frobnicate
    {
      "error": {
        "code": "VALIDATION_ERROR",
        "message": "unknown command 'frobnicate'",
        "nextAction": "Run `testsprite --help`, or `testsprite <command> --help`, for usage.",
        "requestId": "local",
        "details": { "commanderCode": "commander.unknownCommand" }
      }
    }
    # exit 5

    $ testsprite --output json project list --bogus   # subcommand -> still JSON
    { "error": { "code": "VALIDATION_ERROR", "message": "unknown option '--bogus'", ... } }

Text mode and help are untouched:

    $ testsprite frobnicate
    error: unknown command 'frobnicate'            # plain text, exit 5

    $ testsprite test list --debugg
    error: unknown option '--debugg'
    (Did you mean --debug?)

    $ testsprite --output json --help              # exit 0, human-readable
    Usage: testsprite [options] [command]
    ...

Tests:

    npm test
    # 1453 passed
    npm run typecheck && npm run lint && npm run format:check
    # all clean

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Problem: the JSON output contract was enforced for command-action errors but not for the argument-parse layer that runs first. Commander writes parse errors via its `outputError` hook (plain text) and then throws a `CommanderError` that the entry point's catch maps to exit 5 — so the plain text was already on stderr before the catch could format anything.

Alternatives considered:
1. Re-implement argument parsing / pre-validate argv to catch these before Commander. Rejected: brittle and duplicates Commander's logic.
2. Have `outputError` itself emit the JSON envelope. Rejected: `outputError` only sees the message string, not a clean code; the catch already classifies the `CommanderError` (help/version vs parse error) and owns exit-code mapping, so it is the right place to emit. `outputError` only needs to *suppress* the duplicate plain-text write in JSON mode.
3. (chosen) Two cooperating pieces: a mode-aware `outputError` (suppress in JSON, rephrase in text) applied to every command, plus a JSON branch in the existing `CommanderError` handler in the catch.

Key pieces: `outputModeFromArgv(argv)` scans for `--output <mode>` / `--output=<mode>` (returns `text` for an unknown value or when absent) — needed because `program.opts()` is unreliable when parsing failed early. `configureErrorOutput(cmd)` recursively installs the mode-aware `outputError` (mirroring the existing `applyExitOverrideDeep`, since `addCommand()` subcommands don't inherit it). The catch strips any leading `error:` prefix from `err.message` and emits `{ code: VALIDATION_ERROR, message, nextAction, requestId: "local", details: { commanderCode } }`.

Edge cases handled/tested: unknown command; unknown option on a subcommand (proves the deep config, not just root); missing required argument on a nested subcommand (`test code get`); `--output` placed *after* the failing token; text mode still plain text (regression guard); `--help` under `--output json` still exits 0 with human text (help/version are checked before the JSON branch, and don't go through `outputError`).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
