### PR TITLE
docs(project): fix create URL flag example

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -319,10 +319,10 @@ testsprite test plan put test_xxxxxxxx --steps ./refined.plan.json --dry-run --o
 
 #### `testsprite project create` / `project update`
 
-Manage projects from the CLI. Both pre-flight `--target-url` against local addresses for fast feedback.
+Manage projects from the CLI. Both pre-flight `--url` against local addresses for fast feedback.
 
 ```bash
-testsprite project create --name "Checkout" --target-url https://staging.example.com
+testsprite project create --type frontend --name "Checkout" --url https://staging.example.com
 testsprite project update proj_xxxxxxxx --name "Checkout v2"
 ```
 


### PR DESCRIPTION
## What

The `project create` documentation used `--target-url`, but the actual command exposes `--url` for project target URLs. The example also omitted the required `--type` flag.

## Changes

- Replace `--target-url` with `--url` in the project create/update docs section.
- Add `--type frontend` to the `project create` example so the command is runnable as written.

## Verification

- `node dist/index.js project create --help`
- `npm run format:check`