### PR TITLE
fix(rerun): preserve exit code and escalate auth errors in batch rerun

### DIFF
--- a/src/commands/test.rerun.spec.ts
+++ b/src/commands/test.rerun.spec.ts
@@ -4698,3 +4698,485 @@ describe('rerun --wait — dashboardUrl on terminal output', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// [fix-exitcode] pollAccepted preserves ApiError exit codes (not hardcoded 1)
+// ---------------------------------------------------------------------------
+
+describe('[fix-exitcode] polling error exit codes preserved in batch rerun results', () => {
+  it('AUTH_REQUIRED during polling → batch escalates to exitCode 3', async () => {
+    const creds = makeCreds();
+    const passRun = makeTerminalRun('run_pass_a1', 'passed');
+    const batchResp: BatchRerunResponse = {
+      accepted: [
+        { testId: 'test_1', runId: 'run_auth_fail', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+        { testId: 'test_2', runId: 'run_pass_a1', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+      ],
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+
+    const fetchImpl = makeFetch(url => {
+      if (url.includes('/tests/batch/rerun')) return { status: 202, body: batchResp };
+      if (url.includes('/runs/run_auth_fail')) return errorBody('AUTH_REQUIRED');
+      if (url.includes('/runs/run_pass_a1')) return { body: passRun };
+      return errorBody('NOT_FOUND');
+    });
+
+    const err = await runTestRerun(
+      {
+        testIds: ['test_1', 'test_2'],
+        all: false,
+        wait: true,
+        timeoutSeconds: 10,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 5,
+        output: 'json',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+      },
+      { ...creds, sleep: instantSleep, fetchImpl, stdout: () => {}, stderr: () => {} },
+    ).catch(e => e as { exitCode?: number; message?: string });
+
+    expect((err as { exitCode?: number }).exitCode).toBe(3);
+  });
+
+  it('RATE_LIMITED during polling → non-auth, batch exits 1', async () => {
+    const creds = makeCreds();
+    const passRun = makeTerminalRun('run_pass_a2', 'passed');
+    const batchResp: BatchRerunResponse = {
+      accepted: [
+        { testId: 'test_1', runId: 'run_rl', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+        { testId: 'test_2', runId: 'run_pass_a2', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+      ],
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+
+    const fetchImpl = makeFetch(url => {
+      if (url.includes('/tests/batch/rerun')) return { status: 202, body: batchResp };
+      if (url.includes('/runs/run_rl')) return errorBody('RATE_LIMITED');
+      if (url.includes('/runs/run_pass_a2')) return { body: passRun };
+      return errorBody('NOT_FOUND');
+    });
+
+    const err = await runTestRerun(
+      {
+        testIds: ['test_1', 'test_2'],
+        all: false,
+        wait: true,
+        timeoutSeconds: 10,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 5,
+        output: 'json',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+      },
+      { ...creds, sleep: instantSleep, fetchImpl, stdout: () => {}, stderr: () => {} },
+    ).catch(e => e);
+
+    expect((err as { exitCode?: number }).exitCode).toBe(1);
+  });
+
+  it('NOT_FOUND during run polling → non-auth, batch exits 1', async () => {
+    const creds = makeCreds();
+    const passRun = makeTerminalRun('run_pass_a3', 'passed');
+    const batchResp: BatchRerunResponse = {
+      accepted: [
+        { testId: 'test_1', runId: 'run_nf', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+        { testId: 'test_2', runId: 'run_pass_a3', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+      ],
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+
+    const fetchImpl = makeFetch(url => {
+      if (url.includes('/tests/batch/rerun')) return { status: 202, body: batchResp };
+      if (url.includes('/runs/run_nf')) return errorBody('NOT_FOUND');
+      if (url.includes('/runs/run_pass_a3')) return { body: passRun };
+      return errorBody('NOT_FOUND');
+    });
+
+    const err = await runTestRerun(
+      {
+        testIds: ['test_1', 'test_2'],
+        all: false,
+        wait: true,
+        timeoutSeconds: 10,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 5,
+        output: 'json',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+      },
+      { ...creds, sleep: instantSleep, fetchImpl, stdout: () => {}, stderr: () => {} },
+    ).catch(e => e);
+
+    expect((err as { exitCode?: number }).exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [fix-auth-escalation] batch auth failure escalates to exit 3
+// ---------------------------------------------------------------------------
+
+describe('[fix-auth-escalation] auth error in batch rerun polling escalates to exit 3', () => {
+  it('auth failure in batch poll → batch exits 3, not 1', async () => {
+    const creds = makeCreds();
+    const passRun = makeTerminalRun('run_other', 'passed');
+    const batchResp: BatchRerunResponse = {
+      accepted: [
+        { testId: 'test_auth', runId: 'run_auth', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+        { testId: 'test_other', runId: 'run_other', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+      ],
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+
+    const fetchImpl = makeFetch(url => {
+      if (url.includes('/tests/batch/rerun')) return { status: 202, body: batchResp };
+      if (url.includes('/runs/run_auth')) return errorBody('AUTH_REQUIRED');
+      if (url.includes('/runs/run_other')) return { body: passRun };
+      return errorBody('NOT_FOUND');
+    });
+
+    const err = await runTestRerun(
+      {
+        testIds: ['test_auth', 'test_other'],
+        all: false,
+        wait: true,
+        timeoutSeconds: 10,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 5,
+        output: 'json',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+      },
+      { ...creds, sleep: instantSleep, fetchImpl, stdout: () => {}, stderr: () => {} },
+    ).catch(e => e);
+
+    expect((err as { exitCode?: number }).exitCode).toBe(3);
+  });
+
+  it('mixed batch: one pass, one auth failure → exits 3 (auth wins)', async () => {
+    const creds = makeCreds();
+    const batchResp: BatchRerunResponse = {
+      accepted: [
+        { testId: 'test_1', runId: 'run_pass', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+        { testId: 'test_2', runId: 'run_auth2', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+      ],
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+    const passRun = makeTerminalRun('run_pass', 'passed');
+    passRun.testId = 'test_1';
+
+    const fetchImpl = makeFetch(url => {
+      if (url.includes('/tests/batch/rerun')) return { status: 202, body: batchResp };
+      if (url.includes('/runs/run_pass')) return { body: passRun };
+      if (url.includes('/runs/run_auth2')) return errorBody('AUTH_REQUIRED');
+      return errorBody('NOT_FOUND');
+    });
+
+    const err = await runTestRerun(
+      {
+        testIds: ['test_1', 'test_2'],
+        all: false,
+        wait: true,
+        timeoutSeconds: 10,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 5,
+        output: 'json',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+      },
+      { ...creds, sleep: instantSleep, fetchImpl, stdout: () => {}, stderr: () => {} },
+    ).catch(e => e);
+
+    expect((err as { exitCode?: number }).exitCode).toBe(3);
+    expect((err as { message?: string }).message).toMatch(/auth error/i);
+  });
+
+  it('non-auth failure → exits 1 (no escalation)', async () => {
+    const creds = makeCreds();
+    const failRun = makeTerminalRun('run_fail', 'failed');
+    failRun.testId = 'test_1';
+    const passRun = makeTerminalRun('run_pass_c3', 'passed');
+    passRun.testId = 'test_2';
+    const batchResp: BatchRerunResponse = {
+      accepted: [
+        { testId: 'test_1', runId: 'run_fail', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+        { testId: 'test_2', runId: 'run_pass_c3', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+      ],
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+
+    const fetchImpl = makeFetch(url => {
+      if (url.includes('/tests/batch/rerun')) return { status: 202, body: batchResp };
+      if (url.includes('/runs/run_fail')) return { body: failRun };
+      if (url.includes('/runs/run_pass_c3')) return { body: passRun };
+      return errorBody('NOT_FOUND');
+    });
+
+    const err = await runTestRerun(
+      {
+        testIds: ['test_1', 'test_2'],
+        all: false,
+        wait: true,
+        timeoutSeconds: 10,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 5,
+        output: 'json',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+      },
+      { ...creds, sleep: instantSleep, fetchImpl, stdout: () => {}, stderr: () => {} },
+    ).catch(e => e);
+
+    expect((err as { exitCode?: number }).exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [fix-D4] initial chunk idempotency key bounded to ≤256 chars
+// ---------------------------------------------------------------------------
+
+describe('[fix-D4] initial chunk dispatch idempotency key bounded to 256 chars', () => {
+  it('short key with multiple chunks passes through unchanged', async () => {
+    const creds = makeCreds();
+    const receivedKeys: string[] = [];
+
+    // 51 test IDs forces 2 chunks (MAX_BATCH_RERUN_IDS = 50)
+    const testIds = Array.from({ length: 51 }, (_, i) => `test_${i}`);
+    const batchResp: BatchRerunResponse = {
+      accepted: testIds.slice(0, 50).map(id => ({
+        testId: id,
+        runId: `run_${id}`,
+        enqueuedAt: '2026-06-03T10:00:00.000Z',
+      })),
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+    const batchResp2: BatchRerunResponse = {
+      accepted: [
+        {
+          testId: testIds[50]!,
+          runId: `run_${testIds[50]}`,
+          enqueuedAt: '2026-06-03T10:00:00.000Z',
+        },
+      ],
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+    let callCount = 0;
+
+    const fetchImpl = makeFetch((url, init) => {
+      if (url.includes('/tests/batch/rerun')) {
+        const h = new Headers(init.headers ?? {});
+        const key = h.get('idempotency-key') ?? '';
+        receivedKeys.push(key);
+        callCount++;
+        return { status: 202, body: callCount === 1 ? batchResp : batchResp2 };
+      }
+      return errorBody('NOT_FOUND');
+    });
+
+    await runTestRerun(
+      {
+        testIds,
+        all: false,
+        wait: false,
+        timeoutSeconds: 600,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 10,
+        output: 'json',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+        idempotencyKey: 'short-key',
+      },
+      { ...creds, sleep: instantSleep, fetchImpl, stdout: () => {}, stderr: () => {} },
+    );
+
+    expect(receivedKeys).toHaveLength(2);
+    expect(receivedKeys[0]).toBe('short-key:chunk0');
+    expect(receivedKeys[1]).toBe('short-key:chunk1');
+    expect(receivedKeys[0]!.length).toBeLessThanOrEqual(256);
+    expect(receivedKeys[1]!.length).toBeLessThanOrEqual(256);
+  });
+
+  it('249-char key + :chunk0 suffix would exceed 256 → key truncated to keep total ≤256', async () => {
+    const creds = makeCreds();
+    const receivedKeys: string[] = [];
+
+    // key is 249 chars; `:chunk0` is 7 chars → 256 total (edge case, fits exactly)
+    const longKey = 'k'.repeat(249);
+    const testIds = Array.from({ length: 51 }, (_, i) => `test_${i}`);
+    const batchResp: BatchRerunResponse = {
+      accepted: testIds.slice(0, 50).map(id => ({
+        testId: id,
+        runId: `run_${id}`,
+        enqueuedAt: '2026-06-03T10:00:00.000Z',
+      })),
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+    const batchResp2: BatchRerunResponse = {
+      accepted: [
+        {
+          testId: testIds[50]!,
+          runId: `run_${testIds[50]}`,
+          enqueuedAt: '2026-06-03T10:00:00.000Z',
+        },
+      ],
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+    let callCount = 0;
+
+    const fetchImpl = makeFetch((url, init) => {
+      if (url.includes('/tests/batch/rerun')) {
+        const h = new Headers(init.headers ?? {});
+        receivedKeys.push(h.get('idempotency-key') ?? '');
+        callCount++;
+        return { status: 202, body: callCount === 1 ? batchResp : batchResp2 };
+      }
+      return errorBody('NOT_FOUND');
+    });
+
+    await runTestRerun(
+      {
+        testIds,
+        all: false,
+        wait: false,
+        timeoutSeconds: 600,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 10,
+        output: 'json',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+        idempotencyKey: longKey,
+      },
+      { ...creds, sleep: instantSleep, fetchImpl, stdout: () => {}, stderr: () => {} },
+    );
+
+    expect(receivedKeys).toHaveLength(2);
+    for (const key of receivedKeys) {
+      expect(key.length).toBeLessThanOrEqual(256);
+    }
+    // suffix must be preserved
+    expect(receivedKeys[0]).toMatch(/:chunk0$/);
+    expect(receivedKeys[1]).toMatch(/:chunk1$/);
+  });
+
+  it('256-char key + :chunk0 suffix → base truncated so total is exactly 256', async () => {
+    const creds = makeCreds();
+    const receivedKeys: string[] = [];
+
+    // Max-length user key: 256 chars. `:chunk0` = 7 chars → need to truncate base to 249.
+    const maxKey = 'x'.repeat(256);
+    const testIds = Array.from({ length: 51 }, (_, i) => `test_${i}`);
+    const batchResp: BatchRerunResponse = {
+      accepted: testIds.slice(0, 50).map(id => ({
+        testId: id,
+        runId: `run_${id}`,
+        enqueuedAt: '2026-06-03T10:00:00.000Z',
+      })),
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+    const batchResp2: BatchRerunResponse = {
+      accepted: [
+        {
+          testId: testIds[50]!,
+          runId: `run_${testIds[50]}`,
+          enqueuedAt: '2026-06-03T10:00:00.000Z',
+        },
+      ],
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+    let callCount = 0;
+
+    const fetchImpl = makeFetch((url, init) => {
+      if (url.includes('/tests/batch/rerun')) {
+        const h = new Headers(init.headers ?? {});
+        receivedKeys.push(h.get('idempotency-key') ?? '');
+        callCount++;
+        return { status: 202, body: callCount === 1 ? batchResp : batchResp2 };
+      }
+      return errorBody('NOT_FOUND');
+    });
+
+    await runTestRerun(
+      {
+        testIds,
+        all: false,
+        wait: false,
+        timeoutSeconds: 600,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 10,
+        output: 'json',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+        idempotencyKey: maxKey,
+      },
+      { ...creds, sleep: instantSleep, fetchImpl, stdout: () => {}, stderr: () => {} },
+    );
+
+    expect(receivedKeys).toHaveLength(2);
+    for (const key of receivedKeys) {
+      expect(key.length).toBeLessThanOrEqual(256);
+    }
+    expect(receivedKeys[0]).toMatch(/:chunk0$/);
+    expect(receivedKeys[1]).toMatch(/:chunk1$/);
+  });
+});

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -6285,7 +6285,15 @@ export async function runTestRerun(
     chunkResponses = [];
     for (let idx = 0; idx < chunks.length; idx++) {
       const chunk = chunks[idx]!;
-      const chunkKey = chunks.length === 1 ? idempotencyKey : `${idempotencyKey}:chunk${idx}`;
+      // Bound the per-chunk idempotency key to <=256 chars (mirrors the retry
+      // path). A long base key plus the `:chunkN` suffix could otherwise exceed
+      // the server cap and be rejected or truncated inconsistently.
+      const chunkSuffix = chunks.length === 1 ? '' : `:chunk${idx}`;
+      const chunkBase =
+        chunkSuffix.length > 0 && idempotencyKey.length + chunkSuffix.length > 256
+          ? idempotencyKey.slice(0, 256 - chunkSuffix.length)
+          : idempotencyKey;
+      const chunkKey = `${chunkBase}${chunkSuffix}`;
       const chunkResp = await client.triggerBatchRerun(
         {
           source: 'cli',
@@ -6631,11 +6639,14 @@ export async function runTestRerun(
         };
       }
       if (err instanceof ApiError) {
+        // Preserve the real exit code (AUTH_INVALID=3, RATE_LIMITED=11, …) so the
+        // batch exit-code aggregator can escalate auth failures correctly. Mirroring
+        // the identical fix already applied to runTestRunAll's pollFreshAccepted.
         return {
           testId: entry.testId,
           runId: entry.runId,
           status: 'error',
-          error: { code: err.code, message: err.message, exitCode: 1 },
+          error: { code: err.code, message: err.message, exitCode: err.exitCode },
         };
       }
       throw err;
@@ -6736,6 +6747,17 @@ export async function runTestRerun(
   }
 
   if (failed > 0) {
+    // Auth failure on any member is a batch-wide condition — the credential is
+    // bad, not the test. Propagate exit 3 so the operator fixes auth rather than
+    // chasing a "rerun failed" (exit 1). Mirrors the identical logic already
+    // applied to runTestRunAll lines 5462-5468.
+    const authErr = rerunResults.find(r => r.error?.exitCode === 3);
+    if (authErr) {
+      throw new CLIError(
+        `${failed} rerun${failed !== 1 ? 's' : ''} failed — auth error (${authErr.error?.code}): ${authErr.error?.message}`,
+        3,
+      );
+    }
     throw new CLIError(`${failed} rerun${failed !== 1 ? 's' : ''} failed.`, 1);
   }
 


### PR DESCRIPTION
## Summary

`runTestRerun`'s `pollAccepted` hardcoded `exitCode: 1` on every `ApiError` during run polling. The batch aggregator detects auth failures via `rerunResults.find(r => r.error?.exitCode === 3)`. With every error stored as `exitCode: 1`, auth errors were never escalated and the batch always exited 1 instead of 3.

The sibling function `runTestRunAll` already had both fixes applied. `runTestRerun` missed them.

## The Fix

- **Exit Code Preservation:** `pollAccepted` now stores `exitCode: err.exitCode` instead of hardcoded `1`, so the aggregator sees the real error class from each polling failure.
- **Auth Escalation:** Added an `authErr` check before the generic exit-1 throw: any batch member with `exitCode: 3` (`AUTH_REQUIRED` / `AUTH_INVALID`) escalates the whole batch to exit 3 with an actionable message.
- **Idempotency Key Overflow (D4):** Initial chunk dispatch now truncates the base key so `base + :chunkN` never exceeds 256 chars, matching the identical guard already present in the deferred-retry path.

## Testing

Added 9 tests to `src/commands/test.rerun.spec.ts` across three describe blocks:

- `[fix-exitcode]`: `AUTH_REQUIRED` escalates to exit 3; `RATE_LIMITED` and `NOT_FOUND` remain exit 1 (no spurious escalation)
- `[fix-auth-escalation]`: auth failure exits 3; mixed pass+auth batch exits 3; non-auth failure exits 1
- `[fix-D4]`: short key passes through unchanged; 249-char key fits exactly at 256; 256-char key truncated to preserve suffix

## Files Changed

- `src/commands/test.ts`
- `src/commands/test.rerun.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `test rerun` batch polling so authentication failures now return the correct exit code, even in mixed results.
  * Non-authentication errors continue to return a standard failure exit code.
  * Ensured chunked rerun requests keep derived keys within the allowed length limit, including edge cases near the boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->