### PR TITLE
fix(auth): reject invalid output modes

### DIFF
--- a/src/commands/auth.test.ts
+++ b/src/commands/auth.test.ts
@@ -986,6 +986,27 @@ describe('createAuthCommand wiring', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it('status rejects unsupported global --output modes', async () => {
+    const { deps } = makeCapture();
+    const auth = createAuthCommand({ ...deps });
+    const parent = new (await import('commander')).Command('testsprite');
+    parent.option('--output <mode>', 'output', 'text');
+    parent.option('--profile <name>', 'profile', 'default');
+    parent.option('--endpoint-url <url>');
+    parent.option('--debug', 'debug', false);
+    parent.option('--verbose', 'verbose', false);
+    parent.option('--dry-run', 'dry-run', false);
+    parent.addCommand(auth);
+
+    await expect(
+      parent.parseAsync(['node', 'ts', 'auth', 'status', '--output', 'yaml', '--dry-run']),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+      details: { field: 'output' },
+    });
+  });
+
   it('logout removes the profile', async () => {
     writeProfile('default', { apiKey: 'sk' }, { path: credentialsPath });
     const { deps } = makeCapture();

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -5,7 +5,7 @@ import {
   type CommonOptions as FactoryCommonOptions,
 } from '../lib/client-factory.js';
 import type { ErrorCode } from '../lib/errors.js';
-import { ApiError, CLIError } from '../lib/errors.js';
+import { ApiError, CLIError, localValidationError } from '../lib/errors.js';
 import { facadeBaseUrl } from '../lib/facade.js';
 import type { FetchImpl } from '../lib/http.js';
 import { HttpClient } from '../lib/http.js';
@@ -316,9 +316,13 @@ function resolveCommonOptions(command: Command): CommonOptions {
   const globals = command.optsWithGlobals() as Partial<CommonOptions> & {
     requestTimeout?: string;
   };
+  const rawOutput = globals.output;
+  if (rawOutput !== undefined && rawOutput !== 'json' && rawOutput !== 'text') {
+    throw localValidationError('output', 'must be one of: json, text', ['json', 'text']);
+  }
   return {
     profile: globals.profile ?? 'default',
-    output: globals.output ?? 'text',
+    output: (globals.output as OutputMode | undefined) ?? 'text',
     endpointUrl: globals.endpointUrl,
     debug: globals.debug ?? false,
     verbose: globals.verbose ?? false,


### PR DESCRIPTION
## Summary

- validate `testsprite auth ... --output <mode>` against the supported `json|text` modes
- return the existing local `VALIDATION_ERROR` shape instead of silently treating unsupported modes as text
- add command-wiring coverage for `auth status`

## Before

`testsprite auth status --output yaml --dry-run` exited 0 and printed text output.

## After

`testsprite auth status --output yaml --dry-run` exits 5 with:

```text
Error: Invalid request.
Flag `--output` is invalid: must be one of: json, text.
```

## Verification

- `npm test -- src/commands/auth.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `node dist/index.js auth status --output yaml --dry-run`