### PR TITLE
fix(target-url): treat trailing-dot hostnames as loopback

### DIFF
--- a/src/lib/target-url.spec.ts
+++ b/src/lib/target-url.spec.ts
@@ -210,6 +210,31 @@ describe('assertNotLocal — IPv6 hardening (SSRF bypass guard)', () => {
   });
 });
 
+describe('assertNotLocal — trailing-dot FQDN normalization (SSRF bypass guard)', () => {
+  // `localhost.` is the fully-qualified form of `localhost` (RFC 6761 reserves
+  // both to resolve to loopback). It previously bypassed the
+  // `host === 'localhost'` check because the WHATWG URL parser keeps the
+  // trailing dot on named hosts (IP literals are dot-normalized, named hosts
+  // are not).
+  it('blocks http://localhost. (trailing-dot loopback)', () => {
+    expectBlocked('http://localhost.');
+  });
+
+  it('blocks http://localhost.:8080 (trailing-dot loopback with port)', () => {
+    expectBlocked('http://localhost.:8080');
+  });
+
+  it('blocks http://localhost%2e (percent-encoded trailing dot)', () => {
+    expectBlocked('http://localhost%2e');
+  });
+
+  // A legitimate public FQDN with a trailing dot must still be allowed
+  // (no false positive from the dot strip).
+  it('allows https://example.com. (public FQDN with trailing dot)', () => {
+    expectAllowed('https://example.com.');
+  });
+});
+
 describe('assertNotLocal — allowed public URLs', () => {
   it('allows https://example.com', () => {
     expectAllowed('https://example.com');

--- a/src/lib/target-url.ts
+++ b/src/lib/target-url.ts
@@ -41,7 +41,14 @@ export function assertNotLocal(rawUrl: string): void {
     throw localTargetError('target-url', 'must use http or https scheme');
   }
 
-  const host = parsed.hostname.toLowerCase();
+  // Normalize a single trailing dot in the hostname. `localhost.` is the
+  // fully-qualified form of `localhost` (RFC 6761 reserves both to resolve to
+  // loopback), so `http://localhost.` must be rejected just like
+  // `http://localhost`. Without this strip, the trailing-dot form (also
+  // reachable via `localhost%2e`) slips past the `host === 'localhost'` check.
+  // IP literals are already dot-normalized by the WHATWG URL parser, so this
+  // only affects named hosts.
+  const host = parsed.hostname.toLowerCase().replace(/\.$/, '');
 
   // Loopback / unspecified.
   if (host === 'localhost' || host === '0.0.0.0') {


### PR DESCRIPTION
## What

`assertNotLocal` (the `--target-url` pre-flight guard) rejects `http://localhost` but accepts `http://localhost.` — the trailing-dot (fully-qualified) form of the same loopback name.

## Why this matters

`localhost.` resolves to the loopback address just like `localhost`, so `test create --target-url http://localhost.` / `test run --target-url …` passes the guard when the equivalent `http://localhost` is correctly rejected. The guard's `localhost` special-case is simply incomplete for the FQDN form.

## Reproduction

```
http://localhost       -> REJECTED  (correct)
http://localhost.      -> ACCEPTED  (bug — trailing-dot loopback)
http://localhost.:8080 -> ACCEPTED  (bug)
http://localhost%2e    -> ACCEPTED  (bug — decodes to localhost.)
http://127.0.0.1.      -> REJECTED  (control — WHATWG URL normalizes IP literals, so numeric forms are already handled)
```

Reproduced directly against `assertNotLocal`. The `http://127.0.0.1.` control shows the numeric-IP path is already fine; only the named-host trailing-dot form slips through.

## Root cause

`src/lib/target-url.ts`, `assertNotLocal`:

```ts
const host = parsed.hostname.toLowerCase();
...
if (host === 'localhost' || host === '0.0.0.0') { ... }
```

The WHATWG URL parser dot-normalizes IP literals but keeps the trailing dot on named hosts, so `localhost.` never equals `localhost`.

## Fix

Strip a single trailing dot from the hostname before the comparison:

```ts
const host = parsed.hostname.toLowerCase().replace(/\.$/, '');
```

IP literals are unaffected (already dot-normalized by `new URL()`); only named hosts change.

## Tests

Added 4 tests to `src/lib/target-url.spec.ts`: 3 trailing-dot loopback variants (`localhost.`, `localhost.:8080`, `localhost%2e`) now blocked, plus 1 no-false-positive check that a legitimate public FQDN with a trailing dot (`https://example.com.`) is still allowed. The 3 "blocked" tests fail on `main` before this fix and pass after.

- Before (`main`): `Tests 16 failed | 1359 passed | 72 skipped`
- After (this branch): `Tests 16 failed | 1363 passed | 72 skipped` (+4 new tests)

The 16 failures are pre-existing and environment-specific (Windows path/line-ending), unrelated to this change — see #4.

## Verification

- `npm test`: same 16 pre-existing (environment-specific) failures as baseline, zero new
- `npm run typecheck`: pass
- `npm run lint`: pass

## Note on scope

`assertNotLocal` is documented as a best-effort client-side pre-flight check, not the security boundary (the backend enforces that). This PR doesn't change that posture — it just closes a gap in the guard's own existing special-case for `localhost`, since `localhost.` (trailing dot, RFC 952 / 1123 FQDN form) resolves to the same loopback address but wasn't being normalized before the comparison. Happy to close this if the maintainers consider trailing-dot normalization out of scope for this guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL safety checks by treating hostnames with a trailing dot the same as their non-trailing-dot equivalents.
  * Blocked localhost-style addresses such as `localhost.`, including port and encoded variants, while still allowing valid public domains like `example.com.`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->