### PR TITLE
fix(test): reject whitespace-only --name in test update (parity with test create)

### DIFF
--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -5777,6 +5777,31 @@ describe('runUpdate', () => {
     expect(called).toBe(0);
   });
 
+  it('rejects a whitespace-only --name before sending (parity with test create)', async () => {
+    const { credentialsPath } = makeCreds();
+    let called = 0;
+    const fetchImpl = makeFetch(() => {
+      called += 1;
+      return { body: SAMPLE_RESPONSE };
+    });
+    await expect(
+      runUpdate(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          testId: 'test_alpha',
+          name: '   ',
+        },
+        { credentialsPath, fetchImpl, stdout: () => undefined },
+      ),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      details: expect.objectContaining({ field: 'name' }),
+    });
+    expect(called).toBe(0);
+  });
+
   it('renders text mode with one line per updated field', async () => {
     const { credentialsPath } = makeCreds();
     const fetchImpl = makeFetch(() => ({ body: SAMPLE_RESPONSE }));

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1244,7 +1244,10 @@ export async function runUpdate(
   requireNonEmpty('test-id', opts.testId);
   // P1-3: client-side length checks matching server limits.
   if (opts.name !== undefined && opts.name.trim().length === 0) {
-    throw localValidationError('name', 'must be a non-empty string (whitespace-only is not allowed)');
+    throw localValidationError(
+      'name',
+      'must be a non-empty string (whitespace-only is not allowed)',
+    );
   }
   if (opts.name !== undefined && opts.name.length > 200) {
     throw localValidationError('name', 'must be at most 200 characters');

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1243,6 +1243,9 @@ export async function runUpdate(
   assertIdempotencyKey(opts.idempotencyKey);
   requireNonEmpty('test-id', opts.testId);
   // P1-3: client-side length checks matching server limits.
+  if (opts.name !== undefined && opts.name.trim().length === 0) {
+    throw localValidationError('name', 'must be a non-empty string (whitespace-only is not allowed)');
+  }
   if (opts.name !== undefined && opts.name.length > 200) {
     throw localValidationError('name', 'must be at most 200 characters');
   }


### PR DESCRIPTION
## What

`test update --name "   "` (whitespace-only) is accepted and would send a blank name to the backend, while the sibling `test create --name "   "` correctly rejects it with `VALIDATION_ERROR` (exit 5).

## Why this matters

A whitespace-only name produces a junk test record that is effectively invisible in `test list` output and the dashboard. The `test create` path already prevents this via `requireString` (dogfood P1 fix #1); `test update` missed the same guard and only checks the upper length bound.

## Reproduction

```bash
# test update -- whitespace name ACCEPTED (exit 0), would send "   " to backend:
$ testsprite test update test_abc --name "   " --dry-run --output json
{ "testId": "test_dryrun_update_2026", "updatedFields": ["name"], ... }   # exit 0

# control: test create -- whitespace name correctly REJECTED (exit 5):
$ testsprite test create --project proj_1 --type frontend --name "   " --code-file x.ts --dry-run --output json
{ "error": { "code": "VALIDATION_ERROR", "nextAction": "Flag `--name` is invalid: is required." } }   # exit 5
```

## Root cause

`src/commands/test.ts`, `runUpdate` (line ~1212). The function validates name length:

```ts
if (opts.name !== undefined && opts.name.length > 200) {
  throw localValidationError('name', 'must be at most 200 characters');
}
```

But has no lower-bound / whitespace check. A whitespace-only string passes `opts.name !== undefined` (it's a non-empty string), the length check (3 < 200), and flows into the PATCH body.

## Fix

Add a whitespace rejection before the length check, mirroring the existing `requireNonEmpty` / `requireString` pattern used elsewhere in the same file:

```ts
if (opts.name !== undefined && opts.name.trim().length === 0) {
  throw localValidationError('name', 'must be a non-empty string (whitespace-only is not allowed)');
}
```

## Tests

Added 1 regression test to `src/commands/test.test.ts` (in the `runUpdate` describe block) asserting `name: '   '` rejects with `VALIDATION_ERROR` / field `name` and makes no network call. Fails on `main` before this fix; passes after.

- Before (`main`): `Tests 16 failed | 1359 passed | 72 skipped`
- After (this branch): `Tests 16 failed | 1360 passed | 72 skipped` (+1 new test)

The 16 failures are pre-existing and environment-specific (Windows path/line-ending), unrelated -- see #4.

## Verification

- `npm test`: same 16 pre-existing (environment-specific) failures as baseline, zero new
- `npm run typecheck`: pass
- `npm run lint`: pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the `--name` option so whitespace-only values are now rejected before any update request is sent.
  * Invalid input now returns a clear validation error associated with the `name` field.
* **Tests**
  * Added coverage to ensure whitespace-only `--name` inputs fail validation and do not trigger any network call.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->