### PR TITLE
fix(history): reject fractional page sizes

### DIFF
--- a/src/commands/test.result.history.spec.ts
+++ b/src/commands/test.result.history.spec.ts
@@ -533,6 +533,32 @@ describe('runResultHistory — pagination', () => {
 
     expect(capturedUrl).toContain('pageSize=5');
   });
+
+  it('rejects fractional --page-size before making a request', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = makeFetch(() => {
+      throw new Error('should not be called');
+    });
+
+    await expect(
+      runResultHistory(
+        {
+          output: 'json',
+          testId: 'test_abc',
+          pageSize: 1.5,
+          profile: 'default',
+          dryRun: false,
+          debug: false,
+          verbose: false,
+        },
+        { credentialsPath, fetchImpl, stdout: () => {} },
+      ),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+      details: expect.objectContaining({ field: 'page-size' }),
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -3799,7 +3799,10 @@ export async function runResultHistory(
   // configured (codex round-2), matching validatePaginationFlags ordering
   // in `test list` / `project list`.
   if (opts.pageSize !== undefined) {
-    if (!Number.isFinite(opts.pageSize) || opts.pageSize < 1 || opts.pageSize > 100) {
+    if (!Number.isFinite(opts.pageSize) || !Number.isInteger(opts.pageSize)) {
+      throw localValidationError('page-size', 'must be an integer between 1 and 100');
+    }
+    if (opts.pageSize < 1 || opts.pageSize > 100) {
       throw localValidationError('page-size', 'must be between 1 and 100');
     }
   }


### PR DESCRIPTION
## Summary
- make `test result --history --page-size` reject fractional values before building the request
- keep the existing 1-100 bounds check, but add an integer check for values such as `1.5`
- add regression coverage that ensures no request is made for a fractional history page size

## Repro
Before this change, `testsprite test result test_abc --history --dry-run --page-size 1.5 --output json` exited 0 and passed the fractional page size through. After this change it exits 5 with a local VALIDATION_ERROR naming `page-size`.

## Verification
- `npm test -- src/commands/test.result.history.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `node dist/index.js --output json test result test_abc --history --dry-run --page-size 1.5`