### PR TITLE
feat(agent): add windsurf as an install target

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -112,16 +112,17 @@ testsprite agent install claude     # install the skill for Claude Code
 testsprite agent install codex      # install into AGENTS.md for Codex (managed-section)
 testsprite agent install cursor     # .cursor/rules/testsprite-verify.mdc
 testsprite agent install cline      # .clinerules/testsprite-verify.md
+testsprite agent install windsurf   # .windsurf/rules/testsprite-verify.md
 testsprite agent install antigravity  # .agents/skills/testsprite-verify/SKILL.md
 testsprite agent install kiro       # .kiro/skills/testsprite-verify/SKILL.md
-testsprite agent list               # list all 6 targets with status + mode + path
+testsprite agent list               # list all 7 targets with status + mode + path
 ```
 
-Supported targets: `claude` (GA), `codex` (experimental), `cursor` (experimental), `cline` (experimental), `antigravity` (experimental), `kiro` (experimental).
+Supported targets: `claude` (GA), `codex` (experimental), `cursor` (experimental), `cline` (experimental), `antigravity` (experimental), `kiro` (experimental), `windsurf` (experimental).
 
 The `codex` target uses **managed-section mode** — it writes only a sentinel-delimited section inside your existing `AGENTS.md`, so your project instructions are never clobbered. Re-running without `--force` replaces the section in-place; user content outside the sentinels is always preserved.
 
-Re-running with `--force` on **own-file targets** (claude, cursor, cline, antigravity, kiro) backs up the existing file to `<path>.bak` first.
+Re-running with `--force` on **own-file targets** (claude, cursor, cline, antigravity, kiro, windsurf) backs up the existing file to `<path>.bak` first.
 
 ## Command reference
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ npm install -g @testsprite/testsprite-cli
 testsprite setup
 ```
 
