### PR TITLE
fix(test): validate artifact run id default path

### DIFF
--- a/src/commands/test.artifact.spec.ts
+++ b/src/commands/test.artifact.spec.ts
@@ -20,6 +20,7 @@ import type { CliFailureContext, CliLatestResult, CliTestStep } from './test.js'
 import {
   assertOutDirParentExists,
   createTestArtifactCommand,
+  resolveDefaultArtifactDir,
   runArtifactGet,
   runFailureGet,
 } from './test.js';
@@ -317,6 +318,31 @@ describe('runArtifactGet', () => {
     } finally {
       cwdSpy.mockRestore();
     }
+  });
+
+  it('rejects path-like runId before auth or fetch when default --out is used', async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>();
+
+    await expect(
+      runArtifactGet(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          runId: '../../outside',
+          failedOnly: false,
+        },
+        { fetchImpl, stdout: () => {} },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('keeps the documented default directory for path-safe runIds', () => {
+    expect(resolveDefaultArtifactDir(SAMPLE_RUN_ID, '/repo')).toBe(
+      join('/repo', '.testsprite', 'runs', SAMPLE_RUN_ID),
+    );
   });
 
   // ---- --failed-only passed through to writeBundle ----

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -6703,6 +6703,20 @@ export interface ArtifactGetResult {
   bundle?: WriteBundleResult;
 }
 
+export function resolveDefaultArtifactDir(runId: string, cwd: string = process.cwd()): string {
+  requireNonEmpty('run-id', runId);
+  if (runId === '.' || runId === '..' || runId.includes('/') || runId.includes('\\')) {
+    throw localValidationError(
+      'run-id',
+      'must be a single path-safe segment for the default output directory; pass --out <dir> to choose a custom path',
+    );
+  }
+  if (runId.includes('\0')) {
+    throw localValidationError('run-id', 'must not contain NUL bytes');
+  }
+  return join(cwd, '.testsprite', 'runs', runId);
+}
+
 /**
  * Validate that the parent directory of `resolvedDir` exists and is a
  * directory. Surfaces `VALIDATION_ERROR` (exit 5) — matches the convention
@@ -6752,14 +6766,13 @@ export async function runArtifactGet(
   deps: TestDeps = {},
 ): Promise<ArtifactGetResult> {
   const out = makeOutput(opts.output, deps);
-  const client = makeClient(opts, deps);
   const { runId } = opts;
 
   // Resolve output dir: explicit --out or the default .testsprite/runs/<runId>/
   const resolvedDir =
     opts.out !== undefined
       ? resolveBundleDir(opts.out)
-      : join(process.cwd(), '.testsprite', 'runs', runId);
+      : resolveDefaultArtifactDir(runId);
 
   // --dry-run: no network, no disk write.
   // The client (makeClient) is already wired with createDryRunFetch() when
@@ -6804,6 +6817,8 @@ export async function runArtifactGet(
   if (opts.out !== undefined) {
     await assertOutDirParentExists(resolvedDir);
   }
+
+  const client = makeClient(opts, deps);
 
   // Fetch the run-scoped failure bundle.
   const { body: context, requestId: fetchRequestId } = await client.getWithMeta<CliFailureContext>(


### PR DESCRIPTION
## Summary

Fixes #45.

`test artifact get <run-id>` used the raw positional `runId` as the final segment of the default output directory:

```text
./.testsprite/runs/<run-id>/
```

That made the implicit destination path interpret path-like run IDs as filesystem structure. For example, a value like `../../outside` would normalize outside the documented `.testsprite/runs/` artifact root when `--out` was omitted.

This PR treats `runId` as an opaque identifier for the implicit default path. If callers want a custom filesystem location, the existing explicit `--out <dir>` path remains the supported mechanism.

## Changes

- Add `resolveDefaultArtifactDir(runId, cwd)` for the implicit artifact output directory.
- Reject path-like run IDs for the default path:
  - `.` / `..`
  - `/`
  - `\`
  - NUL bytes
- Keep normal run IDs on the documented path: `./.testsprite/runs/<run-id>/`.
- Move HTTP client construction until after local path validation and dry-run handling, so invalid local input fails before credentials, network, or disk work.
- Add regression coverage for unsafe path-like run IDs and the normal default path.

## Why

`test artifact get` writes a multi-file failure bundle. The documented default path implies containment under `.testsprite/runs/`, while `--out` is already available for intentional custom paths. Failing closed on path-like positional IDs keeps the default artifact tree predictable and avoids surprising local writes.

## Verification

- `npx vitest run src/commands/test.artifact.spec.ts`
- `npm run typecheck`
