### PR TITLE
fix(cli): route interactive prompts and prelude to stderr (keep stdout pure)

### DIFF
--- a/src/commands/auth.test.ts
+++ b/src/commands/auth.test.ts
@@ -140,6 +140,35 @@ describe('runConfigure', () => {
     expect(capture.prelude.join('')).toContain('Configuring profile "default"');
   });
 
+  it('routes the interactive prelude to stderr by default, keeping stdout for the result', async () => {
+    // Regression: the prelude used to default to process.stdout, polluting the
+    // result stream (and the JSON document under --output json). With no
+    // injected preludeWrite/stderr, the default must land on stderr, not stdout.
+    const stdout: string[] = [];
+    const errChunks: string[] = [];
+    const origErr = process.stderr.write.bind(process.stderr);
+    (process.stderr as unknown as { write: (c: string) => boolean }).write = c => {
+      errChunks.push(String(c));
+      return true;
+    };
+    try {
+      await runConfigure(
+        { profile: 'default', output: 'text', debug: false, fromEnv: false },
+        {
+          stdout: line => stdout.push(line),
+          prompt: { secret: vi.fn(async () => 'sk-typed') },
+          fetchImpl: meOkFetch,
+          credentialsPath,
+          env: {},
+        },
+      );
+    } finally {
+      (process.stderr as unknown as { write: typeof origErr }).write = origErr;
+    }
+    expect(errChunks.join('')).toContain('Configuring profile "default"');
+    expect(stdout.join('\n')).not.toContain('Configuring profile');
+  });
+
   it('interactive path resolves the endpoint from TESTSPRITE_API_URL without prompting', async () => {
     const { capture, deps } = makeCapture();
     const prompt = { secret: vi.fn(async () => 'sk-typed') };

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -73,7 +73,10 @@ export async function runConfigure(opts: ConfigureOptions, deps: AuthDeps = {}):
   const env = deps.env ?? process.env;
   const credentialsPath = deps.credentialsPath ?? defaultCredentialsPath();
   const out = makeOutput(opts.output, deps);
-  const prelude = deps.preludeWrite ?? ((chunk: string) => process.stdout.write(chunk));
+  // The "Configuring profile …" prelude is informational, not result data, so
+  // it defaults to stderr — stdout stays a pure result stream (the configured
+  // JSON/text), which matters under `--output json` (§8.1 stdout purity).
+  const prelude = deps.preludeWrite ?? ((chunk: string) => process.stderr.write(chunk));
   const stderr = deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
 
   // Normalize the env endpoint: an empty / whitespace-only TESTSPRITE_API_URL is

--- a/src/lib/prompt.test.ts
+++ b/src/lib/prompt.test.ts
@@ -44,6 +44,33 @@ describe('promptText', () => {
     const output = new CaptureStream();
     expect(await promptText('? ', { input, output })).toBe('eof-no-newline');
   });
+
+  it('writes the question to stderr by default — keeps stdout pure for --output json', async () => {
+    // Regression: prompts used to default to stdout, which polluted the JSON
+    // result on the interactive setup/configure path. Interactive UI belongs
+    // on stderr. Manually swap the global stream writers (prompt reads
+    // process.stderr/stdout at call time, so this is reliably intercepted).
+    const errChunks: string[] = [];
+    const outChunks: string[] = [];
+    const origErr = process.stderr.write.bind(process.stderr);
+    const origOut = process.stdout.write.bind(process.stdout);
+    (process.stderr as unknown as { write: (c: string) => boolean }).write = c => {
+      errChunks.push(String(c));
+      return true;
+    };
+    (process.stdout as unknown as { write: (c: string) => boolean }).write = c => {
+      outChunks.push(String(c));
+      return true;
+    };
+    try {
+      await promptText('Q: ', { input: Readable.from(['x\n']) }); // no output → default
+    } finally {
+      (process.stderr as unknown as { write: typeof origErr }).write = origErr;
+      (process.stdout as unknown as { write: typeof origOut }).write = origOut;
+    }
+    expect(errChunks.join('')).toContain('Q: ');
+    expect(outChunks.join('')).not.toContain('Q: ');
+  });
 });
 
 describe('promptSecret (non-TTY behavior)', () => {
@@ -61,6 +88,35 @@ describe('promptSecret (non-TTY behavior)', () => {
     const written = output.text();
     expect(written).toContain('Key: ');
     expect(written).not.toContain('sk-hidden-12345');
+  });
+
+  it('writes the prompt to stderr by default — keeps stdout pure for --output json', async () => {
+    // Same regression as promptText: the secret prompt is interactive UI and
+    // must default to stderr so stdout carries only the command result. Manual
+    // stream swap (vi.spyOn does not intercept process.stderr.write here).
+    const errChunks: string[] = [];
+    const outChunks: string[] = [];
+    const origErr = process.stderr.write.bind(process.stderr);
+    const origOut = process.stdout.write.bind(process.stdout);
+    (process.stderr as unknown as { write: (c: string) => boolean }).write = c => {
+      errChunks.push(String(c));
+      return true;
+    };
+    (process.stdout as unknown as { write: (c: string) => boolean }).write = c => {
+      outChunks.push(String(c));
+      return true;
+    };
+    try {
+      await promptSecret('Key: ', { input: Readable.from(['sk-x\n']) }); // no output → default
+    } finally {
+      (process.stderr as unknown as { write: typeof origErr }).write = origErr;
+      (process.stdout as unknown as { write: typeof origOut }).write = origOut;
+    }
+    expect(errChunks.join('')).toContain('Key: ');
+    expect(outChunks.join('')).not.toContain('Key: ');
+    // The typed secret is never echoed to either real stream.
+    expect(errChunks.join('')).not.toContain('sk-x');
+    expect(outChunks.join('')).not.toContain('sk-x');
   });
 
   it('honors DEL/backspace before submission', async () => {

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -13,14 +13,20 @@ interface RawModeCapable {
 
 export async function promptText(question: string, streams: PromptStreams = {}): Promise<string> {
   const input = streams.input ?? process.stdin;
-  const output = streams.output ?? process.stdout;
+  // Prompts are interactive UI, not data — write the question (and any echo)
+  // to stderr so stdout carries only the command's result. This keeps
+  // `--output json` stdout a single pure JSON document even on the interactive
+  // setup / configure path (§8.1 stdout purity). stderr is still the user's
+  // TTY, so the prompt remains visible.
+  const output = streams.output ?? process.stderr;
   output.write(question);
   return readLine(input, output, false);
 }
 
 export async function promptSecret(question: string, streams: PromptStreams = {}): Promise<string> {
   const input = streams.input ?? process.stdin;
-  const output = streams.output ?? process.stdout;
+  // See promptText: interactive prompt + masking go to stderr, not stdout.
+  const output = streams.output ?? process.stderr;
   output.write(question);
 
   const inputAsTTY = input as Readable & RawModeCapable;


### PR DESCRIPTION
Fixes #30

#### Describe the changes you have made in this PR -

Interactive prompts wrote to **stdout**, polluting the result stream:

- `prompt.ts` (`promptText` / `promptSecret`) defaulted the question + masking to stdout — used by the API-key prompt in `setup`/`auth configure` and the target prompt in `agent install`.
- the `Configuring profile …` prelude in `auth.ts` defaulted to stdout.

On any interactive path this mixes UI text into stdout, and under `--output json` it breaks the contract that stdout is a single JSON document (a consumer doing `JSON.parse(stdout)` fails on the prompt text). The repo already enforces stdout purity elsewhere (the `stdoutPurity` helper, §8.1) — the interactive prompt path was the gap.

Change: default both to **stderr**. Prompts and informational preludes are interactive UI, not result data; stderr is still the user's TTY so they stay visible, and the secret is still never echoed. Callers that inject explicit streams are unaffected.

### Demo/Screenshot for feature changes and bug fixes -

The cleanest reproduction uses `agent install` with no `--target` (it prompts, and is fully local — no key/network). Redirect **stdout** to a file; the prompt should appear on your terminal (stderr) and the file should hold only the result.

<img width="1501" height="829" alt="image" src="https://github.com/user-attachments/assets/d234f9dc-a93e-4bbb-a259-fbf260e4940a" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Problem: the repo treats stdout as a pure result stream (so `--output json` yields one parseable document and text-mode stdout is script-clean), but interactive prompts and the configure prelude wrote to stdout, violating that on the interactive path.

Approach: prompts are UI, not data, so the fix is to default their output stream to stderr. `prompt.ts` already accepts an injectable `output` stream; I only changed the default (`process.stdout` → `process.stderr`) in `promptText`/`promptSecret`, and changed the `auth.ts` prelude's default writer the same way. stderr is the controlling terminal in an interactive session, so the prompt stays visible; nothing about masking or the "never echo the secret" behavior changes.

Alternatives considered: (1) gate the stream on `--output json` only — rejected, because text-mode stdout should be clean too (e.g. `KEY=$(testsprite … )`), and a mode-dependent stream is more surprising than "prompts always go to stderr," which is the conventional behavior for CLIs. (2) Strip the prompt from stdout after the fact — not possible/clean.

Edge cases handled/tested: a `promptText` regression test confirms the question goes to stderr (not stdout) when no stream is injected; an `auth` regression test confirms the `Configuring profile …` prelude lands on stderr while the result stays on stdout. Existing prompt tests (which inject an explicit `output` stream) are unaffected, and the secret-not-echoed test still passes.

Note on the tests: I swap the global `process.stderr`/`process.stdout` writers manually (save/restore) rather than `vi.spyOn`, because `vi.spyOn(process.stderr, 'write')` did not intercept the writes in this setup — the manual override is reliable since the code reads `process.stderr` at call time.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive prompts and “Configuring profile …” prelude messages now display on `stderr` by default instead of `stdout`.
  * Keeps `stdout` clean for structured output, including JSON mode.
  * Added regression tests covering prompt text, secret input behavior, and configure prelude routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->