### PR TITLE
fix(test): reject empty code get --out and strip code-file BOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
+      - run: npm run build
       - run: npm test
         env:
           CI: true

--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -1708,7 +1708,7 @@ describe('runCodePut', () => {
   it('strips a UTF-8 BOM from --code-file before uploading (Windows PowerShell 5.1 default)', async () => {
     const { credentialsPath } = makeCreds();
     const dir = mkdtempSync(join(tmpdir(), 'cli-p4-bom-'));
-    const codeFile = join(dir, 'updated.spec.ts');
+    const codeFile = join(dir, 'updated.py');
     writeFileSync(codeFile, '\uFEFF' + 'updated body', 'utf8');
     let seenBody: unknown;
     const fetchImpl = makeFetch((_url, init) => {

--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -1591,21 +1591,65 @@ describe('runCodeGet', () => {
     expect(leftovers).toEqual([]);
   });
 
-  // Regression: the "no code generated yet" branch writes nothing but
-  // previously still closed (and thus truncated) the opened file.
+  it('--out (text mode) rejects empty inline code with VALIDATION_ERROR and leaves no artifact', async () => {
+    const { credentialsPath } = makeCreds();
+    const emptyCode: CliTestCode = { ...TEST_CODE_INLINE, code: '' };
+    const fetchImpl = makeFetch(() => ({ body: emptyCode }));
+    const dir = mkdtempSync(join(tmpdir(), 'cli-test-code-empty-out-'));
+    const target = join(dir, 'empty.ts');
+    await expect(
+      runCodeGet(
+        {
+          profile: 'default',
+          output: 'text',
+          debug: false,
+          testId: 'test_fe',
+          out: target,
+        },
+        { credentialsPath, fetchImpl },
+      ),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+      details: expect.objectContaining({ field: 'out' }),
+    });
+    expect(existsSync(target)).toBe(false);
+  });
+
+  // Regression: empty inline code with --out must reject (exit 5) without
+  // truncating or replacing a pre-existing destination file.
   it('--out: "no code generated yet" leaves a pre-existing file untouched', async () => {
     const { credentialsPath } = makeCreds();
     const dir = mkdtempSync(join(tmpdir(), 'cli-test-code-out-empty-'));
     const target = join(dir, 'existing.ts');
     writeFileSync(target, 'PRE-EXISTING CONTENT', 'utf8');
     const fetchImpl = makeFetch(() => ({ body: { ...TEST_CODE_INLINE, code: '' } }));
-    await runCodeGet(
-      { profile: 'default', output: 'text', debug: false, testId: 'test_fe', out: target },
-      { credentialsPath, fetchImpl, stderr: () => undefined },
-    );
+    await expect(
+      runCodeGet(
+        { profile: 'default', output: 'text', debug: false, testId: 'test_fe', out: target },
+        { credentialsPath, fetchImpl, stderr: () => undefined },
+      ),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+      details: expect.objectContaining({ field: 'out' }),
+    });
     expect(readFileSync(target, 'utf-8')).toBe('PRE-EXISTING CONTENT');
     const leftovers = readdirSync(dir).filter(f => f !== 'existing.ts');
     expect(leftovers).toEqual([]);
+  });
+
+  it('text mode without --out still hints on stderr when inline code is empty', async () => {
+    const { credentialsPath } = makeCreds();
+    const emptyCode: CliTestCode = { ...TEST_CODE_INLINE, code: '' };
+    const fetchImpl = makeFetch(() => ({ body: emptyCode }));
+    const stderr: string[] = [];
+    const got = await runCodeGet(
+      { profile: 'default', output: 'text', debug: false, testId: 'test_fe' },
+      { credentialsPath, fetchImpl, stderr: line => stderr.push(line) },
+    );
+    expect(got.code).toBe('');
+    expect(stderr.join('\n')).toContain('no code generated yet');
   });
 });
 
@@ -1659,6 +1703,30 @@ describe('runCodePut', () => {
     expect(sent.headers.get('if-match')).toBe('v3');
     expect(sent.headers.get('idempotency-key')).toMatch(/^cli-code-put-[0-9a-f-]{36}$/);
     expect(sent.headers.get('content-type')).toBe('application/json');
+  });
+
+  it('strips a UTF-8 BOM from --code-file before uploading (Windows PowerShell 5.1 default)', async () => {
+    const { credentialsPath } = makeCreds();
+    const dir = mkdtempSync(join(tmpdir(), 'cli-p4-bom-'));
+    const codeFile = join(dir, 'updated.spec.ts');
+    writeFileSync(codeFile, '\uFEFF' + 'updated body', 'utf8');
+    let seenBody: unknown;
+    const fetchImpl = makeFetch((_url, init) => {
+      seenBody = init.body ? JSON.parse(init.body as string) : undefined;
+      return { body: SAMPLE_RESPONSE };
+    });
+    await runCodePut(
+      {
+        profile: 'default',
+        output: 'json',
+        debug: false,
+        testId: 'test_alpha',
+        codeFile,
+        expectedVersion: 'v3',
+      },
+      { credentialsPath, fetchImpl, stdout: () => undefined, stderr: () => undefined },
+    );
+    expect(seenBody).toEqual({ code: 'updated body' });
   });
 
   it('forwards --language in the body when set', async () => {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -8011,7 +8011,14 @@ async function closeOutputFile(sink: FileSink, commit: boolean): Promise<void> {
 
 /** Tear down an opened `--out` sink without leaving a zero-byte artifact. */
 async function abortOutputFile(sink: FileSink): Promise<void> {
-  sink.stream.destroy();
+  await new Promise<void>(resolve => {
+    if (sink.stream.destroyed) {
+      resolve();
+      return;
+    }
+    sink.stream.once('close', () => resolve());
+    sink.stream.destroy();
+  });
   await unlink(sink.tmpPath).catch(() => undefined);
 }
 

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -911,7 +911,7 @@ function readCodeFileGuarded(path: string): string {
 
 function readCodeFile(path: string): string {
   try {
-    return readFileSync(resolveAbsolute(path), 'utf8');
+    return stripBom(readFileSync(resolveAbsolute(path), 'utf8'));
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === 'ENOENT') {
@@ -3292,7 +3292,7 @@ export async function runCodeGet(opts: CodeGetOptions, deps: TestDeps = {}): Pro
     return code;
   }
 
-  const fileSink = opts.out !== undefined ? openOutputFile(opts.out) : null;
+  let fileSink = opts.out !== undefined ? openOutputFile(opts.out) : null;
   const out = fileSink ? makeFileOutput(opts.output, fileSink) : makeOutput(opts.output, deps);
   const client = makeClient(opts, deps);
 
@@ -3317,9 +3317,20 @@ export async function runCodeGet(opts: CodeGetOptions, deps: TestDeps = {}): Pro
     } else if (code.code === '' || code.code === null) {
       // P2-10: draft test with no code yet — empty body would produce
       // silent empty stdout. Print a friendly hint to stderr instead so
-      // the operator knows what happened, and keep exit 0. Nothing was
-      // written, so the temp file is discarded below without touching
-      // a pre-existing `--out` file.
+      // the operator knows what happened, and keep exit 0 when no `--out`.
+      //
+      // With `--out`, refuse to leave a zero-byte artifact behind: agents
+      // and scripts that check file size would otherwise treat exit 0 as
+      // a successful download. Discard the temp sink without touching a
+      // pre-existing destination file.
+      if (fileSink) {
+        await abortOutputFile(fileSink);
+        fileSink = null;
+        throw localValidationError(
+          'out',
+          'test has no generated code yet — run the test first (refusing to write an empty --out file)',
+        );
+      }
       const stderrFn = deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
       stderrFn('(no code generated yet — run the test first)');
     } else {
@@ -7996,6 +8007,12 @@ async function closeOutputFile(sink: FileSink, commit: boolean): Promise<void> {
     return;
   }
   await rename(sink.tmpPath, sink.path);
+}
+
+/** Tear down an opened `--out` sink without leaving a zero-byte artifact. */
+async function abortOutputFile(sink: FileSink): Promise<void> {
+  sink.stream.destroy();
+  await unlink(sink.tmpPath).catch(() => undefined);
 }
 
 /** A presigned `code` body is any `https://` URL — never anything else. */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     include: ['src/**/*.{test,spec}.ts', 'test/**/*.{test,spec}.ts'],
     exclude: ['test/dev-e2e/**', 'test/e2e/**', 'node_modules/**', 'dist/**'],
+    // Subprocess/snapshot suites each run `npm run build` in beforeAll; parallel
+    // file workers can race on dist/ and produce a stale binary (exit 1 vs 5 flakes).
+    fileParallelism: false,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'text-summary', 'json-summary', 'html'],


### PR DESCRIPTION
## Summary

Two silent-failure fixes in the test command surface:

### 1. `test code get --out` with empty inline code

When the API returns an empty/null `code` body in text mode, the CLI printed a stderr hint and exited 0 - but if `--out` was set, `closeOutputFile()` still ran and left a **zero-byte file**. Agents and scripts checking file existence/size treated that as a successful download.

**Fix:** abort the file sink, unlink any artifact, and throw `VALIDATION_ERROR` (exit 5). Stderr-only text mode (no `--out`) behavior is unchanged.

### 2. UTF-8 BOM on `--code-file`

Plan/steps JSON reads already strip a leading BOM from PowerShell 5.1 `Set-Content -Encoding utf8` files. `readCodeFile()` did not - the invisible `U+FEFF` prefix was uploaded as part of the test source via `test code put` / `test create --code-file`.

**Fix:** apply existing `stripBom()` in `readCodeFile()`.

## Tests

- `runCodeGet`: empty inline code + `--out` ? exit 5, no file left behind; stderr hint preserved without `--out`
- `runCodePut`: BOM-prefixed code file uploads body without BOM

This Pr is  Solving Issue #117 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `test code get` so empty results now fail cleanly when saving to a file, without leaving behind empty or partial output files.
  * Preserved the existing “no code generated yet” hint when no output file is requested.
  * Uploads now handle files with a UTF-8 BOM correctly.

* **Chores**
  * Updated automated checks to run builds before tests and reduced flaky test behavior in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->