### PR TITLE
fix(skill-nudge): require complete Codex managed section

### DIFF
--- a/src/lib/skill-nudge.test.ts
+++ b/src/lib/skill-nudge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { MANAGED_SECTION_BEGIN, TARGETS } from './agent-targets.js';
+import { MANAGED_SECTION_BEGIN, MANAGED_SECTION_END, TARGETS } from './agent-targets.js';
 import type { OutputMode } from './output.js';
 import {
   SKILL_NUDGE_COMMANDS,
@@ -36,8 +36,15 @@ describe('isVerifySkillInstalled', () => {
 
   it('true when AGENTS.md exists AND carries our BEGIN sentinel', () => {
     const existsSync = (p: string) => p.endsWith('AGENTS.md');
-    const readFileSync = () => `# project\n${MANAGED_SECTION_BEGIN}\n...skill...\n`;
+    const readFileSync = () =>
+      `# project\n${MANAGED_SECTION_BEGIN}\n...skill...\n${MANAGED_SECTION_END}\n`;
     expect(isVerifySkillInstalled('/proj', { existsSync, readFileSync })).toBe(true);
+  });
+
+  it('false when AGENTS.md has only the BEGIN sentinel without a complete managed section', () => {
+    const existsSync = (p: string) => p.endsWith('AGENTS.md');
+    const readFileSync = () => `# project\n${MANAGED_SECTION_BEGIN}\n...partial skill...\n`;
+    expect(isVerifySkillInstalled('/proj', { existsSync, readFileSync })).toBe(false);
   });
 
   it('false when only a bare AGENTS.md (no sentinel) exists', () => {

--- a/src/lib/skill-nudge.ts
+++ b/src/lib/skill-nudge.ts
@@ -70,6 +70,7 @@ export function isVerifySkillInstalled(dir: string, deps: SkillPresenceDeps = {}
   return false;
 }
 
+/** True when a managed-section file contains an ordered TestSprite BEGIN/END pair. */
 function hasCompleteManagedSection(content: string): boolean {
   const begin = content.indexOf(MANAGED_SECTION_BEGIN);
   if (begin === -1) return false;
@@ -140,6 +141,7 @@ export function maybeEmitSkillNudge(ctx: SkillNudgeContext): void {
   }
 }
 
+/** Interpret common env-var spellings for an enabled opt-out flag. */
 function isTruthyEnv(v: string | undefined): boolean {
   if (v === undefined) return false;
   const s = v.trim().toLowerCase();

--- a/src/lib/skill-nudge.ts
+++ b/src/lib/skill-nudge.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { MANAGED_SECTION_BEGIN, TARGETS } from './agent-targets.js';
+import { MANAGED_SECTION_BEGIN, MANAGED_SECTION_END, TARGETS } from './agent-targets.js';
 import { defaultCredentialsPath, readProfile } from './credentials.js';
 import type { OutputMode } from './output.js';
 
@@ -44,8 +44,8 @@ export interface SkillPresenceDeps {
  * True if the `testsprite-verify` skill is installed for ANY supported agent in
  * `dir`. own-file targets (claude/cursor/cline/antigravity): the landing file
  * exists. managed-section target (codex / AGENTS.md): the file exists AND
- * carries our BEGIN sentinel — a user-authored AGENTS.md without the sentinel
- * does NOT count as our skill.
+ * carries one complete managed section — a user-authored AGENTS.md without the
+ * sentinels, or with a truncated section, does NOT count as our skill.
  *
  * The TARGETS table is the single source of truth for landing paths, so this
  * stays in lockstep with `agent install` without re-listing paths. Best-effort:
@@ -59,7 +59,7 @@ export function isVerifySkillInstalled(dir: string, deps: SkillPresenceDeps = {}
     if (!exists(full)) continue;
     if (spec.mode === 'managed-section') {
       try {
-        if (read(full).includes(MANAGED_SECTION_BEGIN)) return true;
+        if (hasCompleteManagedSection(read(full))) return true;
       } catch {
         // unreadable AGENTS.md → treat this target as absent, keep checking
       }
@@ -68,6 +68,13 @@ export function isVerifySkillInstalled(dir: string, deps: SkillPresenceDeps = {}
     return true; // own-file landing file present
   }
   return false;
+}
+
+function hasCompleteManagedSection(content: string): boolean {
+  const begin = content.indexOf(MANAGED_SECTION_BEGIN);
+  if (begin === -1) return false;
+  const end = content.indexOf(MANAGED_SECTION_END, begin + MANAGED_SECTION_BEGIN.length);
+  return end !== -1;
 }
 
 export interface SkillNudgeContext {


### PR DESCRIPTION
## Summary

Fixes a false-positive TestSprite verification-skill detection case for Codex.

`isVerifySkillInstalled()` previously returned `true` for `AGENTS.md` as soon as it found `<!-- BEGIN TESTSPRITE AGENT SECTION -->`. If the file was truncated or half-written and the END marker was missing, the CLI suppressed the missing-skill warning even though Codex did not have a complete managed TestSprite section.

This change requires a complete managed section: BEGIN marker plus a later END marker.

## Why

A partial Codex managed block can happen after an interrupted write, merge conflict, manual edit, or failed install. Treating that as installed makes the verify-loop warning disappear at the exact moment the agent needs repair guidance.

## Tests

RED first:

```text
npm test -- src/lib/skill-nudge.test.ts
```

Failed before the fix with:

```text
expected true to be false
```

GREEN:

```text
npm test -- src/lib/skill-nudge.test.ts
npm run typecheck
npm run lint
npm run format:check
npm run test:e2e -- test/e2e/skill-nudge.e2e.test.ts
npm test
```

Additional submission prep:

```text
@testsprite/testsprite-mcp@0.0.38 tools/list
@testsprite/testsprite-mcp@0.0.38 testsprite_check_account_info
@testsprite/testsprite-mcp@0.0.38 testsprite_generate_standardized_prd
```

Manual CLI check:

Built CLI against a temp configured profile and truncated `AGENTS.md` emitted:

```text
[warn] No TestSprite verification skill is installed in this project ...
```

The command then exited nonzero only because the test endpoint was intentionally dead.

## Scope

- No new dependencies.
- No command surface changes.
- No output changes except fixing the false-negative warning suppression for incomplete Codex managed sections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill detection so a managed section is only recognized when it includes both required markers.
  * Fixed cases where an incomplete managed section could be treated as installed.
  * Expanded test coverage for complete and incomplete managed-section content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->