### PR TITLE
fix(auth): preserve typed API error envelope when setup key verification fails

### DIFF
--- a/src/commands/auth.test.ts
+++ b/src/commands/auth.test.ts
@@ -268,6 +268,46 @@ describe('runConfigure', () => {
     expect(capture.stderr.join('\n')).toContain('profile NOT updated');
   });
 
+  it('key-rejected error preserves the typed ApiError envelope (JSON contract)', async () => {
+    const { deps } = makeCapture();
+    const rejectedFetch: AuthDeps['fetchImpl'] = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'AUTH_INVALID',
+              message: 'API key is invalid or revoked.',
+              nextAction: 'Rotate your key.',
+              requestId: 'req_reject',
+              details: { reason: 'malformed' },
+            },
+          }),
+          { status: 401, headers: { 'content-type': 'application/json' } },
+        ),
+    ) as unknown as AuthDeps['fetchImpl'];
+
+    // The thrown error must be an ApiError (with code, nextAction, requestId)
+    // — not a CLIError wrapper that drops those fields. Under --output json,
+    // index.ts renders ApiError as the full typed envelope; CLIError would
+    // render only {"error":"...string..."}, violating the JSON contract.
+    await expect(
+      runConfigure(
+        { profile: 'default', output: 'json', debug: false, fromEnv: true },
+        {
+          ...deps,
+          env: { TESTSPRITE_API_KEY: 'sk-bad' },
+          credentialsPath,
+          fetchImpl: rejectedFetch,
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: 'AUTH_INVALID',
+      exitCode: 3,
+      nextAction: 'Rotate your key.',
+      requestId: 'req_reject',
+    });
+  });
+
   // The old "run `testsprite agent install`" self-bootstrap tip was removed with
   // the setup consolidation — runConfigure now runs ONLY as part of `setup`,
   // which installs the skill itself. These guard that the tip stays gone.

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -158,13 +158,22 @@ export async function runConfigure(opts: ConfigureOptions, deps: AuthDeps = {}):
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     stderr(`API key rejected by ${apiUrl}: ${message} — profile NOT updated`);
-    const exitCode = err instanceof ApiError ? err.exitCode : 3;
-    // Include the resolved endpoint in the thrown message so the user knows
-    // which host rejected the key. This prevents the "invalid or revoked"
-    // message from being ambiguous when the key is valid for a different env.
+    // When the verification call returned a typed API error (AUTH_INVALID,
+    // AUTH_FORBIDDEN, etc.), re-throw it directly so `index.ts` renders the
+    // full typed envelope under `--output json` (code, nextAction, requestId,
+    // details). Previously wrapping it in CLIError discarded those fields and
+    // emitted a bare `{"error":"...string..."}` — violating the JSON contract.
+    // Augment the message with the endpoint context so text-mode users still
+    // see which host rejected the key.
+    if (err instanceof ApiError) {
+      err.message = `API key rejected by ${apiUrl}: ${message} — did you mean to set TESTSPRITE_API_URL?`;
+      throw err;
+    }
+    // Non-ApiError (truly unexpected throws like a TypeError from a
+    // misconfigured fetchImpl). Exit 3 (auth family).
     throw new CLIError(
       `API key rejected by ${apiUrl}: ${message} — did you mean to set TESTSPRITE_API_URL?`,
-      exitCode,
+      3,
     );
   }
 


### PR DESCRIPTION
## What

When `setup --from-env --output json` verifies an API key and the key is rejected (e.g. invalid or revoked), the JSON output is a bare `{"error":"...string..."}` instead of the typed envelope with `code`, `nextAction`, `requestId`, and `details`.

## Why this matters

Machine consumers (coding agents, CI scripts) that `JSON.parse(stderr)` expect the typed envelope shape documented in DOCUMENTATION.md. A bare string error gives them no `code` to branch on, no `nextAction` to surface, and no `requestId` for support. Every other API error path in the CLI already emits the full typed envelope; this is the sole exception.

## Reproduction

```bash
$ TESTSPRITE_API_KEY=sk-invalid testsprite setup --from-env --output json --yes --no-agent

# BEFORE (exit 3, bare string error):
{"error":"API key rejected by https://api.testsprite.com: API key is invalid or revoked. - did you mean to set TESTSPRITE_API_URL?"}

# AFTER (exit 3, full typed envelope):
{
  "error": {
    "code": "AUTH_INVALID",
    "message": "API key rejected by https://api.testsprite.com: API key is invalid or revoked. - did you mean to set TESTSPRITE_API_URL?",
    "nextAction": "API key is invalid or revoked. Generate a new one at https://www.testsprite.com/dashboard/settings/apikey.",
    "requestId": "cli_...",
    "details": { "reason": "malformed" }
  }
}

# Control: missing key (already correct, exit 5 with typed envelope):
$ testsprite setup --from-env --output json --yes --no-agent
{"error":{"code":"VALIDATION_ERROR","message":"TESTSPRITE_API_KEY is not set..."}}
```

## Root cause

`src/commands/auth.ts`, `runConfigure`, line 157-168. The key-verification catch block wraps the original `ApiError` in a `CLIError`:

```ts
} catch (err) {
  ...
  throw new CLIError(
    `API key rejected by ${apiUrl}: ${message} - did you mean to set TESTSPRITE_API_URL?`,
    exitCode,
  );
}
```

`CLIError` has only `message` and `exitCode`. In `index.ts`, the `CLIError` path renders via `output.error(err.message)` which produces `{"error":"...string..."}` -- losing the full typed envelope that the `ApiError` path would have rendered.

## Fix

When `err` is an `ApiError`, augment its `.message` with the endpoint context (so text-mode users still see which host rejected them), then re-throw it directly. The `ApiError` catch path in `index.ts` renders the full typed envelope. Non-`ApiError` throws (truly unexpected errors) still wrap in `CLIError` for a clean exit 3.

This mirrors how every other command path that catches and re-throws API errors already works (the error carries its own envelope; the CLI just sets exit code from it).

## Tests

Added 1 regression test to `src/commands/auth.test.ts` asserting the thrown error is an `ApiError` with `code: 'AUTH_INVALID'`, `exitCode: 3`, `nextAction`, and `requestId` intact. Fails on `main` before this fix; passes after.

- Before (`main`): `Tests 16 failed | 1359 passed | 72 skipped`
- After (this branch): `Tests 16 failed | 1360 passed | 72 skipped` (+1 new test)

The 16 failures are pre-existing and environment-specific (Windows path/line-ending), unrelated -- see #4.

## Verification

- `npm test`: same 16 pre-existing (environment-specific) failures as baseline, zero new
- `npm run typecheck`: pass
- `npm run lint`: pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key verification errors so rejected requests now preserve structured JSON details instead of being converted into a generic CLI error.
  * Kept the original error fields available for JSON output, including the error code, next action, and request ID.
  * Continued to show a clear endpoint-related message while maintaining the expected exit code for non-API errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->