### PR TITLE
feat(lib): add duration parser and formatter utility

### DIFF
--- a/src/lib/duration.test.ts
+++ b/src/lib/duration.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+import { formatDuration, parseDuration, requireDuration } from './duration.js';
+import { ApiError } from './errors.js';
+
+describe('parseDuration', () => {
+  describe('valid inputs', () => {
+    it('parses hours', () => {
+      expect(parseDuration('4h')).toBe(4 * 3_600_000);
+    });
+
+    it('parses minutes', () => {
+      expect(parseDuration('30m')).toBe(30 * 60_000);
+    });
+
+    it('parses seconds', () => {
+      expect(parseDuration('45s')).toBe(45 * 1_000);
+    });
+
+    it('parses compound h+m', () => {
+      expect(parseDuration('1h30m')).toBe(1 * 3_600_000 + 30 * 60_000);
+    });
+
+    it('parses compound h+m+s', () => {
+      expect(parseDuration('2h15m30s')).toBe(2 * 3_600_000 + 15 * 60_000 + 30 * 1_000);
+    });
+
+    it('parses compound m+s', () => {
+      expect(parseDuration('5m30s')).toBe(5 * 60_000 + 30 * 1_000);
+    });
+
+    it('parses fractional hours', () => {
+      expect(parseDuration('1.5h')).toBe(5_400_000);
+    });
+
+    it('parses fractional minutes', () => {
+      expect(parseDuration('2.5m')).toBe(150_000);
+    });
+
+    it('parses fractional seconds', () => {
+      expect(parseDuration('1.5s')).toBe(1_500);
+    });
+
+    it('is case-insensitive', () => {
+      expect(parseDuration('4H')).toBe(4 * 3_600_000);
+      expect(parseDuration('30M')).toBe(30 * 60_000);
+      expect(parseDuration('45S')).toBe(45 * 1_000);
+      expect(parseDuration('1H30M')).toBe(1 * 3_600_000 + 30 * 60_000);
+    });
+
+    it('trims whitespace', () => {
+      expect(parseDuration('  4h  ')).toBe(4 * 3_600_000);
+    });
+
+    it('parses 1s (minimum practical duration)', () => {
+      expect(parseDuration('1s')).toBe(1_000);
+    });
+
+    it('parses 24h (maximum allowed)', () => {
+      expect(parseDuration('24h')).toBe(24 * 3_600_000);
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('rejects empty string', () => {
+      expect(() => parseDuration('')).toThrow(ApiError);
+    });
+
+    it('rejects whitespace-only string', () => {
+      expect(() => parseDuration('   ')).toThrow(ApiError);
+    });
+
+    it('rejects bare number without unit', () => {
+      expect(() => parseDuration('120')).toThrow(ApiError);
+    });
+
+    it('rejects unit without number', () => {
+      expect(() => parseDuration('h')).toThrow(ApiError);
+    });
+
+    it('rejects unsupported units', () => {
+      expect(() => parseDuration('4d')).toThrow(ApiError);
+      expect(() => parseDuration('2w')).toThrow(ApiError);
+    });
+
+    it('rejects spaces between segments', () => {
+      expect(() => parseDuration('1h 30m')).toThrow(ApiError);
+    });
+
+    it('rejects duplicate units', () => {
+      expect(() => parseDuration('1h2h')).toThrow(ApiError);
+      expect(() => parseDuration('1m2m')).toThrow(ApiError);
+      expect(() => parseDuration('1s2s')).toThrow(ApiError);
+    });
+
+    it('rejects zero duration', () => {
+      expect(() => parseDuration('0h')).toThrow(ApiError);
+      expect(() => parseDuration('0m')).toThrow(ApiError);
+      expect(() => parseDuration('0s')).toThrow(ApiError);
+      expect(() => parseDuration('0h0m0s')).toThrow(ApiError);
+    });
+
+    it('rejects duration exceeding 24 hours', () => {
+      expect(() => parseDuration('25h')).toThrow(ApiError);
+      expect(() => parseDuration('24h1s')).toThrow(ApiError);
+      expect(() => parseDuration('1500m')).toThrow(ApiError);
+    });
+
+    it('rejects non-string-like inputs via the grammar', () => {
+      expect(() => parseDuration('abc')).toThrow(ApiError);
+      expect(() => parseDuration('--4h')).toThrow(ApiError);
+      expect(() => parseDuration('4h-')).toThrow(ApiError);
+    });
+  });
+
+  describe('error messages', () => {
+    it('includes the field name in the error', () => {
+      try {
+        parseDuration('', 'maxDuration');
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        const apiErr = err as ApiError;
+        expect(apiErr.code).toBe('VALIDATION_ERROR');
+        expect(apiErr.exitCode).toBe(5);
+        expect(apiErr.nextAction).toContain('--max-duration');
+      }
+    });
+
+    it('uses the default field name when not specified', () => {
+      try {
+        parseDuration('');
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        const apiErr = err as ApiError;
+        expect(apiErr.nextAction).toContain('--duration');
+      }
+    });
+
+    it('includes the formatted excess duration in the message', () => {
+      try {
+        parseDuration('25h');
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        const apiErr = err as ApiError;
+        expect(apiErr.nextAction).toContain('24 hours');
+      }
+    });
+
+    it('mentions duplicate unit in the message', () => {
+      try {
+        parseDuration('1h2h');
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        const apiErr = err as ApiError;
+        expect(apiErr.nextAction).toContain('duplicate');
+        expect(apiErr.nextAction).toContain('"h"');
+      }
+    });
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats hours only', () => {
+    expect(formatDuration(3_600_000)).toBe('1h');
+    expect(formatDuration(7_200_000)).toBe('2h');
+  });
+
+  it('formats minutes only', () => {
+    expect(formatDuration(60_000)).toBe('1m');
+    expect(formatDuration(1_800_000)).toBe('30m');
+  });
+
+  it('formats seconds only', () => {
+    expect(formatDuration(1_000)).toBe('1s');
+    expect(formatDuration(45_000)).toBe('45s');
+  });
+
+  it('formats hours + minutes', () => {
+    expect(formatDuration(5_400_000)).toBe('1h 30m');
+  });
+
+  it('formats hours + minutes + seconds', () => {
+    expect(formatDuration(8_130_000)).toBe('2h 15m 30s');
+  });
+
+  it('formats minutes + seconds', () => {
+    expect(formatDuration(90_000)).toBe('1m 30s');
+  });
+
+  it('formats sub-second as "<1s"', () => {
+    expect(formatDuration(500)).toBe('<1s');
+    expect(formatDuration(1)).toBe('<1s');
+    expect(formatDuration(999)).toBe('<1s');
+  });
+
+  it('formats zero as "0s"', () => {
+    expect(formatDuration(0)).toBe('0s');
+  });
+
+  it('formats negative as "0s"', () => {
+    expect(formatDuration(-1000)).toBe('0s');
+  });
+
+  it('truncates fractional seconds (floor)', () => {
+    // 1500ms = 1s + 500ms remainder → "1s" (floor to whole seconds)
+    expect(formatDuration(1_500)).toBe('1s');
+  });
+
+  it('formats large durations', () => {
+    expect(formatDuration(24 * 3_600_000)).toBe('24h');
+    expect(formatDuration(23 * 3_600_000 + 59 * 60_000 + 59 * 1_000)).toBe('23h 59m 59s');
+  });
+});
+
+describe('requireDuration', () => {
+  it('returns milliseconds for valid input', () => {
+    expect(requireDuration('4h')).toBe(4 * 3_600_000);
+  });
+
+  it('rejects below minimum', () => {
+    expect(() => requireDuration('30s', 'maxDuration', { min: 60_000 })).toThrow(ApiError);
+    try {
+      requireDuration('30s', 'maxDuration', { min: 60_000 });
+      expect.fail('should have thrown');
+    } catch (err) {
+      const apiErr = err as ApiError;
+      expect(apiErr.nextAction).toContain('at least');
+      expect(apiErr.nextAction).toContain('1m');
+    }
+  });
+
+  it('rejects above maximum', () => {
+    expect(() => requireDuration('5h', 'maxDuration', { max: 4 * 3_600_000 })).toThrow(ApiError);
+    try {
+      requireDuration('5h', 'maxDuration', { max: 4 * 3_600_000 });
+      expect.fail('should have thrown');
+    } catch (err) {
+      const apiErr = err as ApiError;
+      expect(apiErr.nextAction).toContain('must not exceed');
+      expect(apiErr.nextAction).toContain('4h');
+    }
+  });
+
+  it('accepts value at minimum boundary', () => {
+    expect(requireDuration('1m', 'timeout', { min: 60_000 })).toBe(60_000);
+  });
+
+  it('accepts value at maximum boundary', () => {
+    expect(requireDuration('4h', 'timeout', { max: 4 * 3_600_000 })).toBe(4 * 3_600_000);
+  });
+
+  it('accepts value within both bounds', () => {
+    expect(requireDuration('2h', 'timeout', { min: 60_000, max: 4 * 3_600_000 })).toBe(7_200_000);
+  });
+
+  it('propagates parse errors', () => {
+    expect(() => requireDuration('abc')).toThrow(ApiError);
+  });
+});

--- a/src/lib/duration.ts
+++ b/src/lib/duration.ts
@@ -178,8 +178,9 @@ export function formatDuration(ms: number): string {
  * @param input  Raw duration string.
  * @param field  Flag/field name for error messages.
  * @param opts.min  Minimum duration in milliseconds (inclusive).
- * @param opts.max  Maximum duration in milliseconds (inclusive).
- *                  Defaults to 24 hours.
+ * @param opts.max  Maximum duration in milliseconds (inclusive), capped at
+ *                  and never able to exceed the 24-hour ceiling enforced by
+ *                  `parseDuration`. Defaults to 24 hours when omitted.
  */
 export function requireDuration(
   input: string,

--- a/src/lib/duration.ts
+++ b/src/lib/duration.ts
@@ -1,0 +1,211 @@
+/**
+ * Human-readable duration parser and formatter.
+ *
+ * Parses strings like `"4h"`, `"30m"`, `"45s"`, `"1h30m"`, `"2h15m30s"`
+ * into milliseconds, and formats milliseconds back into concise
+ * human-readable text.
+ *
+ * Design notes:
+ *   - Only hours (`h`), minutes (`m`), and seconds (`s`) are supported.
+ *     Days and larger units are intentionally omitted — they introduce
+ *     DST and calendar ambiguity that a CLI should not silently absorb.
+ *   - Bare numbers without a unit are rejected. This avoids the
+ *     "is 120 seconds or minutes?" ambiguity that plagues many CLIs.
+ *   - The parser is case-insensitive (`4H30M` works).
+ *   - Fractional values (e.g. `1.5h`) are supported within each segment.
+ *   - Negative durations and zero are rejected; a duration represents a
+ *     strictly positive time span.
+ *   - Maximum duration is capped at 24 hours to prevent accidental
+ *     multi-day sessions.
+ *   - Integrates with the existing `localValidationError` helper so
+ *     error wording and exit codes stay consistent with the rest of
+ *     the CLI (exit 5, VALIDATION_ERROR).
+ *
+ * @example
+ *   parseDuration('4h');        // 14_400_000
+ *   parseDuration('30m');       //  1_800_000
+ *   parseDuration('1h30m');     //  5_400_000
+ *   parseDuration('2h15m30s'); //  8_130_000
+ *   formatDuration(5_400_000); // '1h 30m'
+ */
+
+import { localValidationError } from './errors.js';
+
+/** 24 hours in milliseconds — hard ceiling for parsed durations. */
+const MAX_DURATION_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Matches one or more `<number><unit>` segments. Each segment is a
+ * (possibly fractional) number followed by one of `h`, `m`, `s`.
+ *
+ * The regex validates that the ENTIRE string is composed exclusively
+ * of `<number><unit>` segments with no stray characters.
+ *
+ * Examples that match: `4h`, `30m`, `1h30m`, `2h15m30s`, `1.5h`
+ * Examples that don't: `4`, `h30`, `4h 30m` (space), `4x`, ``
+ */
+const DURATION_RE = /^(?:\d+(?:\.\d+)?[hms])+$/i;
+
+/**
+ * Captures individual `<number><unit>` segments for iteration.
+ * Used with `matchAll` after the full-string regex has validated shape.
+ */
+const SEGMENT_RE = /(\d+(?:\.\d+)?)([hms])/gi;
+
+/** Unit multipliers to convert each segment to milliseconds. */
+const UNIT_MS: Record<string, number> = {
+  h: 3_600_000,
+  m: 60_000,
+  s: 1_000,
+};
+
+/**
+ * Parse a human-readable duration string into milliseconds.
+ *
+ * Accepted formats:
+ *   - `"4h"` — 4 hours
+ *   - `"30m"` — 30 minutes
+ *   - `"45s"` — 45 seconds
+ *   - `"1h30m"` — 1 hour 30 minutes
+ *   - `"2h15m30s"` — 2 hours 15 minutes 30 seconds
+ *   - `"1.5h"` — 1 hour 30 minutes (fractional)
+ *
+ * @param input  The raw duration string.
+ * @param field  Field name for error messages (default: `'duration'`).
+ *               Passed as a CLI flag name to `localValidationError`.
+ * @returns Duration in milliseconds (always a positive integer).
+ *
+ * @throws {ApiError} VALIDATION_ERROR (exit 5) when the input is
+ *   empty, malformed, zero, negative (impossible given the grammar),
+ *   or exceeds the 24-hour ceiling.
+ */
+export function parseDuration(input: string, field = 'duration'): number {
+  const trimmed = input.trim();
+
+  if (trimmed === '') {
+    throw localValidationError(
+      field,
+      'must be a duration string (e.g. "4h", "30m", "1h30m")',
+      undefined,
+      'flag',
+    );
+  }
+
+  if (!DURATION_RE.test(trimmed)) {
+    throw localValidationError(
+      field,
+      'must be a duration string using h (hours), m (minutes), s (seconds) — e.g. "4h", "30m", "1h30m", "2h15m30s"',
+      undefined,
+      'flag',
+    );
+  }
+
+  // Track which units have been seen to reject duplicates like `1h2h`.
+  const seen = new Set<string>();
+  let totalMs = 0;
+
+  for (const match of trimmed.matchAll(SEGMENT_RE)) {
+    const value = parseFloat(match[1]!);
+    const unit = match[2]!.toLowerCase();
+
+    if (seen.has(unit)) {
+      throw localValidationError(
+        field,
+        `contains duplicate unit "${unit}" — each unit (h, m, s) may appear at most once`,
+        undefined,
+        'flag',
+      );
+    }
+    seen.add(unit);
+
+    totalMs += value * UNIT_MS[unit]!;
+  }
+
+  // Round to the nearest integer millisecond to avoid floating-point drift
+  // from fractional segments like `1.5h`.
+  totalMs = Math.round(totalMs);
+
+  if (totalMs <= 0) {
+    throw localValidationError(field, 'must be a positive duration', undefined, 'flag');
+  }
+
+  if (totalMs > MAX_DURATION_MS) {
+    throw localValidationError(
+      field,
+      `must not exceed 24 hours (got ${formatDuration(totalMs)})`,
+      undefined,
+      'flag',
+    );
+  }
+
+  return totalMs;
+}
+
+/**
+ * Format a duration in milliseconds to a concise human-readable string.
+ *
+ * Output uses the largest applicable units with no leading zeros:
+ *   - `formatDuration(5_400_000)` → `"1h 30m"`
+ *   - `formatDuration(90_000)` → `"1m 30s"`
+ *   - `formatDuration(3_600_000)` → `"1h"`
+ *   - `formatDuration(1_000)` → `"1s"`
+ *   - `formatDuration(500)` → `"<1s"`
+ *
+ * @param ms Non-negative duration in milliseconds.
+ * @returns Human-readable duration string.
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 0) return '0s';
+  if (ms < 1000) return ms > 0 ? '<1s' : '0s';
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const parts: string[] = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0) parts.push(`${seconds}s`);
+
+  return parts.join(' ') || '0s';
+}
+
+/**
+ * Convenience: validate that a raw string is a valid duration within
+ * the given bounds. Returns the parsed milliseconds.
+ *
+ * @param input  Raw duration string.
+ * @param field  Flag/field name for error messages.
+ * @param opts.min  Minimum duration in milliseconds (inclusive).
+ * @param opts.max  Maximum duration in milliseconds (inclusive).
+ *                  Defaults to 24 hours.
+ */
+export function requireDuration(
+  input: string,
+  field = 'duration',
+  opts: { min?: number; max?: number } = {},
+): number {
+  const ms = parseDuration(input, field);
+  const { min, max } = opts;
+
+  if (min !== undefined && ms < min) {
+    throw localValidationError(
+      field,
+      `must be at least ${formatDuration(min)} (got ${formatDuration(ms)})`,
+      undefined,
+      'flag',
+    );
+  }
+
+  if (max !== undefined && ms > max) {
+    throw localValidationError(
+      field,
+      `must not exceed ${formatDuration(max)} (got ${formatDuration(ms)})`,
+      undefined,
+      'flag',
+    );
+  }
+
+  return ms;
+}


### PR DESCRIPTION
## Summary

Add `parseDuration()`, `formatDuration()`, and `requireDuration()` to `src/lib/duration.ts` — a human-readable duration string parser and formatter utility.

### Motivation

The CLI currently has no way to parse duration strings like `4h`, `30m`, or `1h30m`. This utility is needed for any time-bounded CLI option (e.g. `--max-duration`, `--timeout`, `--announce-every`, `--checkpoint-every`) and lays the groundwork for future features that accept duration inputs.

### What's included

| Function | Purpose |
|----------|---------|
| `parseDuration(input, field?)` | Parse `"4h"`, `"30m"`, `"1h30m"`, `"2h15m30s"` into milliseconds |
| `formatDuration(ms)` | Format milliseconds into `"1h 30m"`, `"45s"`, `"<1s"` |
| `requireDuration(input, field?, opts?)` | Parse and validate min/max bounds |

### Design decisions

- **Zero new production dependencies** — pure TypeScript, no external libs
- Integrates with existing `localValidationError` for consistent error envelopes (`VALIDATION_ERROR`, exit 5)
- Case-insensitive (`4H30M` works)
- Supports fractional values (`1.5h` = 90 minutes)
- Rejects: bare numbers without units, duplicate units (`1h2h`), zero, exceeds 24h ceiling
- Follows existing code style (JSDoc, assertion helpers, structural validation)

### Test coverage

**45 tests** across 3 describe blocks covering:
- Valid inputs: all accepted formats, compound segments, fractional, case-insensitive
- Invalid inputs: empty, bare numbers, bad units, duplicates, overflow, zero
- Error messages: field name inclusion, formatting, duplicate detection
- Formatting: hours/minutes/seconds, compound, sub-second, zero, negative
- Bounded validation: min/max constraints, boundary values

### Checklist

- [x] PR targets `main`
- [x] Commit uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `npm run lint` passes
- [x] `npm run format:check` passes (new files only — existing CRLF issues are pre-existing)
- [x] `npm run typecheck` passes
- [x] `npm test` passes (45/45 duration tests pass)
- [x] New behavior has tests (mock-based, deterministic, no real timers)
- [x] No secrets, API keys, or internal endpoints
- [x] Zero new production dependencies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for parsing, formatting, and validating duration values using hours, minutes, and seconds.
  * Inputs now accept mixed units, fractional values, and flexible spacing/casing, with consistent handling of invalid formats, duplicate units, and out-of-range durations.
* **Tests**
  * Added comprehensive automated coverage for duration parsing, formatting, and validation, including edge cases and error messaging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->