### PR TITLE
fix: align documented Node engine floor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ the thread or in Discord is welcome.
 
 ## Prerequisites
 
-- Node 20 or newer (development happens on Node 22).
+- Node 20.19+, Node 22.13+, or Node 24+ (development happens on Node 22).
 
 ## Build from source
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -35,7 +35,7 @@ Or run it without installing:
 npx @testsprite/testsprite-cli --version
 ```
 
-Requires **Node.js ≥ 20**.
+Requires **Node.js 20.19+**, **22.13+**, or **24+**.
 
 Confirm the binary works **without** configuring an API key:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AI ships code in minutes — verifying it hasn't. `testsprite` opens your live a
 <p>
   <a href="https://www.npmjs.com/package/@testsprite/testsprite-cli"><img src="https://img.shields.io/npm/v/@testsprite/testsprite-cli?color=19C379&label=npm" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/@testsprite/testsprite-cli"><img src="https://img.shields.io/npm/dm/@testsprite/testsprite-cli?color=19C379&label=downloads" alt="npm downloads"></a>
-  <a href="#quickstart"><img src="https://img.shields.io/badge/node-%3E%3D20-19C379" alt="Node >= 20"></a>
+  <a href="#quickstart"><img src="https://img.shields.io/badge/node-20.19%2B%20%7C%2022.13%2B%20%7C%2024%2B-19C379" alt="Node 20.19+, 22.13+, or 24+"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-0A0A0A" alt="License Apache 2.0"></a>
   <a href="https://github.com/TestSprite/testsprite-cli/actions/workflows/ci.yml"><img src="https://github.com/TestSprite/testsprite-cli/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
 </p>
@@ -54,7 +54,7 @@ If you find `testsprite` useful, a GitHub Star ⭐️ would be greatly appreciat
 
 ## Quickstart
 
-Requires **Node.js ≥ 20**. (No global install? `npx @testsprite/testsprite-cli` works too.)
+Requires **Node.js 20.19+**, **22.13+**, or **24+**. (No global install? `npx @testsprite/testsprite-cli` works too.)
 
 ```bash
 npm install -g @testsprite/testsprite-cli
@@ -173,7 +173,7 @@ That's the point of all of this: you no longer need the biggest, most expensive 
 
 ## Contributing
 
-Contributions are welcome — the CLI is plain TypeScript/Node (≥ 20), tested with Vitest, built with `tsc`. Getting a dev loop running takes a minute:
+Contributions are welcome — the CLI is plain TypeScript/Node (20.19+, 22.13+, or 24+), tested with Vitest, built with `tsc`. Getting a dev loop running takes a minute:
 
 ```bash
 git clone https://github.com/TestSprite/testsprite-cli.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "vitest": "^2.1.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:e2e": "npm run build && vitest run -c vitest.e2e.config.ts"
   },
   "engines": {
-    "node": ">=20"
+    "node": "^20.19.0 || ^22.13.0 || >=24"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## What does this PR do?

Aligns the project-level Node engine declaration and contributor docs with the locked dependency graph enforced by the repo's committed \.npmrc\ (\engine-strict=true\).

The previous \>=20\ claim allowed Node 20.0-20.18, Node 21, and early Node 22 releases, but \
pm ci\ can fail before contributors can build or test because locked dev dependencies require the intersection \^20.19.0 || ^22.13.0 || >=24\.

This updates:

- root \package.json\ engine range
- root package entry in \package-lock.json\
- README badge, quickstart, and contributing copy
- CONTRIBUTING and DOCUMENTATION prerequisites

## Related issue

Refs hackathon CLI improvement bonus.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [x] Build / CI / chore

## Checklist

- [x] PR targets the \main\ branch.
- [x] Commits follow Conventional Commits.
- [ ] \
pm run lint\ and \
pm run format:check\ pass.
- [x] \
pm run typecheck\ passes.
- [ ] \
pm test\ passes and coverage stays at or above the 80% gate.
- [ ] New behavior is covered by unit tests (mock-based; no network or credentials required).
- [x] No secrets, API keys, internal endpoints, or personal data are included.
- [x] User-facing changes are reflected in \README.md\ / \DOCUMENTATION.md\ where relevant.

## Notes for reviewers

Local verification was run on Windows with Node \20.11.0\, which intentionally no longer satisfies the updated engine range. To verify this metadata/docs-only change in the existing local environment, npm scripts were run with engine strict disabled:

- \
pm --engine-strict=false run build\ passed
- \
pm --engine-strict=false run typecheck\ passed
- \
ode node_modules/prettier/bin/prettier.cjs --check package.json package-lock.json README.md CONTRIBUTING.md DOCUMENTATION.md\ passed

I did not mark the full test suite as passing because the current Windows environment previously failed unrelated symlink/path/permission tests. CI uses Node 22 and should be the authoritative full-suite check.