### PR TITLE
fix(project): reject empty/whitespace-only --name in create and update

### DIFF
--- a/src/commands/project.test.ts
+++ b/src/commands/project.test.ts
@@ -564,6 +564,33 @@ describe('runCreate', () => {
     ).rejects.toMatchObject({ exitCode: 5, code: 'VALIDATION_ERROR' });
     expect(fetchImpl).not.toHaveBeenCalled();
   });
+
+  it('rejects a whitespace-only --name with VALIDATION_ERROR (exit 5), no network', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('should not hit network — validation must fire client-side');
+    });
+
+    await expect(
+      runCreate(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          type: 'frontend',
+          name: '   ',
+          targetUrl: 'https://example.com',
+        },
+        {
+          credentialsPath,
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          stdout: () => {},
+          stderr: () => {},
+        },
+      ),
+    ).rejects.toMatchObject({ exitCode: 5, code: 'VALIDATION_ERROR' });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -629,6 +656,31 @@ describe('runUpdate', () => {
           debug: false,
           projectId: 'proj_abc',
           // no mutable fields
+        },
+        {
+          credentialsPath,
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          stdout: () => {},
+          stderr: () => {},
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('rejects a whitespace-only --name with VALIDATION_ERROR (exit 5), no network', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('should not be called');
+    });
+    await expect(
+      runUpdate(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          projectId: 'proj_abc',
+          name: '   ',
         },
         {
           credentialsPath,

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -140,6 +140,15 @@ export async function runCreate(
   // (exit 10 UNAVAILABLE) — fail fast with a clear exit 5 instead.
   assertIdempotencyKey(opts.idempotencyKey);
 
+  // Reject empty / whitespace-only names so a junk record never reaches the
+  // backend — matches the `requireString` whitespace guard `test create` uses
+  // (dogfood P1 fix #1). Without this, `--name "   "` passes the action
+  // handler's `if (!name)` check (a non-empty string is truthy) and is sent
+  // verbatim, creating a blank-named project.
+  if (opts.name !== undefined && opts.name.trim().length === 0) {
+    throw localValidationError('--name must not be empty or whitespace-only');
+  }
+
   // P1-3: client-side length checks matching server limits.
   if (opts.name !== undefined && opts.name.length > 200) {
     throw localValidationError('--name must be at most 200 characters');
@@ -247,6 +256,9 @@ export async function runUpdate(
   assertIdempotencyKey(opts.idempotencyKey);
 
   // P1-3: client-side length checks matching server limits.
+  if (opts.name !== undefined && opts.name.trim().length === 0) {
+    throw localValidationError('--name must not be empty or whitespace-only');
+  }
   if (opts.name !== undefined && opts.name.length > 200) {
     throw localValidationError('--name must be at most 200 characters');
   }


### PR DESCRIPTION
## What

`testsprite project create` and `project update` accept a whitespace-only `--name` (e.g. `--name "   "`) and send it to the backend verbatim, creating a blank-named project.

## Why this matters

A whitespace-only name produces a junk project record that's effectively unidentifiable in `project list` and the dashboard. The sibling `test create` already rejects this input, so the two write paths behave inconsistently for the same kind of value.

## Reproduction

```
# project create — whitespace name is ACCEPTED (exit 0), would be sent as "   "
$ testsprite project create --type frontend --name "   " --url http://example.com --dry-run --output json
{
  "id": "p_dryrun_2026",
  "type": "frontend",
  "name": "   ",
  ...
}

# control: an EMPTY name is correctly rejected (exit 5)
$ testsprite project create --type frontend --name "" --url http://example.com --dry-run
Error: --name is required        # exit 5

# sibling `test create` — whitespace name is correctly rejected (exit 5)
$ testsprite test create --project proj_1 --type frontend --name "   " --code-file x.ts --dry-run --output json
{ "error": { "code": "VALIDATION_ERROR", "nextAction": "Flag `--name` is invalid: is required." } }   # exit 5
```

## Root cause

`src/commands/project.ts`. The command action validates the name with `if (!cmdOpts.name)`, which a whitespace-only string passes (a non-empty string is truthy), and `runCreate` / `runUpdate` only check the upper length bound:

```ts
if (opts.name !== undefined && opts.name.length > 200) {
  throw localValidationError('--name must be at most 200 characters');
}
```

There is no lower-bound / whitespace check, so `"   "` flows straight into the request body.

## Fix

Reject empty / whitespace-only names in both `runCreate` and `runUpdate`, before the existing length checks:

```ts
if (opts.name !== undefined && opts.name.trim().length === 0) {
  throw localValidationError('--name must not be empty or whitespace-only');
}
```

This mirrors the existing `requireString` whitespace guard in `src/lib/validate.ts` that `test create` already uses (added as "dogfood P1 fix #1" to stop junk records reaching the backend) — the project path just wasn't going through it.

## Tests

Added 2 tests to `src/commands/project.test.ts` (one for `runCreate`, one for `runUpdate`) asserting a whitespace-only `--name` rejects with `VALIDATION_ERROR` / exit 5 and makes no network call. Both fail on `main` before this fix and pass after.

- Before (`main`): `Tests 16 failed | 1359 passed | 72 skipped`
- After (this branch): `Tests 16 failed | 1361 passed | 72 skipped` (+2 new tests)

The 16 failures are pre-existing and environment-specific (Windows path/line-ending), unrelated to this change — see #4.

## Verification

- `npm test`: same 16 pre-existing (environment-specific) failures as baseline, zero new
- `npm run typecheck`: pass
- `npm run lint`: pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent creating or updating projects with empty or whitespace-only names.
  * Improved client-side checks so invalid names are rejected before any request is sent.
  * Added test coverage to confirm validation errors are returned consistently and no network call is made for invalid names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->