### PR TITLE
fix(agent): reject invalid output modes

### DIFF
--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -854,6 +854,28 @@ describe('createAgentCommand wiring', () => {
     expect(out).toContain('claude');
     expect(out).toContain('antigravity');
   });
+
+  it('agent list rejects unsupported global --output modes', async () => {
+    const { deps } = makeCapture();
+
+    const command = createAgentCommand({ cwd: CWD, ...deps });
+    const parent = new (await import('commander')).Command('testsprite');
+    parent.option('--output <mode>', 'output', 'text');
+    parent.option('--profile <name>', 'profile', 'default');
+    parent.option('--endpoint-url <url>');
+    parent.option('--debug', 'debug', false);
+    parent.option('--verbose', 'verbose', false);
+    parent.option('--dry-run', 'dry-run', false);
+    parent.addCommand(command);
+
+    await expect(
+      parent.parseAsync(['node', 'ts', 'agent', 'list', '--output', 'yaml']),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+      details: { field: 'output' },
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -755,9 +755,13 @@ export function createAgentCommand(deps: AgentDeps = {}): Command {
 
 function resolveCommonOptions(command: Command): CommonOptions {
   const globals = command.optsWithGlobals() as Partial<CommonOptions>;
+  const rawOutput = globals.output;
+  if (rawOutput !== undefined && rawOutput !== 'json' && rawOutput !== 'text') {
+    throw localValidationError('output', 'must be one of: json, text', ['json', 'text']);
+  }
   return {
     profile: globals.profile ?? 'default',
-    output: globals.output ?? 'text',
+    output: (globals.output as OutputMode | undefined) ?? 'text',
     endpointUrl: globals.endpointUrl,
     debug: globals.debug ?? false,
     verbose: globals.verbose ?? false,


### PR DESCRIPTION
## Summary

- validate `testsprite agent ... --output <mode>` against the supported `json|text` modes
- return the existing local `VALIDATION_ERROR` shape instead of silently treating unsupported modes as text
- add command-wiring coverage for `agent list`

## Before

`testsprite agent list --output yaml` exited 0 and printed text output.

## After

`testsprite agent list --output yaml` exits 5 with:

```text
Error: Invalid request.
Flag `--output` is invalid: must be one of: json, text.
```

## Verification

- `npm test -- src/commands/agent.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `node dist/index.js agent list --output yaml`