### PR TITLE
fix(help): include request-timeout in global flag guidance

### DIFF
--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -3,10 +3,10 @@ export type OutputMode = 'json' | 'text';
 /**
  * Help-text footer pointing at the global options surface so users
  * looking at any subcommand `--help` don't miss `--dry-run`, `--output`,
- * `--profile`, `--endpoint-url`, `--debug`.
+ * `--profile`, `--endpoint-url`, `--request-timeout`, `--debug`.
  */
 export const GLOBAL_OPTS_HINT =
-  '\nGlobal options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):' +
+  '\nGlobal options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):' +
   '\n  testsprite --help';
 
 export function isOutputMode(value: unknown): value is OutputMode {

--- a/src/lib/render-error.test.ts
+++ b/src/lib/render-error.test.ts
@@ -37,6 +37,12 @@ describe('rephraseUnknownOption', () => {
     expect(result).toContain('--endpoint-url');
   });
 
+  it('rephrases --request-timeout placed after subcommand', () => {
+    const result = rephraseUnknownOption("error: unknown option '--request-timeout'");
+    expect(result).not.toBeNull();
+    expect(result).toContain('--request-timeout');
+  });
+
   it('rephrases --debug placed after subcommand', () => {
     const result = rephraseUnknownOption("error: unknown option '--debug'");
     expect(result).not.toBeNull();
@@ -86,6 +92,12 @@ describe('rephraseUnknownOption', () => {
     const result = rephraseUnknownOption("error: unknown option '--endpoint-url'");
     expect(result).not.toBeNull();
     expect(result).toContain('testsprite --endpoint-url <value> <subcommand>');
+  });
+
+  it('value flag (--request-timeout) example DOES include a <value> placeholder', () => {
+    const result = rephraseUnknownOption("error: unknown option '--request-timeout'");
+    expect(result).not.toBeNull();
+    expect(result).toContain('testsprite --request-timeout <value> <subcommand>');
   });
 });
 

--- a/src/lib/render-error.ts
+++ b/src/lib/render-error.ts
@@ -11,13 +11,15 @@ import type { OutputMode } from './output.js';
  *
  * `boolean` flags (--dry-run, --debug, --verbose) take no value; emit
  * example without a placeholder. `value` flags (--output, --profile,
- * --endpoint-url) take a single argument; emit example with `<value>`.
+ * --endpoint-url, --request-timeout) take a single argument; emit example
+ * with `<value>`.
  */
 const GLOBAL_FLAG_ARITY: Record<string, 'boolean' | 'value'> = {
   'dry-run': 'boolean',
   output: 'value',
   profile: 'value',
   'endpoint-url': 'value',
+  'request-timeout': 'value',
   debug: 'boolean',
   verbose: 'boolean',
 };

--- a/test/__snapshots__/help.snapshot.test.ts.snap
+++ b/test/__snapshots__/help.snapshot.test.ts.snap
@@ -34,7 +34,7 @@ Options:
                 destroyed.
   -h, --help    display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -47,7 +47,7 @@ List supported agent targets, their status, and landing paths
 Options:
   -h, --help  display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -84,7 +84,7 @@ exports[`--help snapshots > auth logout 1`] = `
 Options:
   -h, --help  display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -95,7 +95,7 @@ exports[`--help snapshots > auth whoami 1`] = `
 Options:
   -h, --help  display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -151,7 +151,7 @@ Get a project by id
 Options:
   -h, --help  display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -173,7 +173,7 @@ Options:
   --max-items <n>           stop after this many items across auto-paged pages
   -h, --help                display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -278,7 +278,7 @@ Options:
                 source body; json mode: wire envelope)
   -h, --help    display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -313,7 +313,7 @@ Options:
                              per invocation; pin one yourself for safe retries.
   -h, --help                 display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -329,7 +329,7 @@ Options:
   --failed-only  Keep only the failed step plus its immediate neighbors (±1)
   -h, --help     display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -342,7 +342,7 @@ Get a test by id
 Options:
   -h, --help  display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -367,7 +367,7 @@ Options:
   --max-items <n>           stop after this many items across auto-paged pages
   -h, --help                display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -431,7 +431,7 @@ Dry-run shape notes:
     omit \`closure\` (or return it as null) since there is no dependency expansion.
   • \`autoHeal\` defaults true for FE reruns; BE reruns ignore the field entirely.
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -463,7 +463,7 @@ Options:
   --cursor <token>    with --history: opaque cursor from a prior page
   -h, --help          display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -514,7 +514,7 @@ Dependency-aware fresh run (M4):
 BE tests can declare --produces/--needs at create time to drive wave ordering
 (see \`testsprite test create --help\` for details).
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;
@@ -537,7 +537,7 @@ Options:
                             excluded when this flag is set.
   -h, --help                display help for command
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;


### PR DESCRIPTION
## What

`--request-timeout` is a global flag, but it was missing from two pieces of global-flag guidance:

- the helper that rephrases misplaced global flags after subcommands
- the shared `GLOBAL_OPTS_HINT` footer appended to subcommand help text

## Why

When a user places a known global flag after a subcommand, the CLI tries to turn Commander’s generic `unknown option` message into an actionable hint. `--request-timeout` should get the same treatment as `--output`, `--profile`, and `--endpoint-url`.

## Changes

- Add `request-timeout` to the global flag arity table as a value flag.
- Include `--request-timeout` in the shared global options help footer.
- Add regression tests for the rephrased misplaced-flag message.
- Refresh help snapshots for the updated footer.

## Verification

- `npx vitest run src/lib/render-error.test.ts test/help.snapshot.test.ts -u`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test`