### PR TITLE
fix(pagination): reject fractional pagination flags

### DIFF
--- a/src/lib/pagination.test.ts
+++ b/src/lib/pagination.test.ts
@@ -43,8 +43,16 @@ describe('validatePaginationFlags', () => {
     expect(() => validatePaginationFlags({ pageSize: Number.NaN })).toThrow(ApiError);
   });
 
+  it('rejects fractional pageSize values', () => {
+    expect(() => validatePaginationFlags({ pageSize: 1.5 })).toThrow(ApiError);
+  });
+
   it('rejects maxItems=0', () => {
     expect(() => validatePaginationFlags({ maxItems: 0 })).toThrow(ApiError);
+  });
+
+  it('rejects fractional maxItems values', () => {
+    expect(() => validatePaginationFlags({ maxItems: 2.5 })).toThrow(ApiError);
   });
 
   it('accepts pageSize=100 (the hard cap)', () => {

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -27,9 +27,9 @@ const DEFAULT_PAGE_SIZE = 25;
  * Validates and normalizes pagination flags. Per the CLI OpenAPI spec
  * §components.parameters.PageSize the hard cap is 100. Values above the
  * cap are now rejected with exit 5 rather than silently clamped, giving
- * callers fast feedback that their flag value is out of range. Sub-1 /
- * NaN values also throw. `maxItems` is validated but not capped (it is a
- * client-side cursor, not a server parameter).
+ * callers fast feedback that their flag value is out of range. Fractional,
+ * sub-1, and NaN values also throw. `maxItems` is validated but not capped
+ * (it is a client-side cursor, not a server parameter).
  *
  * NOTE: `runResultHistory` previously did its own silent clamp via
  * `Math.min(Math.max(1, n), 100)` — that was unified to this path by the
@@ -38,7 +38,7 @@ const DEFAULT_PAGE_SIZE = 25;
 export function validatePaginationFlags(flags: PaginationFlags): PaginationFlags {
   const out: PaginationFlags = { ...flags };
   if (out.pageSize !== undefined) {
-    if (!Number.isFinite(out.pageSize) || out.pageSize < 1) {
+    if (!Number.isFinite(out.pageSize) || !Number.isInteger(out.pageSize) || out.pageSize < 1) {
       throw localValidationError(
         'page-size',
         `must be a positive integer between 1 and ${HARD_PAGE_SIZE_CAP}`,
@@ -52,7 +52,7 @@ export function validatePaginationFlags(flags: PaginationFlags): PaginationFlags
     }
   }
   if (out.maxItems !== undefined) {
-    if (!Number.isFinite(out.maxItems) || out.maxItems < 1) {
+    if (!Number.isFinite(out.maxItems) || !Number.isInteger(out.maxItems) || out.maxItems < 1) {
       throw localValidationError('maxItems', 'must be a positive integer');
     }
   }


### PR DESCRIPTION
## What

`--page-size` and `--max-items` are documented as integer pagination values, but shared pagination validation accepted fractional numbers like `1.5` and `2.5`.

## Why

Fractional pagination parameters are invalid per CLI docs/error wording and can produce surprising API requests. Local validation should reject them before credentials or network work.

## Changes

- Require `Number.isInteger` for `pageSize` and `maxItems`.
- Add regression tests for fractional `pageSize` and `maxItems`.

## Verification

- `npx vitest run src/lib/pagination.test.ts src/commands/project.test.ts src/commands/test.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`