-`testsprite setup` prompts for your [API key](https://www.testsprite.com), verifies it, and installs the verification-loop skill for your coding agent (`claude`, `cursor`, `cline`, `antigravity`, `codex`, etc.) — one command, so your agent is wired to verify its own work. Non-interactive (CI / onboarding scripts):
+`testsprite setup` prompts for your [API key](https://www.testsprite.com), verifies it, and installs the verification-loop skill for your coding agent (`claude`, `cursor`, `cline`, `windsurf`, `antigravity`, `codex`, etc.) — one command, so your agent is wired to verify its own work. Non-interactive (CI / onboarding scripts):
 
 ```bash
 TESTSPRITE_API_KEY=sk-... testsprite setup --from-env --yes --agent claude
@@ -89,28 +89,28 @@ Prefer to configure each step by hand (or learn the surface offline with `--dry-
 
 ## Commands
 
-| Group     | Command                                             | What it does                                                                                                          |
-| --------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Setup** | `setup`                                             | **Start here** — one command: configure your API key, verify it, and install the agent verification skill             |
-| **Auth**  | `auth status`                                       | Resolve the active profile to its user, key, env, and scopes                                                          |
-|           | `auth remove`                                       | Remove the active profile from the credentials file                                                                   |
-| **Read**  | `project list` / `project get`                      | List projects / fetch one by id                                                                                       |
-|           | `test list` / `test get`                            | List tests under a project / fetch one by id                                                                          |
-|           | `test code get`                                     | Print (or write) the generated test source                                                                            |
-|           | `test steps`                                        | List the latest run's steps with screenshot / DOM pointers                                                            |
-|           | `test result`                                       | Latest result; `--history` lists a test's prior runs                                                                  |
-|           | `test failure get`                                  | The agent entry point: one self-contained latest-failure bundle                                                       |
-|           | `test failure summary`                              | One-screen triage card (no media download)                                                                            |
-| **Write** | `test create` / `test create-batch`                 | Create a test (or bulk-create from a plan file); `--produces` / `--needs` / `--category` wire BE dependency metadata  |
-|           | `test update` / `test delete` / `test delete-batch` | Edit metadata / soft-delete                                                                                           |
-|           | `test code put`                                     | Replace generated code (etag-guarded)                                                                                 |
-|           | `test plan put`                                     | Replace a frontend test's plan-steps                                                                                  |
-|           | `project create` / `project update`                 | Manage projects                                                                                                       |
-| **Run**   | `test run`                                          | Trigger a fresh run; `--wait` blocks until terminal; `--all --project <id>` runs all tests in a project in wave order |
-|           | `test rerun`                                        | Cheap replay of one/many tests (FE verbatim; BE with deps); `--all --project <id>` reruns all tests                   |
-|           | `test wait`                                         | Block on a `runId` until terminal                                                                                     |
-|           | `test artifact get`                                 | Download the failure bundle for a specific `runId`                                                                    |
-| **Agent** | `agent install` / `agent list`                      | Add or list coding-agent targets (pure-local): `claude`, `codex`, `cursor`, `cline`, `antigravity`, `kiro`            |
+| Group     | Command                                             | What it does                                                                                                           |
+| --------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **Setup** | `setup`                                             | **Start here** — one command: configure your API key, verify it, and install the agent verification skill              |
+| **Auth**  | `auth status`                                       | Resolve the active profile to its user, key, env, and scopes                                                           |
+|           | `auth remove`                                       | Remove the active profile from the credentials file                                                                    |
+| **Read**  | `project list` / `project get`                      | List projects / fetch one by id                                                                                        |
+|           | `test list` / `test get`                            | List tests under a project / fetch one by id                                                                           |
+|           | `test code get`                                     | Print (or write) the generated test source                                                                             |
+|           | `test steps`                                        | List the latest run's steps with screenshot / DOM pointers                                                             |
+|           | `test result`                                       | Latest result; `--history` lists a test's prior runs                                                                   |
+|           | `test failure get`                                  | The agent entry point: one self-contained latest-failure bundle                                                        |
+|           | `test failure summary`                              | One-screen triage card (no media download)                                                                             |
+| **Write** | `test create` / `test create-batch`                 | Create a test (or bulk-create from a plan file); `--produces` / `--needs` / `--category` wire BE dependency metadata   |
+|           | `test update` / `test delete` / `test delete-batch` | Edit metadata / soft-delete                                                                                            |
+|           | `test code put`                                     | Replace generated code (etag-guarded)                                                                                  |
+|           | `test plan put`                                     | Replace a frontend test's plan-steps                                                                                   |
+|           | `project create` / `project update`                 | Manage projects                                                                                                        |
+| **Run**   | `test run`                                          | Trigger a fresh run; `--wait` blocks until terminal; `--all --project <id>` runs all tests in a project in wave order  |
+|           | `test rerun`                                        | Cheap replay of one/many tests (FE verbatim; BE with deps); `--all --project <id>` reruns all tests                    |
+|           | `test wait`                                         | Block on a `runId` until terminal                                                                                      |
+|           | `test artifact get`                                 | Download the failure bundle for a specific `runId`                                                                     |
+| **Agent** | `agent install` / `agent list`                      | Add or list coding-agent targets (pure-local): `claude`, `codex`, `cursor`, `cline`, `antigravity`, `kiro`, `windsurf` |
 
 > The earlier command names — `init`, `auth configure`, `auth whoami`, `auth logout` — still work as hidden, deprecated aliases (each prints a one-line notice pointing at the new name), so existing scripts keep running. `auth configure` now runs the full `setup` (it also installs the skill).
 

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -769,12 +769,13 @@ describe('runList', () => {
 
     const json = JSON.parse(capture.stdout.join('\n')) as ListResult[];
     expect(Array.isArray(json)).toBe(true);
-    // 6 targets × 2 default skills = 12 rows
-    expect(json).toHaveLength(12);
+    // 7 targets × 2 default skills = 14 rows
+    expect(json).toHaveLength(14);
     const targets = json.map(r => r.target);
     expect(targets).toContain('claude');
     expect(targets).toContain('cursor');
     expect(targets).toContain('cline');
+    expect(targets).toContain('windsurf');
     expect(targets).toContain('antigravity');
     expect(targets).toContain('kiro');
     expect(targets).toContain('codex');
@@ -916,11 +917,11 @@ describe('createAgentCommand wiring', () => {
 });
 
 // ---------------------------------------------------------------------------
-// All five own-file targets installed at once
+// All own-file targets installed at once
 // ---------------------------------------------------------------------------
 
-describe('runInstall — all five own-file targets', () => {
-  it('installs all five own-file targets in one invocation', async () => {
+describe('runInstall — all own-file targets', () => {
+  it('installs every own-file target in one invocation', async () => {
     const { store, fs: agentFs } = makeMemFs();
     const { capture, deps } = makeCapture();
 
@@ -930,7 +931,7 @@ describe('runInstall — all five own-file targets', () => {
         output: 'text',
         debug: false,
         dryRun: false,
-        target: ['claude', 'cursor', 'cline', 'antigravity', 'kiro'],
+        target: [...OWN_FILE_TARGETS],
         skills: ['testsprite-verify'],
         force: false,
       },
@@ -948,11 +949,11 @@ describe('runInstall — all five own-file targets', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Dry-run for all five own-file targets
+// Dry-run for all six own-file targets
 // ---------------------------------------------------------------------------
 
 describe('runInstall — dry-run all own-file targets', () => {
-  it('writes nothing for any of the five own-file targets (default 2 skills = 10 would-write lines)', async () => {
+  it('writes nothing for any of the six own-file targets (default 2 skills = 12 would-write lines)', async () => {
     const { store, fs: agentFs } = makeMemFs();
     const { capture, deps } = makeCapture();
 
@@ -962,7 +963,7 @@ describe('runInstall — dry-run all own-file targets', () => {
         output: 'text',
         debug: false,
         dryRun: true,
-        target: ['claude', 'cursor', 'cline', 'antigravity', 'kiro'],
+        target: ['claude', 'cursor', 'cline', 'antigravity', 'kiro', 'windsurf'],
         force: false,
       },
       { cwd: CWD, fs: agentFs, ...deps },
@@ -972,9 +973,9 @@ describe('runInstall — dry-run all own-file targets', () => {
     const stderrOut = capture.stderr.join('\n');
     // Banner appears once
     expect(stderrOut).toContain('[dry-run] no files written');
-    // 5 targets × 2 default skills = 10 would-write lines
+    // 6 targets × 2 default skills = 12 would-write lines
     const wouldWriteLines = stderrOut.split('\n').filter(l => l.includes('would write'));
-    expect(wouldWriteLines.length).toBe(10);
+    expect(wouldWriteLines.length).toBe(12);
   });
 });
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -15,6 +15,7 @@ import {
   pathFor,
   loadSkillBodyFor,
   bodyHash12,
+  compactBodyFor,
   buildCodexAggregate,
   buildSkillMarker,
   parseSkillMarker,
@@ -443,6 +444,21 @@ export async function runInstall(opts: InstallOptions, deps: AgentDeps = {}): Pr
     }
     return b;
   };
+  // Budget-capped own-file targets (e.g. windsurf) render the compact per-skill
+  // body so the rule file isn't truncated by the agent. Cached separately; must
+  // match renderForTarget's default selection so written bytes equal the asserted
+  // render.
+  const compactBodyCache = new Map<string, string>();
+  const compactBodyForSkill = (skill: string): string => {
+    let b = compactBodyCache.get(skill);
+    if (b === undefined) {
+      b = compactBodyFor(skill);
+      compactBodyCache.set(skill, b);
+    }
+    return b;
+  };
+  const ownFileBodyFor = (t: AgentTarget, skill: string): string =>
+    TARGETS[t].compactBody ? compactBodyForSkill(skill) : bodyForSkill(skill);
   let codexSectionCache: string | undefined;
   const getCodexSection = (): string => {
     if (codexSectionCache === undefined) {
@@ -651,7 +667,7 @@ export async function runInstall(opts: InstallOptions, deps: AgentDeps = {}): Pr
       if (abs !== root && !abs.startsWith(root + path.sep)) {
         throw new CLIError(`refusing to write outside --dir: ${relPath}`, 5);
       }
-      const content = renderForTarget(t, skill, bodyForSkill(skill)).content;
+      const content = renderForTarget(t, skill, ownFileBodyFor(t, skill)).content;
 
       if (opts.dryRun) {
         // Apply the SAME symlink fail-close guard as the real install path
@@ -1045,7 +1061,7 @@ function collect(v: string, prev: string[]): string[] {
 
 export function createAgentCommand(deps: AgentDeps = {}): Command {
   const agent = new Command('agent').description(
-    'Install TestSprite guidance into coding-agent config (Claude Code, Cursor, Cline, Antigravity, Codex)',
+    'Install TestSprite guidance into coding-agent config (Claude Code, Cursor, Cline, Windsurf, Antigravity, Codex)',
   );
 
   agent
@@ -1055,7 +1071,7 @@ export function createAgentCommand(deps: AgentDeps = {}): Command {
     )
     .option(
       '--target <t>',
-      'Agent target(s): claude, cursor, cline, antigravity, kiro, codex (comma-separated or repeated)',
+      'Agent target(s): claude, cursor, cline, antigravity, kiro, windsurf, codex (comma-separated or repeated)',
       collect,
       [],
     )

--- a/src/lib/agent-targets.test.ts
+++ b/src/lib/agent-targets.test.ts
@@ -80,18 +80,19 @@ testsprite test artifact get <run-id> --out ./out/
 // ---------------------------------------------------------------------------
 
 describe('TARGETS', () => {
-  it('has all six required keys', () => {
+  it('has all seven required keys', () => {
     const keys = Object.keys(TARGETS).sort();
-    expect(keys).toEqual(['antigravity', 'claude', 'cline', 'codex', 'cursor', 'kiro']);
+    expect(keys).toEqual(['antigravity', 'claude', 'cline', 'codex', 'cursor', 'kiro', 'windsurf']);
   });
 
   it('claude is GA', () => {
     expect(TARGETS.claude.status).toBe('ga');
   });
 
-  it('cursor, cline, antigravity, kiro, and codex are experimental', () => {
+  it('cursor, cline, windsurf, antigravity, kiro, and codex are experimental', () => {
     expect(TARGETS.cursor.status).toBe('experimental');
     expect(TARGETS.cline.status).toBe('experimental');
+    expect(TARGETS.windsurf.status).toBe('experimental');
     expect(TARGETS.antigravity.status).toBe('experimental');
     expect(TARGETS.kiro.status).toBe('experimental');
     expect(TARGETS.codex.status).toBe('experimental');
@@ -110,6 +111,7 @@ describe('TARGETS', () => {
     expect(TARGETS.cursor.mode).toBe('own-file');
     expect(TARGETS.cline.mode).toBe('own-file');
     expect(TARGETS.kiro.mode).toBe('own-file');
+    expect(TARGETS.windsurf.mode).toBe('own-file');
   });
 
   it('codex target has mode managed-section', () => {
@@ -290,6 +292,52 @@ describe('renderForTarget("cline")', () => {
 
   it('starts with the TestSprite Verification Loop H1 (the body H1)', () => {
     expect(result.content.trimStart().startsWith('# TestSprite Verification Loop')).toBe(true);
+  });
+});
+
+describe('renderForTarget("windsurf")', () => {
+  const result = renderForTarget('windsurf', 'testsprite-verify', STUB_BODY);
+
+  it('returns the .windsurf/rules path', () => {
+    expect(result.path).toBe('.windsurf/rules/testsprite-verify.md');
+  });
+
+  it('uses the Cascade frontmatter (trigger: model_decision + description)', () => {
+    expect(result.content.startsWith('---\n')).toBe(true);
+    expect(result.content).toContain('trigger: model_decision');
+    expect(result.content).toContain(`description: ${SKILL_DESCRIPTION}`);
+  });
+
+  it('does NOT carry the Claude/Cursor frontmatter keys', () => {
+    const match = /^---\n([\s\S]*?)\n---/.exec(result.content);
+    const fm = match?.[1] ?? '';
+    expect(fm).not.toContain('name:'); // claude key
+    expect(fm).not.toContain('alwaysApply:'); // cursor .mdc key
+  });
+});
+
+describe('windsurf renders within the rules-file budget', () => {
+  // Regression: a `.windsurf/rules/*.md` file caps at ~12 K characters and
+  // Cascade silently truncates beyond that. The full verify body (~22 KB) would
+  // be cut in half, so windsurf renders the COMPACT body for verify (its trimmed
+  // codex asset) and the full body for onboard (which already fits). Uses the
+  // REAL bodies (no stub) so the size reflects what a user receives.
+  for (const skill of DEFAULT_SKILLS) {
+    it(`${skill} fits under 12 000 characters`, () => {
+      const r = renderForTarget('windsurf', skill);
+      expect(r.content.length).toBeLessThan(12_000);
+    });
+  }
+
+  it('verify uses the compact body (smaller than the full claude render)', () => {
+    const windsurf = renderForTarget('windsurf', 'testsprite-verify');
+    const claude = renderForTarget('claude', 'testsprite-verify');
+    expect(windsurf.content.length).toBeLessThan(claude.content.length);
+    // The full-body-only intro line is absent from the compact body...
+    expect(claude.content).toContain('The verification loop that flies');
+    expect(windsurf.content).not.toContain('The verification loop that flies');
+    // ...but the load-bearing command survives.
+    expect(windsurf.content).toContain('testsprite test run');
   });
 });
 

--- a/src/lib/agent-targets.ts
+++ b/src/lib/agent-targets.ts
@@ -2,7 +2,14 @@ import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { VERSION } from '../version.js';
 
-export type AgentTarget = 'claude' | 'cursor' | 'cline' | 'antigravity' | 'codex' | 'kiro';
+export type AgentTarget =
+  | 'claude'
+  | 'cursor'
+  | 'cline'
+  | 'antigravity'
+  | 'codex'
+  | 'kiro'
+  | 'windsurf';
 
 export interface TargetSpec {
   status: 'ga' | 'experimental';
@@ -14,11 +21,19 @@ export interface TargetSpec {
    */
   path: string;
   /**
-   * 'own-file': the CLI owns the whole file (claude/cursor/cline/antigravity).
+   * 'own-file': the CLI owns the whole file (claude/cursor/cline/antigravity/windsurf).
    * 'managed-section': the CLI writes only a sentinel-delimited section inside
    * a potentially user-authored file (codex target, AGENTS.md).
    */
   mode: 'own-file' | 'managed-section';
+  /**
+   * When true, render the budget-friendly body (see {@link compactBodyFor})
+   * instead of the full own-file skill body. Used for own-file targets whose
+   * rule files are size-capped — currently `windsurf` (`.windsurf/rules/*.md`
+   * files cap at ~12 K characters and Cascade silently truncates beyond that,
+   * which would cut the full ~22 KB verify skill in half).
+   */
+  compactBody?: boolean;
   /**
    * Wrap a skill body in this target's frontmatter/header. Takes the skill's
    * `name`+`description` (own-file targets emit them as frontmatter) and the body.
@@ -122,6 +137,18 @@ function wrapMdc(_name: string, description: string, body: string): string {
   return `---\ndescription: ${description}\nalwaysApply: false\n---\n\n${body}\n`;
 }
 
+/**
+ * Windsurf (Cascade) reads workspace rules from `.windsurf/rules/*.md` with YAML
+ * frontmatter. `trigger: model_decision` is the Cascade equivalent of the Cursor
+ * `.mdc` `alwaysApply: false` mode: only the `description` is surfaced up front,
+ * and Cascade pulls in the full rule body when the description shows it is
+ * relevant — exactly the on-demand activation these skills want. (The other
+ * triggers are `always_on`, `manual`, and `glob`.)
+ */
+function wrapWindsurf(_name: string, description: string, body: string): string {
+  return `---\ntrigger: model_decision\ndescription: ${description}\n---\n\n${body}\n`;
+}
+
 // ---------------------------------------------------------------------------
 // Landing paths
 // ---------------------------------------------------------------------------
@@ -144,6 +171,8 @@ export function pathFor(target: AgentTarget, skill: string): string {
       return `.clinerules/${skill}.md`;
     case 'kiro':
       return `.kiro/skills/${skill}/SKILL.md`;
+    case 'windsurf':
+      return `.windsurf/rules/${skill}.md`;
     case 'codex':
       return 'AGENTS.md';
   }
@@ -181,6 +210,15 @@ export const TARGETS: Record<AgentTarget, TargetSpec> = {
     // kiro reads SKILL.md files with name/description frontmatter, same as
     // claude/antigravity, so it shares the wrapSkill wrapper.
     wrap: wrapSkill,
+  },
+  windsurf: {
+    status: 'experimental',
+    path: pathFor('windsurf', SKILL_NAME),
+    mode: 'own-file',
+    // Windsurf rules files are budget-capped (~12 K chars per `.windsurf/rules/*.md`),
+    // so render the compact body per skill (see compactBodyFor).
+    compactBody: true,
+    wrap: wrapWindsurf,
   },
   /**
    * codex target — managed-section mode.
@@ -319,6 +357,24 @@ export function loadSkillBodyFor(skill: string, read: ReadFn = defaultRead): str
 }
 
 /**
+ * Budget-friendly body for an own-file target whose rule files are size-capped
+ * (e.g. windsurf). For a skill that ships a trimmed codex asset (`codex.kind ===
+ * 'full'`, e.g. `testsprite-verify` — full body ~22 KB, codex ~5 KB) we render
+ * that compact asset so the wrapped file stays under the cap. For skills whose
+ * codex contribution is only a one-liner (`'line'`/`'none'`, e.g.
+ * `testsprite-onboard`), the one-liner is useless as a standalone rule and the
+ * full own-file body (~6.5 KB) already fits the budget — so the full body is
+ * used.
+ */
+export function compactBodyFor(skill: string, read: ReadFn = defaultRead): string {
+  const spec = SKILLS[skill];
+  if (!spec) throw new Error(`unknown skill: ${skill}`);
+  return spec.codex.kind === 'full'
+    ? readSkillAsset(spec.codex.file, read)
+    : loadSkillBodyFor(skill, read);
+}
+
+/**
  * Resolve a skill's codex (AGENTS.md) contribution as a Markdown string.
  * 'full' → read the `*.codex.md` asset; 'line' → the inline one-liner; 'none' → ''.
  */
@@ -441,7 +497,8 @@ export function renderForTarget(
     const resolvedBody = body !== undefined ? body : codexContentFor(skill);
     return { path, content: spec.wrap(skillSpec.name, skillSpec.description, resolvedBody) };
   }
-  const resolvedBody = body !== undefined ? body : loadSkillBodyFor(skill);
+  const resolvedBody =
+    body !== undefined ? body : spec.compactBody ? compactBodyFor(skill) : loadSkillBodyFor(skill);
   return {
     path,
     content: renderOwnFileWithMarker(t, skill, buildSkillMarker(skill, resolvedBody), resolvedBody),

--- a/test/__snapshots__/help.snapshot.test.ts.snap
+++ b/test/__snapshots__/help.snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`--help snapshots > agent 1`] = `
 "Usage: testsprite agent [options] [command]
 
 Install TestSprite guidance into coding-agent config (Claude Code, Cursor,
-Cline, Antigravity, Codex)
+Cline, Windsurf, Antigravity, Codex)
 
 Options:
   -h, --help         display help for command
@@ -29,7 +29,7 @@ into a project for a coding agent
 
 Options:
   --target <t>    Agent target(s): claude, cursor, cline, antigravity, kiro,
-                  codex (comma-separated or repeated) (default: [])
+                  windsurf, codex (comma-separated or repeated) (default: [])
   --skill <name>  Skill(s) to install: testsprite-verify, testsprite-onboard
                   (comma-separated or repeated; default: all) (default: [])
   --dir <path>    Project root to write into (default: cwd)
@@ -115,8 +115,8 @@ Options:
   --from-env        Read TESTSPRITE_API_KEY from the environment instead of
                     prompting (default: false)
   --agent <target>  Coding-agent target to install: claude, antigravity,
-                    cursor, cline, kiro, codex (default: claude) (default:
-                    "claude")
+                    cursor, cline, kiro, windsurf, codex (default: claude)
+                    (default: "claude")
   --no-agent        Skip the agent skill install (configure credentials only)
   --force           Overwrite an existing skill file (a .bak backup is kept)
   --dir <path>      Project root for the skill install (default: current
@@ -604,8 +604,8 @@ Commands:
   project                      Manage TestSprite projects
   test                         Inspect TestSprite tests
   agent                        Install TestSprite guidance into coding-agent
-                               config (Claude Code, Cursor, Cline, Antigravity,
-                               Codex)
+                               config (Claude Code, Cursor, Cline, Windsurf,
+                               Antigravity, Codex)
   usage|credits                Show credit balance and plan/entitlement info
                                (proactive pre-flight before a large test run)
   help [command]               display help for command

--- a/test/e2e/agent-install.e2e.test.ts
+++ b/test/e2e/agent-install.e2e.test.ts
@@ -169,11 +169,20 @@ describe('content integrity', () => {
           content.trimStart().startsWith('#'),
           `cline: should start with a markdown heading`,
         ).toBe(true);
+      } else if (target === 'windsurf') {
+        // Windsurf Cascade frontmatter: trigger + description (no name/alwaysApply)
+        expect(content.startsWith('---'), `windsurf: should start with ---`).toBe(true);
+        expect(content).toContain('trigger: model_decision');
+        expect(content).toContain('description:');
       }
 
-      // (b) branding — the renamed H1 must be present
+      // (b) branding — the renamed H1 must be present in every body variant
       expect(content).toContain('TestSprite Verification Loop');
-      expect(content).toContain('The verification loop that flies');
+      // The full-body intro line lives only in the FULL body; compact-body targets
+      // (e.g. windsurf, budget-capped) ship the trimmed verify body and omit it.
+      if (!TARGETS[target].compactBody) {
+        expect(content).toContain('The verification loop that flies');
+      }
 
       // (c) Load-bearing command strings
       expect(content, `${target}: missing 'testsprite test run'`).toContain('testsprite test run');
@@ -198,6 +207,10 @@ describe('content integrity', () => {
         expect(content).toContain('alwaysApply: false');
       } else if (target === 'cline') {
         expect(content.startsWith('---'), `cline/onboard: must NOT start with ---`).toBe(false);
+      } else if (target === 'windsurf') {
+        expect(content.startsWith('---'), `windsurf/onboard: should start with ---`).toBe(true);
+        expect(content).toContain('trigger: model_decision');
+        expect(content).toContain('description:');
       }
 
       // Load-bearing onboard string: the skill body must reference setup
@@ -790,7 +803,7 @@ describe('agent list', () => {
     }>;
     expect(Array.isArray(parsed)).toBe(true);
 
-    // Expected: 5 targets × 2 skills = 10 rows
+    // Expected: 7 targets × 2 skills = 14 rows
     const expectedCount = Object.keys(TARGETS).length * DEFAULT_SKILLS.length;
     expect(parsed.length).toBe(expectedCount);
 
@@ -825,6 +838,7 @@ describe('matrix coverage guard', () => {
       'cursor',
       'cline',
       'kiro',
+      'windsurf',
       'codex',
     ]);
   });

--- a/test/e2e/setup.e2e.test.ts
+++ b/test/e2e/setup.e2e.test.ts
@@ -228,6 +228,7 @@ describe('matrix coverage guard', () => {
       'cursor',
       'cline',
       'kiro',
+      'windsurf',
       'codex',
     ]);
   });


### PR DESCRIPTION
Fixes #138

#### Describe the changes you have made in this PR -

Adds **Windsurf** (Codeium's Cascade editor) as an `agent install` target, so `testsprite agent install --target windsurf` and `testsprite setup --agent windsurf` wire the verification-loop skill into a Windsurf project.

- New own-file target `windsurf` → `.windsurf/rules/testsprite-verify.md`.
- Cascade frontmatter `trigger: model_decision` + `description:` — the equivalent of the Cursor `.mdc` `alwaysApply: false` mode (only the description is surfaced up front; Cascade pulls in the full rule body when the description shows it is relevant), which matches how this skill should activate.
- **Budget handling:** a `.windsurf/rules/*.md` file is capped at ~12 K characters and Cascade silently truncates beyond it. The full skill body (~21 KB) would be cut in half, so the windsurf target renders the **compact body** — the same trimmed variant the Codex/AGENTS.md target already ships (~5 KB) — selected via a new `compactBody` flag on the target spec. The rendered file is ~5.5 KB: well within budget, and it still carries the H1, the when-to-run guidance, and the load-bearing `testsprite test run … --wait` / `test artifact get` commands. `agent.ts` and `renderForTarget` choose the same body so the installed bytes equal the asserted render.
- Everything else derives from the `TARGETS` map automatically (the `agent list` table, the `setup --agent` choices, skill-nudge install detection). Updated the two hardcoded help strings in `agent.ts`, the `--help` snapshot, the unit tests (render test for the Cascade frontmatter + a budget test asserting the windsurf render stays under 12 K and uses the compact body), the **e2e** matrix guards / multi-target / content-integrity coverage, and the README / DOCUMENTATION target lists.

### Demo/Screenshot for feature changes and bug fixes -

<img width="1048" height="637" alt="image" src="https://github.com/user-attachments/assets/e0d1a6aa-5c86-4075-95d4-9a66907c06e6" />

Tests:

    npm test          
    
<img width="1045" height="320" alt="image" src="https://github.com/user-attachments/assets/1490133e-a165-4192-93d7-80d9f9e93641" />

    npm run test:e2e  # e2e  
    
<img width="799" height="287" alt="image" src="https://github.com/user-attachments/assets/e902fdef-72d9-4646-b8f1-0116a263a9fb" />

    npm run typecheck && npm run lint && npm run format:check
    
    
<img width="753" height="217" alt="image" src="https://github.com/user-attachments/assets/11f60fcb-2a7f-4fd3-886b-380aaf10f40e" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Problem: TestSprite's value is wiring the verify skill into coding agents, but Windsurf — a top-tier AI editor — wasn't a supported target.

The target system is a clean table (`TARGETS` in `agent-targets.ts`) with a per-target `wrap()` for the file's frontmatter, so the core addition is one entry plus a wrap function. I chose `trigger: model_decision` after checking Windsurf's rules docs: its semantics match the existing Cursor target (`alwaysApply: false`) — surface the description, load the body on demand — rather than `always_on` (injects the whole skill into every prompt) or `manual` (needs an `@`-mention, defeating an auto-verify skill).

The non-obvious part is the size budget. Windsurf caps a `.windsurf/rules/*.md` file at ~12 K characters and truncates silently beyond it; the full skill body renders to ~22 KB, so half the skill would be lost. The repo already maintains a trimmed/compact body for the Codex/AGENTS.md target, which is agent-agnostic (no Codex- or AGENTS.md-specific wording), so I reused it for Windsurf via a `compactBody` flag rather than authoring a third asset. Both the `renderForTarget` default and the `agent.ts` install path branch on this flag (loading each source body at most once), so what gets written equals what the unit test renders.

Alternatives considered: (1) reuse `wrapMdc` (Cursor's wrapper) — rejected, Cursor's `description`/`alwaysApply` keys are not Windsurf's `trigger`/`description`; (2) ship the full body and just emit a budget warning like the Codex target — rejected, because unlike Codex (whose body fits its 32 K budget) the full body *always* exceeds Windsurf's cap, so it would warn on every install and still truncate; (3) the legacy single-file `.windsurfrules` — rejected in favour of the current `.windsurf/rules/*.md` directory format.

Edge cases handled/tested: a render test asserts the Windsurf output carries `trigger: model_decision` + `description:` and not the `name:`/`alwaysApply:` keys; a budget test asserts the real windsurf render is < 12 K characters, uses the compact body (a full-body-only sentence is absent) yet keeps the load-bearing commands, and is smaller than the full claude render; the "install all own-file targets" unit test derives its list from `OWN_FILE_TARGETS`; and the e2e content-integrity loop gates the full-body assertion on non-compact targets while adding a Windsurf frontmatter branch.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for the additional agent target **windsurf** (marked experimental), including setup, install, and list command coverage.

* **Bug Fixes**
  * Improved generated rule rendering for **windsurf** to match Windsurf-compatible frontmatter (and apply a compact/trimmed skill body where supported).

* **Documentation**
  * Updated onboarding and README quickstart/commands references to include **windsurf**, including updated `--force` backup/restore behavior descriptions for own-file targets.

* **Tests**
  * Expanded unit and end-to-end test coverage to include **windsurf**, including content-integrity and rendering assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
