### PR TITLE
fix(test,project): replace crashes with VALIDATION_ERROR on --since overflow and --password-file ENOENT

### DIFF
--- a/src/commands/test.result.history.spec.ts
+++ b/src/commands/test.result.history.spec.ts
@@ -169,6 +169,24 @@ describe('parseDuration', () => {
   it('case-insensitive day suffix', () => {
     expect(parseDuration('7D', NOW)).toBe('2026-05-27T12:00:00.000Z');
   });
+
+  it('overflow hours throws VALIDATION_ERROR instead of crashing', () => {
+    expect(() => parseDuration('99999999999h', NOW)).toThrow();
+    try {
+      parseDuration('99999999999h', NOW);
+    } catch (err: unknown) {
+      expect((err as { code?: string }).code).toBe('VALIDATION_ERROR');
+    }
+  });
+
+  it('overflow days throws VALIDATION_ERROR instead of crashing', () => {
+    expect(() => parseDuration('99999999999d', NOW)).toThrow();
+    try {
+      parseDuration('99999999999d', NOW);
+    } catch (err: unknown) {
+      expect((err as { code?: string }).code).toBe('VALIDATION_ERROR');
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -3803,12 +3803,20 @@ export function parseDuration(raw: string, now: Date = new Date()): string {
   const hourMatch = /^(\d+)h$/i.exec(raw);
   if (hourMatch) {
     const hours = Number(hourMatch[1]);
-    return new Date(now.getTime() - hours * 60 * 60 * 1000).toISOString();
+    const result = new Date(now.getTime() - hours * 60 * 60 * 1000);
+    if (!Number.isFinite(result.getTime())) {
+      throw localValidationError('since', 'duration is too large; maximum is ~1141552511h');
+    }
+    return result.toISOString();
   }
   const dayMatch = /^(\d+)d$/i.exec(raw);
   if (dayMatch) {
     const days = Number(dayMatch[1]);
-    return new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+    const result = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+    if (!Number.isFinite(result.getTime())) {
+      throw localValidationError('since', 'duration is too large; maximum is ~47564688d');
+    }
+    return result.toISOString();
   }
   // Pass-through: ISO timestamp or epoch value — server validates.
   return raw;


### PR DESCRIPTION
## Summary

Two edge cases involving invalid user input previously caused unhandled exceptions (raw Node stack traces and exit code 1) instead of standard typed validation errors (exit code 5).

* **Bug 1:** Providing an extremely large value to `--since` (e.g., `99999999999h`) caused a `RangeError: Invalid time value` because it exceeded the valid JavaScript date range during `.toISOString()` conversion.
* **Bug 2:** Providing a non-existent file path to `--password-file` during project creation or updates caused a raw `ENOENT` crash due to an unguarded `readFileSync` call.

## The Fix

* **Date Overflow Guard:** Added a `Number.isFinite(result.getTime())` check in `parseDuration` (`src/commands/test.ts`) to intercept invalid dates and throw a `localValidationError` before attempting conversion.
* **Safe File Reading:** Wrapped `readFileSync` calls for the password file in `try/catch` blocks (`src/commands/project.ts`) to gracefully capture read errors and emit typed validation errors.

## Testing & Validation

**Regression Tests Added:**
* **Overflow Handling:** 2 tests added to `src/commands/test.result.history.spec.ts` verifying that extreme `--since` values now trigger graceful validation errors instead of crashing.
* **File Read Handling:** 2 tests added to `src/commands/project.test.ts` ensuring missing password files are caught during both `create` and `update` operations.

**CI Gates:** All local checks pass.
* Lint & format check
* TypeScript compiler (`typecheck`)
* Unit tests 
* Coverage (≥80% threshold met)

**Files Changed:**
* `src/commands/test.ts`
* `src/commands/project.ts`
* `src/commands/test.result.history.spec.ts`
* `src/commands/project.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duration parsing so extremely large hour or day values are safely rejected instead of causing invalid results.
  * Added clearer validation for oversized time inputs, returning a typed validation error.
  * Expanded test coverage to confirm overflow cases fail consistently for very large hour and day values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->