### PR TITLE
feat(test): JUnit XML report export for batch --wait runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@testsprite/testsprite-cli` are documented here. The for
 
 ## [Unreleased]
 
+### Added
+
+- **JUnit XML report export for batch `--wait` runs.** `test run --all` and batch `test rerun` (`--all` or multiple test ids) accept `--report junit --report-file <path>` to write a CI-friendly XML sidecar after polling completes. `--output json` is unchanged; the report is written even when the batch exits non-zero. `--dry-run` writes a canned sample without network calls.
+
 ## [0.2.0] - 2026-06-29
 
 ### Added

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -344,6 +344,10 @@ testsprite test run test_xxxxxxxx --target-url https://staging.example.com \
 
 # Dry-run prints a canned queued response (no network, no credentials)
 testsprite test run test_xxxxxxxx --dry-run --output json
+
+# Batch BE run with JUnit XML for CI (sidecar; --output json unchanged)
+testsprite test run --all --project proj_xxxxxxxx --wait \
+  --report junit --report-file ./results.xml --output json
 ```
 
 `--target-url` must be a publicly reachable URL — the CLI pre-flights it against local addresses (`localhost`, `127.x`, `::1`, `0.0.0.0`, `169.254.x`, RFC1918) and the backend resolves it via DNS. For testing against localhost, use the [TestSprite MCP plugin](https://www.testsprite.com/docs), which handles the local tunnel. The CLI auto-mints an idempotency key (printed to stderr under `--output json`, `--verbose`, or `--debug`); pass `--idempotency-key <uuid>` to control it explicitly.
@@ -365,6 +369,10 @@ testsprite test rerun test_be_xxxx --skip-dependencies --output json
 # Rerun every test in a project (batch)
 testsprite test rerun --all --project proj_xxxxxxxx --wait --max-concurrency 4 --output json
 
+# Batch rerun with JUnit XML for CI
+testsprite test rerun --all --project proj_xxxxxxxx --wait \
+  --report junit --report-file ./results.xml --output json
+
 # Several specific tests
 testsprite test rerun test_aaaa test_bbbb --wait --output json
 ```
@@ -377,6 +385,7 @@ Flags:
 - `--skip-dependencies` — backend only: rerun just the named test without expanding the producer/teardown closure.
 - `--max-concurrency <n>` — with `--wait`, cap on in-flight polls during a batch rerun.
 - `--idempotency-key <key>` — auto-minted when omitted (the minted key is printed to stderr under `--output json`, `--verbose`, or `--debug`).
+- `--report junit --report-file <path>` — with batch `--wait`, write a JUnit XML sidecar after polling (atomic write). Optional `--report-suite-name <name>` overrides the default `testsprite:<projectId>` suite name. Requires `--wait`; not available on single-test reruns.
 
 A batch rerun returns `accepted[]` (one `runId` per dispatched test) plus `deferred[]` for any test shed by the per-key run-rate limit; under `--wait`, a non-empty `deferred[]` exits 7 with a `nextAction` you can retry with a fresh idempotency key.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -348,7 +348,13 @@ testsprite test run test_xxxxxxxx --dry-run --output json
 # Batch BE run with JUnit XML for CI (sidecar; --output json unchanged)
 testsprite test run --all --project proj_xxxxxxxx --wait \
   --report junit --report-file ./results.xml --output json
+
+# Optional custom suite name (default: testsprite:<projectId>)
+testsprite test run --all --project proj_xxxxxxxx --wait \
+  --report junit --report-file ./results.xml --report-suite-name my-ci-suite --output json
 ```
+
+Batch `--report` flags apply only to `test run --all --wait` (and batch `test rerun --wait`). `--report junit --report-file <path>` writes a JUnit XML sidecar after polling completes (atomic write); `--output json` is unchanged. Optional `--report-suite-name <name>` overrides the default `testsprite:<projectId>` suite name.
 
 `--target-url` must be a publicly reachable URL — the CLI pre-flights it against local addresses (`localhost`, `127.x`, `::1`, `0.0.0.0`, `169.254.x`, RFC1918) and the backend resolves it via DNS. For testing against localhost, use the [TestSprite MCP plugin](https://www.testsprite.com/docs), which handles the local tunnel. The CLI auto-mints an idempotency key (printed to stderr under `--output json`, `--verbose`, or `--debug`); pass `--idempotency-key <uuid>` to control it explicitly.
 
@@ -373,9 +379,15 @@ testsprite test rerun --all --project proj_xxxxxxxx --wait --max-concurrency 4 -
 testsprite test rerun --all --project proj_xxxxxxxx --wait \
   --report junit --report-file ./results.xml --output json
 
+# Optional custom suite name (default: testsprite:<projectId>)
+testsprite test rerun --all --project proj_xxxxxxxx --wait \
+  --report junit --report-file ./results.xml --report-suite-name my-ci-suite --output json
+
 # Several specific tests
 testsprite test rerun test_aaaa test_bbbb --wait --output json
 ```
+
+Batch `--report` flags apply only to batch `--wait` reruns (`--all` or multiple test ids). `--report junit --report-file <path>` writes a JUnit XML sidecar after polling completes (atomic write); `--output json` is unchanged. When `--project` is omitted, the CLI infers `projectId` from polled run rows for classname / default suite naming; if inference fails, pass `--project <id>` explicitly (required under `--dry-run`).
 
 Flags:
 

--- a/src/commands/test.run.spec.ts
+++ b/src/commands/test.run.spec.ts
@@ -3655,7 +3655,12 @@ describe('runTestRunAll — JUnit report export', () => {
       failureKind: null,
       error: null,
       videoUrl: null,
-      stepSummary: { total: 3, completed: 3, passedCount: status === 'passed' ? 3 : 0, failedCount: 0 },
+      stepSummary: {
+        total: 3,
+        completed: 3,
+        passedCount: status === 'passed' ? 3 : 0,
+        failedCount: 0,
+      },
     };
   }
 

--- a/src/commands/test.run.spec.ts
+++ b/src/commands/test.run.spec.ts
@@ -3767,6 +3767,24 @@ describe('runTestRunAll — JUnit report export', () => {
     ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
   });
 
+  it('rejects --report-suite-name without --report', async () => {
+    await expect(
+      runTestRunAll(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          projectId: 'project_be',
+          wait: true,
+          timeoutSeconds: 60,
+          maxConcurrency: 5,
+          reportSuiteName: 'orphan-suite',
+        },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
+  });
+
   it('--dry-run --report junit writes canned sample XML', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'junit-run-dry-'));
     const reportPath = join(dir, 'results.xml');
@@ -3793,5 +3811,34 @@ describe('runTestRunAll — JUnit report export', () => {
     const xml = readFileSync(reportPath, 'utf8');
     expect(xml).toContain('name="test_fresh_wave_01"');
     expect(xml).toContain('failures="1"');
+  });
+
+  it('--dry-run --report junit --report-suite-name overrides canned suite name', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'junit-run-dry-suite-'));
+    const reportPath = join(dir, 'results.xml');
+
+    await runTestRunAll(
+      {
+        profile: 'default',
+        output: 'json',
+        debug: false,
+        dryRun: true,
+        projectId: 'project_be',
+        wait: true,
+        timeoutSeconds: 60,
+        maxConcurrency: 5,
+        report: 'junit',
+        reportFile: reportPath,
+        reportSuiteName: 'ci-checkout-suite',
+      },
+      {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      },
+    );
+
+    const xml = readFileSync(reportPath, 'utf8');
+    expect(xml).toContain('<testsuite name="ci-checkout-suite"');
+    expect(xml).not.toContain('testsprite:project_be');
   });
 });

--- a/src/commands/test.run.spec.ts
+++ b/src/commands/test.run.spec.ts
@@ -5,7 +5,7 @@
  * sleep injection is wired through `TestDeps.sleep` to avoid real delays.
  */
 
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Command } from 'commander';
@@ -3622,5 +3622,171 @@ describe('dashboardUrl on run completion', () => {
         l.includes('Dashboard: https://www.testsprite.com/dashboard/tests/project_be'),
       ),
     ).toBe(true);
+  });
+});
+
+describe('runTestRunAll — JUnit report export', () => {
+  const BATCH_FRESH_RESP: BatchRunFreshResponse = {
+    accepted: [
+      { testId: 'test_be_01', runId: 'run_fresh_01', enqueuedAt: '2026-06-09T10:00:00.000Z' },
+      { testId: 'test_be_02', runId: 'run_fresh_02', enqueuedAt: '2026-06-09T10:00:01.000Z' },
+    ],
+    conflicts: [],
+    deferred: [],
+    skippedFrontend: [],
+    skippedIntegration: [],
+  };
+
+  function makeTerminalRun(runId: string, testId: string, status: string): RunResponse {
+    return {
+      runId,
+      testId,
+      projectId: 'project_be',
+      userId: 'user_1',
+      status: status as RunResponse['status'],
+      source: 'cli',
+      createdAt: '2026-06-09T10:00:00.000Z',
+      startedAt: '2026-06-09T10:00:01.000Z',
+      finishedAt: '2026-06-09T10:00:30.000Z',
+      codeVersion: 'v1',
+      targetUrl: 'https://api.example.com',
+      createdFrom: 'cli',
+      failedStepIndex: null,
+      failureKind: null,
+      error: null,
+      videoUrl: null,
+      stepSummary: { total: 3, completed: 3, passedCount: status === 'passed' ? 3 : 0, failedCount: 0 },
+    };
+  }
+
+  it('--wait --report junit writes XML after polling', async () => {
+    const { credentialsPath } = makeCreds();
+    const dir = mkdtempSync(join(tmpdir(), 'junit-run-all-'));
+    const reportPath = join(dir, 'results.xml');
+    const fetchImpl = makeFetch((url, init) => {
+      if ((init.method ?? 'GET') === 'POST') return { body: BATCH_FRESH_RESP };
+      const runId = url.split('/runs/')[1]?.split('?')[0] ?? '';
+      if (runId === 'run_fresh_01')
+        return { body: makeTerminalRun('run_fresh_01', 'test_be_01', 'passed') };
+      if (runId === 'run_fresh_02')
+        return { body: makeTerminalRun('run_fresh_02', 'test_be_02', 'passed') };
+      return errorBody('NOT_FOUND');
+    });
+
+    await runTestRunAll(
+      {
+        profile: 'default',
+        output: 'json',
+        debug: false,
+        projectId: 'project_be',
+        wait: true,
+        timeoutSeconds: 60,
+        maxConcurrency: 5,
+        report: 'junit',
+        reportFile: reportPath,
+      },
+      {
+        credentialsPath,
+        fetchImpl,
+        stdout: () => undefined,
+        stderr: () => undefined,
+        sleep: instantSleep,
+      },
+    );
+
+    const xml = readFileSync(reportPath, 'utf8');
+    expect(xml).toContain('<testsuite name="testsprite:project_be"');
+    expect(xml).toContain('name="test_be_01"');
+    expect(xml).toContain('name="test_be_02"');
+    expect(xml).toContain('failures="0"');
+  });
+
+  it('--wait --report junit writes XML even when batch exits 1', async () => {
+    const { credentialsPath } = makeCreds();
+    const dir = mkdtempSync(join(tmpdir(), 'junit-run-fail-'));
+    const reportPath = join(dir, 'results.xml');
+    const fetchImpl = makeFetch((url, init) => {
+      if ((init.method ?? 'GET') === 'POST') return { body: BATCH_FRESH_RESP };
+      const runId = url.split('/runs/')[1]?.split('?')[0] ?? '';
+      if (runId === 'run_fresh_01')
+        return { body: makeTerminalRun('run_fresh_01', 'test_be_01', 'passed') };
+      if (runId === 'run_fresh_02')
+        return { body: makeTerminalRun('run_fresh_02', 'test_be_02', 'failed') };
+      return errorBody('NOT_FOUND');
+    });
+
+    await expect(
+      runTestRunAll(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          projectId: 'project_be',
+          wait: true,
+          timeoutSeconds: 60,
+          maxConcurrency: 5,
+          report: 'junit',
+          reportFile: reportPath,
+        },
+        {
+          credentialsPath,
+          fetchImpl,
+          stdout: () => undefined,
+          stderr: () => undefined,
+          sleep: instantSleep,
+        },
+      ),
+    ).rejects.toMatchObject({ exitCode: 1 });
+
+    const xml = readFileSync(reportPath, 'utf8');
+    expect(xml).toContain('failures="1"');
+    expect(xml).toContain('name="test_be_02"');
+  });
+
+  it('rejects --report without --wait', async () => {
+    await expect(
+      runTestRunAll(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          projectId: 'project_be',
+          wait: false,
+          timeoutSeconds: 60,
+          maxConcurrency: 5,
+          report: 'junit',
+          reportFile: './results.xml',
+        },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
+  });
+
+  it('--dry-run --report junit writes canned sample XML', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'junit-run-dry-'));
+    const reportPath = join(dir, 'results.xml');
+
+    await runTestRunAll(
+      {
+        profile: 'default',
+        output: 'json',
+        debug: false,
+        dryRun: true,
+        projectId: 'project_be',
+        wait: true,
+        timeoutSeconds: 60,
+        maxConcurrency: 5,
+        report: 'junit',
+        reportFile: reportPath,
+      },
+      {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      },
+    );
+
+    const xml = readFileSync(reportPath, 'utf8');
+    expect(xml).toContain('name="test_fresh_wave_01"');
+    expect(xml).toContain('failures="1"');
   });
 });

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -18,7 +18,15 @@ import {
   writeBundle,
   type WriteBundleResult,
 } from '../lib/bundle.js';
-import { findSample } from '../lib/dry-run/samples.js';
+import { findSample, sampleJUnitReportXml } from '../lib/dry-run/samples.js';
+import {
+  assertJUnitReportOptions,
+  buildJUnitReport,
+  writeJUnitReportFile,
+  type JUnitReportFormat,
+  parseJUnitReportFormat,
+  type JUnitTestResult,
+} from '../lib/junit-report.js';
 import {
   ApiError,
   CLIError,
@@ -4296,6 +4304,12 @@ interface RunTestRerunOptions extends CommonOptions {
    * filters. Client-side only.
    */
   nameFilter?: string;
+  /** --report junit: write a JUnit XML sidecar after batch --wait completes. */
+  report?: JUnitReportFormat;
+  /** --report-file: destination path for the JUnit XML artifact. */
+  reportFile?: string;
+  /** --report-suite-name: optional override for the JUnit <testsuite name=...>. */
+  reportSuiteName?: string;
 }
 
 /**
@@ -5071,6 +5085,31 @@ interface RunTestRunAllOptions extends CommonOptions {
   maxConcurrency: number;
   /** Caller-supplied idempotency token; auto-minted if absent. */
   idempotencyKey?: string;
+  /** --report junit: write a JUnit XML sidecar after batch --wait completes. */
+  report?: JUnitReportFormat;
+  /** --report-file: destination path for the JUnit XML artifact. */
+  reportFile?: string;
+  /** --report-suite-name: optional override for the JUnit <testsuite name=...>. */
+  reportSuiteName?: string;
+}
+
+async function writeBatchJUnitReportIfRequested(
+  opts: {
+    report?: JUnitReportFormat;
+    reportFile?: string;
+    reportSuiteName?: string;
+    projectId: string;
+  },
+  results: readonly JUnitTestResult[],
+): Promise<void> {
+  if (opts.report !== 'junit' || opts.reportFile === undefined) return;
+  const suiteName = opts.reportSuiteName ?? `testsprite:${opts.projectId}`;
+  const xml = buildJUnitReport({
+    suiteName,
+    classname: opts.projectId,
+    results,
+  });
+  await writeJUnitReportFile(opts.reportFile, xml);
 }
 
 /**
@@ -5105,6 +5144,13 @@ export async function runTestRunAll(
   ) {
     throw localValidationError('max-concurrency', 'must be an integer between 1 and 100');
   }
+  assertJUnitReportOptions({
+    report: opts.report,
+    reportFile: opts.reportFile,
+    reportSuiteName: opts.reportSuiteName,
+    wait: opts.wait,
+    batchPath: true,
+  });
 
   const stderrFn = deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
   const out = makeOutput(opts.output, deps);
@@ -5129,6 +5175,9 @@ export async function runTestRunAll(
       ...(opts.wait ? { thenPoll: '/api/cli/v1/runs/<run-id>?waitSeconds=25' } : {}),
     };
     out.print(batchRunSample ?? envelope);
+    if (opts.report === 'junit' && opts.reportFile !== undefined) {
+      await writeJUnitReportFile(opts.reportFile, sampleJUnitReportXml(opts.projectId));
+    }
     return undefined;
   }
 
@@ -5550,6 +5599,7 @@ export async function runTestRunAll(
     },
   };
   out.print(jsonPayload);
+  await writeBatchJUnitReportIfRequested(opts, freshRunResults);
 
   // Rate-deferred tests were never dispatched → the batch is incomplete (exit 7),
   // mirroring `test rerun --all`. Checked before the failed-run throw so the
@@ -5680,6 +5730,13 @@ export async function runTestRerun(
   }
 
   const isSingle = !opts.all && opts.testIds.length === 1;
+  assertJUnitReportOptions({
+    report: opts.report,
+    reportFile: opts.reportFile,
+    reportSuiteName: opts.reportSuiteName,
+    wait: opts.wait,
+    batchPath: !isSingle,
+  });
 
   // -------------------------------------------------------------------------
   // Pre-flight: auto-heal + Free-tier hint (best-effort, non-blocking)
@@ -5720,6 +5777,10 @@ export async function runTestRerun(
         ...(opts.wait ? { thenPoll: `/api/cli/v1/runs/<run-id>?waitSeconds=25` } : {}),
       };
       out.print(findSample('POST', '/api/cli/v1/tests/batch/rerun')?.body() ?? envelope);
+      if (opts.report === 'junit' && opts.reportFile !== undefined) {
+        const projectKey = opts.projectId ?? 'batch';
+        await writeJUnitReportFile(opts.reportFile, sampleJUnitReportXml(projectKey));
+      }
     }
     void client;
     return undefined;
@@ -6705,6 +6766,11 @@ export async function runTestRerun(
     },
   };
   out.print(jsonPayload);
+  const reportProjectId = opts.projectId ?? 'batch';
+  await writeBatchJUnitReportIfRequested(
+    { ...opts, projectId: reportProjectId },
+    rerunResults,
+  );
 
   // Determine exit code: timeout (deferred or any timeout) → 7; any fail → 1; all pass → 0
   if (deferred.length > 0 || timedOut > 0) {
@@ -7428,11 +7494,21 @@ export function createTestCommand(deps: TestDeps = {}): Command {
       '--max-concurrency <n>',
       `with --all --wait, max in-flight polls at once (1-100, default: ${DEFAULT_BATCH_RUN_CONCURRENCY})`,
     )
+    .option(
+      '--report <format>',
+      'with --all --wait: write a JUnit XML sidecar report after polling (accepted: junit)',
+    )
+    .option('--report-file <path>', 'output path for --report (atomic write)')
+    .option(
+      '--report-suite-name <name>',
+      'optional JUnit <testsuite name=...> override (default: testsprite:<projectId>)',
+    )
     .addHelpText(
       'after',
       '\nDependency-aware fresh run (M4):\n' +
         '  testsprite test run --all --project <id>           run all BE tests in wave order\n' +
         '  testsprite test run --all --project <id> --filter <substr>  name-glob subset\n' +
+        '  testsprite test run --all --project <id> --wait --report junit --report-file ./results.xml\n' +
         '\nBE tests can declare --produces/--needs at create time to drive wave ordering\n' +
         '(see `testsprite test create --help` for details).',
     )
@@ -7462,6 +7538,14 @@ export function createTestCommand(deps: TestDeps = {}): Command {
           '--filter only applies with --all (it narrows which project tests run). Remove --filter, or add --all --project <id>.',
         );
       }
+      const report = parseJUnitReportFormat(cmdOpts.report);
+      assertJUnitReportOptions({
+        report,
+        reportFile: cmdOpts.reportFile,
+        reportSuiteName: cmdOpts.reportSuiteName,
+        wait: cmdOpts.wait === true,
+        batchPath: isAll,
+      });
 
       if (isAll) {
         // --all path: wave-ordered fresh batch run.
@@ -7492,6 +7576,9 @@ export function createTestCommand(deps: TestDeps = {}): Command {
               parseNumericFlag(cmdOpts.maxConcurrency, 'max-concurrency') ??
               DEFAULT_BATCH_RUN_CONCURRENCY,
             idempotencyKey: cmdOpts.idempotencyKey,
+            report,
+            reportFile: cmdOpts.reportFile,
+            reportSuiteName: cmdOpts.reportSuiteName,
           },
           deps,
         );
@@ -7599,6 +7686,15 @@ export function createTestCommand(deps: TestDeps = {}): Command {
       '--idempotency-key <key>',
       'opaque key for safe retries (1–256 chars). Printed to stderr at --verbose if auto-generated.',
     )
+    .option(
+      '--report <format>',
+      'with batch --wait: write a JUnit XML sidecar report after polling (accepted: junit)',
+    )
+    .option('--report-file <path>', 'output path for --report (atomic write)')
+    .option(
+      '--report-suite-name <name>',
+      'optional JUnit <testsuite name=...> override (default: testsprite:<projectId>)',
+    )
     .addHelpText(
       'after',
       '\nNotes:\n' +
@@ -7624,10 +7720,20 @@ export function createTestCommand(deps: TestDeps = {}): Command {
       // `--no-auto-heal`. There is no explicit `--auto-heal` flag, so
       // autoHealExplicit is always false in this design — the default-on value
       // is never a deliberate user choice to opt in.
+      const testIds = testIdsArg ?? [];
+      const isBatch = cmdOpts.all === true || testIds.length !== 1;
+      const report = parseJUnitReportFormat(cmdOpts.report);
+      assertJUnitReportOptions({
+        report,
+        reportFile: cmdOpts.reportFile,
+        reportSuiteName: cmdOpts.reportSuiteName,
+        wait: cmdOpts.wait === true,
+        batchPath: isBatch,
+      });
       await runTestRerun(
         {
           ...resolveCommonOptions(command),
-          testIds: testIdsArg ?? [],
+          testIds,
           all: cmdOpts.all === true,
           projectId: cmdOpts.project,
           skipTerminal: cmdOpts.skipTerminal === true,
@@ -7642,6 +7748,9 @@ export function createTestCommand(deps: TestDeps = {}): Command {
             parseNumericFlag(cmdOpts.maxConcurrency, 'max-concurrency') ??
             DEFAULT_BATCH_RUN_CONCURRENCY,
           idempotencyKey: cmdOpts.idempotencyKey,
+          report,
+          reportFile: cmdOpts.reportFile,
+          reportSuiteName: cmdOpts.reportSuiteName,
         },
         deps,
       );
@@ -7665,6 +7774,9 @@ interface RunFlagOpts {
   project?: string;
   filter?: string;
   maxConcurrency?: string;
+  report?: string;
+  reportFile?: string;
+  reportSuiteName?: string;
 }
 
 interface WaitFlagOpts {
@@ -7683,6 +7795,9 @@ interface RerunFlagOpts {
   skipDependencies?: boolean;
   maxConcurrency?: string;
   idempotencyKey?: string;
+  report?: string;
+  reportFile?: string;
+  reportSuiteName?: string;
 }
 
 interface UpdateFlagOpts {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -6767,10 +6767,7 @@ export async function runTestRerun(
   };
   out.print(jsonPayload);
   const reportProjectId = opts.projectId ?? 'batch';
-  await writeBatchJUnitReportIfRequested(
-    { ...opts, projectId: reportProjectId },
-    rerunResults,
-  );
+  await writeBatchJUnitReportIfRequested({ ...opts, projectId: reportProjectId }, rerunResults);
 
   // Determine exit code: timeout (deferred or any timeout) → 7; any fail → 1; all pass → 0
   if (deferred.length > 0 || timedOut > 0) {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -22,6 +22,7 @@ import { findSample, sampleJUnitReportXml } from '../lib/dry-run/samples.js';
 import {
   assertJUnitReportOptions,
   buildJUnitReport,
+  resolveBatchReportProjectId,
   writeJUnitReportFile,
   type JUnitReportFormat,
   parseJUnitReportFormat,
@@ -5098,15 +5099,16 @@ async function writeBatchJUnitReportIfRequested(
     report?: JUnitReportFormat;
     reportFile?: string;
     reportSuiteName?: string;
-    projectId: string;
+    projectId?: string;
   },
   results: readonly JUnitTestResult[],
 ): Promise<void> {
   if (opts.report !== 'junit' || opts.reportFile === undefined) return;
-  const suiteName = opts.reportSuiteName ?? `testsprite:${opts.projectId}`;
+  const projectId = resolveBatchReportProjectId(opts, results);
+  const suiteName = opts.reportSuiteName ?? `testsprite:${projectId}`;
   const xml = buildJUnitReport({
     suiteName,
-    classname: opts.projectId,
+    classname: projectId,
     results,
   });
   await writeJUnitReportFile(opts.reportFile, xml);
@@ -5174,10 +5176,13 @@ export async function runTestRunAll(
       idempotencyKey,
       ...(opts.wait ? { thenPoll: '/api/cli/v1/runs/<run-id>?waitSeconds=25' } : {}),
     };
-    out.print(batchRunSample ?? envelope);
     if (opts.report === 'junit' && opts.reportFile !== undefined) {
-      await writeJUnitReportFile(opts.reportFile, sampleJUnitReportXml(opts.projectId));
+      await writeJUnitReportFile(
+        opts.reportFile,
+        sampleJUnitReportXml(opts.projectId, opts.reportSuiteName),
+      );
     }
+    out.print(batchRunSample ?? envelope);
     return undefined;
   }
 
@@ -5516,7 +5521,12 @@ export async function runTestRunAll(
         },
         resolveAlternate,
       });
-      return { testId: entry.testId, runId, status: finalRun.status };
+      return {
+        testId: entry.testId,
+        runId,
+        projectId: finalRun.projectId,
+        status: finalRun.status,
+      };
     } catch (err) {
       if (err instanceof TimeoutError) {
         return {
@@ -5598,8 +5608,8 @@ export async function runTestRunAll(
       total: pollable.length,
     },
   };
-  out.print(jsonPayload);
   await writeBatchJUnitReportIfRequested(opts, freshRunResults);
+  out.print(jsonPayload);
 
   // Rate-deferred tests were never dispatched → the batch is incomplete (exit 7),
   // mirroring `test rerun --all`. Checked before the failed-run throw so the
@@ -5661,6 +5671,8 @@ export async function runTestRunAll(
 interface CliRerunResult {
   testId: string;
   runId: string;
+  /** Observed on polled runs; used for JUnit report naming when --project omitted. */
+  projectId?: string;
   /** Terminal status, or 'timeout' for per-run deadline exceeded. */
   status: string;
   /** Set when the test is a closure member (not the user's named test). */
@@ -5776,11 +5788,14 @@ export async function runTestRerun(
         idempotencyKey,
         ...(opts.wait ? { thenPoll: `/api/cli/v1/runs/<run-id>?waitSeconds=25` } : {}),
       };
-      out.print(findSample('POST', '/api/cli/v1/tests/batch/rerun')?.body() ?? envelope);
       if (opts.report === 'junit' && opts.reportFile !== undefined) {
-        const projectKey = opts.projectId ?? 'batch';
-        await writeJUnitReportFile(opts.reportFile, sampleJUnitReportXml(projectKey));
+        const projectKey = resolveBatchReportProjectId(opts, []);
+        await writeJUnitReportFile(
+          opts.reportFile,
+          sampleJUnitReportXml(projectKey, opts.reportSuiteName),
+        );
       }
+      out.print(findSample('POST', '/api/cli/v1/tests/batch/rerun')?.body() ?? envelope);
     }
     void client;
     return undefined;
@@ -6677,7 +6692,12 @@ export async function runTestRerun(
         },
         resolveAlternate,
       });
-      return { testId: entry.testId, runId: entry.runId, status: finalRun.status };
+      return {
+        testId: entry.testId,
+        runId: entry.runId,
+        projectId: finalRun.projectId,
+        status: finalRun.status,
+      };
     } catch (err) {
       if (err instanceof TimeoutError) {
         return {
@@ -6765,9 +6785,8 @@ export async function runTestRerun(
       total: accepted.length,
     },
   };
+  await writeBatchJUnitReportIfRequested(opts, rerunResults);
   out.print(jsonPayload);
-  const reportProjectId = opts.projectId ?? 'batch';
-  await writeBatchJUnitReportIfRequested({ ...opts, projectId: reportProjectId }, rerunResults);
 
   // Determine exit code: timeout (deferred or any timeout) → 7; any fail → 1; all pass → 0
   if (deferred.length > 0 || timedOut > 0) {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -5120,6 +5120,8 @@ async function writeBatchJUnitReportIfRequested(
 interface CliBatchRunFreshResult {
   testId: string;
   runId: string | undefined;
+  /** Observed on polled runs; used for JUnit report naming when --project omitted. */
+  projectId?: string;
   status: string;
   error?: { code: string; message: string; exitCode: number };
   /** CLIENT-synthesized Portal deep link (projectId from opts, testId per item). */

--- a/src/lib/dry-run/samples.test.ts
+++ b/src/lib/dry-run/samples.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import { DRY_RUN_SAMPLE_ENTRIES, findSample } from './samples.js';
+import { DRY_RUN_SAMPLE_ENTRIES, findSample, sampleJUnitReportXml } from './samples.js';
+
+describe('sampleJUnitReportXml', () => {
+  it('returns well-formed JUnit XML with canned batch ids', () => {
+    const xml = sampleJUnitReportXml('proj_dry');
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<testsuite name="testsprite:proj_dry"');
+    expect(xml).toContain('classname="proj_dry"');
+    expect(xml).toContain('name="test_fresh_wave_01"');
+    expect(xml).toContain('name="test_fresh_wave_02"');
+    expect(xml).toContain('failures="1"');
+  });
+});
 
 describe('findSample', () => {
   it('resolves /me', () => {

--- a/src/lib/dry-run/samples.test.ts
+++ b/src/lib/dry-run/samples.test.ts
@@ -11,6 +11,12 @@ describe('sampleJUnitReportXml', () => {
     expect(xml).toContain('name="test_fresh_wave_02"');
     expect(xml).toContain('failures="1"');
   });
+
+  it('honors reportSuiteName override', () => {
+    const xml = sampleJUnitReportXml('proj_dry', 'custom-ci-suite');
+    expect(xml).toContain('<testsuite name="custom-ci-suite"');
+    expect(xml).not.toContain('testsprite:proj_dry');
+  });
 });
 
 describe('findSample', () => {

--- a/src/lib/dry-run/samples.ts
+++ b/src/lib/dry-run/samples.ts
@@ -72,9 +72,12 @@ export const SAMPLE_DRY_RUN_REQUEST_ID = SAMPLE_REQUEST_ID;
  * Canned JUnit XML for batch `--wait --report junit --dry-run`. Mirrors the
  * fresh batch-run sample ids so agents can learn the sidecar shape offline.
  */
-export function sampleJUnitReportXml(projectId: string = SAMPLE_PROJECT_ID): string {
+export function sampleJUnitReportXml(
+  projectId: string = SAMPLE_PROJECT_ID,
+  reportSuiteName?: string,
+): string {
   return buildJUnitReport({
-    suiteName: `testsprite:${projectId}`,
+    suiteName: reportSuiteName ?? `testsprite:${projectId}`,
     classname: projectId,
     results: [
       {

--- a/src/lib/dry-run/samples.ts
+++ b/src/lib/dry-run/samples.ts
@@ -27,6 +27,7 @@ import type {
   CliTestStep,
 } from '../../commands/test.js';
 import type { MeResponse } from '../../commands/auth.js';
+import { buildJUnitReport } from '../junit-report.js';
 import type { Page } from '../pagination.js';
 import type {
   TriggerRunResponse,
@@ -66,6 +67,34 @@ const SAMPLE_TARGET_URL = 'https://staging.example.com/checkout';
 const SAMPLE_REQUEST_ID = 'req_dry-run';
 
 export const SAMPLE_DRY_RUN_REQUEST_ID = SAMPLE_REQUEST_ID;
+
+/**
+ * Canned JUnit XML for batch `--wait --report junit --dry-run`. Mirrors the
+ * fresh batch-run sample ids so agents can learn the sidecar shape offline.
+ */
+export function sampleJUnitReportXml(projectId: string = SAMPLE_PROJECT_ID): string {
+  return buildJUnitReport({
+    suiteName: `testsprite:${projectId}`,
+    classname: projectId,
+    results: [
+      {
+        testId: SAMPLE_TEST_ID_FRESH_1,
+        runId: SAMPLE_BATCH_FRESH_RUN_ID_1,
+        status: 'passed',
+      },
+      {
+        testId: SAMPLE_TEST_ID_FRESH_2,
+        runId: SAMPLE_BATCH_FRESH_RUN_ID_2,
+        status: 'failed',
+        error: {
+          code: 'ASSERTION',
+          message: 'Expected checkout heading to be visible',
+          exitCode: 1,
+        },
+      },
+    ],
+  });
+}
 
 const me: MeResponse = {
   userId: SAMPLE_USER_ID,

--- a/src/lib/junit-report.test.ts
+++ b/src/lib/junit-report.test.ts
@@ -52,9 +52,7 @@ describe('parseJUnitReportFormat', () => {
 
 describe('assertJUnitReportOptions', () => {
   it('allows absent report flags', () => {
-    expect(() =>
-      assertJUnitReportOptions({ wait: false, batchPath: true }),
-    ).not.toThrow();
+    expect(() => assertJUnitReportOptions({ wait: false, batchPath: true })).not.toThrow();
   });
 
   it('rejects report-file without report', () => {
@@ -99,7 +97,9 @@ describe('buildJUnitReport', () => {
       classname: 'proj_empty',
       results: [],
     });
-    expect(xml).toContain('<testsuite name="Dry suite" tests="0" failures="0" errors="0" skipped="0"');
+    expect(xml).toContain(
+      '<testsuite name="Dry suite" tests="0" failures="0" errors="0" skipped="0"',
+    );
     expect(xml).toContain('</testsuites>');
   });
 

--- a/src/lib/junit-report.test.ts
+++ b/src/lib/junit-report.test.ts
@@ -8,6 +8,7 @@ import {
   buildJUnitReport,
   escapeXml,
   parseJUnitReportFormat,
+  resolveBatchReportProjectId,
   writeJUnitReportFile,
   type JUnitTestResult,
 } from './junit-report.js';
@@ -61,6 +62,16 @@ describe('assertJUnitReportOptions', () => {
     ).toThrowError(ApiError);
   });
 
+  it('rejects report-suite-name without report', () => {
+    expect(() =>
+      assertJUnitReportOptions({
+        reportSuiteName: 'my-suite',
+        wait: true,
+        batchPath: true,
+      }),
+    ).toThrowError(ApiError);
+  });
+
   it('rejects report on non-batch paths', () => {
     expect(() =>
       assertJUnitReportOptions({
@@ -87,6 +98,26 @@ describe('assertJUnitReportOptions', () => {
     expect(() =>
       assertJUnitReportOptions({ report: 'junit', wait: true, batchPath: true }),
     ).toThrowError(ApiError);
+  });
+});
+
+describe('resolveBatchReportProjectId', () => {
+  it('prefers explicit projectId', () => {
+    expect(resolveBatchReportProjectId({ projectId: 'proj_a' }, [])).toBe('proj_a');
+  });
+
+  it('infers from polled run rows', () => {
+    expect(resolveBatchReportProjectId({}, [{ projectId: 'proj_from_run' }])).toBe('proj_from_run');
+  });
+
+  it('requires --project when the project cannot be inferred', () => {
+    expect(() => resolveBatchReportProjectId({}, [])).toThrowError(ApiError);
+    try {
+      resolveBatchReportProjectId({}, []);
+    } catch (err) {
+      expect((err as ApiError).code).toBe('VALIDATION_ERROR');
+      expect((err as ApiError).exitCode).toBe(5);
+    }
   });
 });
 

--- a/src/lib/junit-report.test.ts
+++ b/src/lib/junit-report.test.ts
@@ -1,0 +1,299 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ApiError } from './errors.js';
+import {
+  assertJUnitReportOptions,
+  buildJUnitReport,
+  escapeXml,
+  parseJUnitReportFormat,
+  writeJUnitReportFile,
+  type JUnitTestResult,
+} from './junit-report.js';
+
+function makeResult(overrides: Partial<JUnitTestResult> & { testId: string }): JUnitTestResult {
+  return {
+    status: 'passed',
+    ...overrides,
+  };
+}
+
+describe('escapeXml', () => {
+  it('escapes XML special characters', () => {
+    expect(escapeXml(`a&b<c>d"e'f`)).toBe('a&amp;b&lt;c&gt;d&quot;e&apos;f');
+  });
+
+  it('leaves plain text unchanged', () => {
+    expect(escapeXml('test_abc123')).toBe('test_abc123');
+  });
+});
+
+describe('parseJUnitReportFormat', () => {
+  it('accepts junit', () => {
+    expect(parseJUnitReportFormat('junit')).toBe('junit');
+  });
+
+  it('returns undefined for absent value', () => {
+    expect(parseJUnitReportFormat(undefined)).toBeUndefined();
+    expect(parseJUnitReportFormat('')).toBeUndefined();
+  });
+
+  it('rejects unknown formats', () => {
+    expect(() => parseJUnitReportFormat('html')).toThrowError(ApiError);
+    try {
+      parseJUnitReportFormat('html');
+    } catch (err) {
+      expect((err as ApiError).code).toBe('VALIDATION_ERROR');
+      expect((err as ApiError).exitCode).toBe(5);
+    }
+  });
+});
+
+describe('assertJUnitReportOptions', () => {
+  it('allows absent report flags', () => {
+    expect(() =>
+      assertJUnitReportOptions({ wait: false, batchPath: true }),
+    ).not.toThrow();
+  });
+
+  it('rejects report-file without report', () => {
+    expect(() =>
+      assertJUnitReportOptions({ reportFile: './out.xml', wait: true, batchPath: true }),
+    ).toThrowError(ApiError);
+  });
+
+  it('rejects report on non-batch paths', () => {
+    expect(() =>
+      assertJUnitReportOptions({
+        report: 'junit',
+        reportFile: './out.xml',
+        wait: true,
+        batchPath: false,
+      }),
+    ).toThrowError(ApiError);
+  });
+
+  it('rejects report without wait', () => {
+    expect(() =>
+      assertJUnitReportOptions({
+        report: 'junit',
+        reportFile: './out.xml',
+        wait: false,
+        batchPath: true,
+      }),
+    ).toThrowError(ApiError);
+  });
+
+  it('rejects report without report-file', () => {
+    expect(() =>
+      assertJUnitReportOptions({ report: 'junit', wait: true, batchPath: true }),
+    ).toThrowError(ApiError);
+  });
+});
+
+describe('buildJUnitReport', () => {
+  it('renders an empty suite', () => {
+    const xml = buildJUnitReport({
+      suiteName: 'Dry suite',
+      classname: 'proj_empty',
+      results: [],
+    });
+    expect(xml).toContain('<testsuite name="Dry suite" tests="0" failures="0" errors="0" skipped="0"');
+    expect(xml).toContain('</testsuites>');
+  });
+
+  it('counts passed tests without child elements', () => {
+    const xml = buildJUnitReport({
+      suiteName: 'Batch',
+      classname: 'proj_1',
+      results: [makeResult({ testId: 'test_a', status: 'passed' })],
+    });
+    expect(xml).toContain('<testcase classname="proj_1" name="test_a" time="0">');
+    expect(xml).not.toContain('<failure');
+    expect(xml).toContain('tests="1" failures="0" errors="0"');
+  });
+
+  it('maps failed status to failure elements', () => {
+    const xml = buildJUnitReport({
+      suiteName: 'Batch',
+      classname: 'proj_1',
+      results: [
+        makeResult({
+          testId: 'test_fail',
+          status: 'failed',
+          runId: 'run_1',
+        }),
+      ],
+    });
+    expect(xml).toContain('<failure message="failed" type="failed">');
+    expect(xml).toContain('runId: run_1');
+    expect(xml).toContain('failures="1"');
+  });
+
+  it('maps blocked and cancelled to failures', () => {
+    const xml = buildJUnitReport({
+      suiteName: 'Batch',
+      classname: 'proj_1',
+      results: [
+        makeResult({ testId: 't_blocked', status: 'blocked' }),
+        makeResult({ testId: 't_cancelled', status: 'cancelled' }),
+      ],
+    });
+    expect(xml).toContain('failures="2"');
+    expect(xml).toContain('type="blocked"');
+    expect(xml).toContain('type="cancelled"');
+  });
+
+  it('maps timeout to failure', () => {
+    const xml = buildJUnitReport({
+      suiteName: 'Batch',
+      classname: 'proj_1',
+      results: [
+        makeResult({
+          testId: 't_timeout',
+          status: 'timeout',
+          error: { code: 'UNSUPPORTED', message: 'Timed out', exitCode: 7 },
+        }),
+      ],
+    });
+    expect(xml).toContain('<failure message="Timed out" type="timeout">');
+  });
+
+  it('maps API error status to error elements', () => {
+    const xml = buildJUnitReport({
+      suiteName: 'Batch',
+      classname: 'proj_1',
+      results: [
+        makeResult({
+          testId: 't_err',
+          status: 'error',
+          error: { code: 'NOT_FOUND', message: 'Run missing', exitCode: 4 },
+        }),
+      ],
+    });
+    expect(xml).toContain('<error message="Run missing" type="NOT_FOUND">');
+    expect(xml).toContain('errors="1"');
+  });
+
+  it('maps auth failures to error elements', () => {
+    const xml = buildJUnitReport({
+      suiteName: 'Batch',
+      classname: 'proj_1',
+      results: [
+        makeResult({
+          testId: 't_auth',
+          status: 'failed',
+          error: { code: 'AUTH_INVALID', message: 'Bad key', exitCode: 3 },
+        }),
+      ],
+    });
+    expect(xml).toContain('<error message="Bad key" type="AUTH_INVALID">');
+    expect(xml).toContain('failures="0" errors="1"');
+  });
+
+  it('escapes special characters in testcase names and messages', () => {
+    const xml = buildJUnitReport({
+      suiteName: 'Suite "A"',
+      classname: 'proj<&>',
+      results: [
+        makeResult({
+          testId: 'test<1>',
+          status: 'failed',
+          error: { code: 'ASSERT', message: 'expected <true> & "ok"', exitCode: 1 },
+        }),
+      ],
+    });
+    expect(xml).toContain('name="test&lt;1&gt;"');
+    expect(xml).toContain('classname="proj&lt;&amp;&gt;"');
+    expect(xml).toContain('message="expected &lt;true&gt; &amp; &quot;ok&quot;"');
+  });
+
+  it('aggregates mixed outcomes', () => {
+    const xml = buildJUnitReport({
+      suiteName: 'Mixed',
+      classname: 'proj_mix',
+      results: [
+        makeResult({ testId: 'p', status: 'passed' }),
+        makeResult({ testId: 'f', status: 'failed' }),
+        makeResult({
+          testId: 'e',
+          status: 'error',
+          error: { code: 'INTERNAL', message: 'boom', exitCode: 10 },
+        }),
+      ],
+    });
+    expect(xml).toContain('tests="3" failures="1" errors="1" skipped="0"');
+  });
+});
+
+describe('writeJUnitReportFile', () => {
+  it('writes XML atomically to the target path', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'junit-report-'));
+    const target = join(dir, 'results.xml');
+    const xml = buildJUnitReport({
+      suiteName: 'Suite',
+      classname: 'proj_write',
+      results: [makeResult({ testId: 't1', status: 'passed' })],
+    });
+
+    await writeJUnitReportFile(target, xml);
+
+    expect(readFileSync(target, 'utf8')).toBe(xml);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('rejects a directory target', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'junit-report-dir-'));
+    await expect(writeJUnitReportFile(dir, '<testsuites/>')).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+    });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('rejects missing parent directory', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'junit-report-parent-'));
+    const missing = join(dir, 'missing', 'out.xml');
+    await expect(writeJUnitReportFile(missing, '<testsuites/>')).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+    });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('overwrites an existing file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'junit-report-overwrite-'));
+    const target = join(dir, 'results.xml');
+    writeFileSync(target, 'old', 'utf8');
+    const xml = buildJUnitReport({
+      suiteName: 'New',
+      classname: 'proj_new',
+      results: [],
+    });
+
+    await writeJUnitReportFile(target, xml);
+
+    expect(readFileSync(target, 'utf8')).toBe(xml);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('rejects empty path', async () => {
+    await expect(writeJUnitReportFile('', '<testsuites/>')).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+    });
+  });
+
+  it('rejects parent that is a file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'junit-report-file-parent-'));
+    const parentFile = join(dir, 'not-a-dir');
+    writeFileSync(parentFile, 'x', 'utf8');
+    const target = join(parentFile, 'out.xml');
+    await expect(writeJUnitReportFile(target, '<testsuites/>')).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+    });
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/lib/junit-report.ts
+++ b/src/lib/junit-report.ts
@@ -11,6 +11,8 @@ export interface JUnitTestResult {
   testId: string;
   runId?: string;
   status: string;
+  /** Observed on polled runs; used for classname when --project is omitted. */
+  projectId?: string;
   error?: { code: string; message: string; exitCode?: number };
 }
 
@@ -49,6 +51,12 @@ export function assertJUnitReportOptions(opts: JUnitReportFlagOptions): void {
     if (opts.reportFile !== undefined && opts.reportFile !== '') {
       throw localValidationError('report-file', '--report-file requires --report junit');
     }
+    if (opts.reportSuiteName !== undefined && opts.reportSuiteName !== '') {
+      throw localValidationError(
+        'report-suite-name',
+        '--report-suite-name requires --report junit',
+      );
+    }
     return;
   }
 
@@ -67,6 +75,23 @@ export function assertJUnitReportOptions(opts: JUnitReportFlagOptions): void {
   if (opts.reportFile === undefined || opts.reportFile === '') {
     throw localValidationError('report-file', '--report junit requires --report-file <path>');
   }
+}
+
+/**
+ * Resolve the project id used for JUnit classname / default suite naming.
+ * Prefer explicit `--project`, then ids observed on polled run rows.
+ */
+export function resolveBatchReportProjectId(
+  opts: { projectId?: string },
+  results: ReadonlyArray<{ projectId?: string }>,
+): string {
+  if (opts.projectId) return opts.projectId;
+  const fromPoll = results.map(r => r.projectId).find((id): id is string => !!id);
+  if (fromPoll) return fromPoll;
+  throw localValidationError(
+    'project',
+    '--report junit requires --project <id> when the project cannot be inferred from run results',
+  );
 }
 
 /**

--- a/src/lib/junit-report.ts
+++ b/src/lib/junit-report.ts
@@ -1,0 +1,240 @@
+import { createWriteStream } from 'node:fs';
+import { rename, stat, unlink } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { localValidationError, TransportError } from './errors.js';
+
+export type JUnitReportFormat = 'junit';
+
+/** Minimal testcase input shared by batch run and batch rerun poll results. */
+export interface JUnitTestResult {
+  testId: string;
+  runId?: string;
+  status: string;
+  error?: { code: string; message: string; exitCode?: number };
+}
+
+export interface JUnitReportBuildOptions {
+  suiteName: string;
+  classname: string;
+  results: readonly JUnitTestResult[];
+}
+
+export interface JUnitReportFlagOptions {
+  report?: JUnitReportFormat;
+  reportFile?: string;
+  reportSuiteName?: string;
+  wait: boolean;
+  /** True when the invocation is a batch path (run --all or rerun batch). */
+  batchPath: boolean;
+}
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8"?>';
+
+/**
+ * Parse `--report <format>`. Only `junit` is accepted in v1.
+ */
+export function parseJUnitReportFormat(raw: string | undefined): JUnitReportFormat | undefined {
+  if (raw === undefined || raw === '') return undefined;
+  if (raw === 'junit') return 'junit';
+  throw localValidationError('report', `unsupported report format "${raw}" — accepted: junit`);
+}
+
+/**
+ * Validate `--report` / `--report-file` / `--report-suite-name` combinations.
+ * Report export is a sidecar artifact for batch `--wait` runs only.
+ */
+export function assertJUnitReportOptions(opts: JUnitReportFlagOptions): void {
+  if (opts.report === undefined) {
+    if (opts.reportFile !== undefined && opts.reportFile !== '') {
+      throw localValidationError('report-file', '--report-file requires --report junit');
+    }
+    return;
+  }
+
+  if (!opts.batchPath) {
+    throw localValidationError(
+      'report',
+      '--report junit only applies to batch --wait runs (test run --all, or test rerun --all / multiple test ids)',
+    );
+  }
+  if (!opts.wait) {
+    throw localValidationError(
+      'report',
+      '--report junit requires --wait (the report is written after batch polling completes)',
+    );
+  }
+  if (opts.reportFile === undefined || opts.reportFile === '') {
+    throw localValidationError('report-file', '--report junit requires --report-file <path>');
+  }
+}
+
+/**
+ * Escape text for inclusion in XML element bodies and double-quoted attributes.
+ */
+export function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+type JUnitOutcome = 'passed' | 'failure' | 'error' | 'skipped';
+
+function classifyJUnitOutcome(status: string, error?: JUnitTestResult['error']): JUnitOutcome {
+  if (status === 'passed') return 'passed';
+  if (status === 'skipped') return 'skipped';
+  if (status === 'error' || error?.exitCode === 3) return 'error';
+  return 'failure';
+}
+
+function failureMessage(result: JUnitTestResult): string {
+  if (result.error?.message) return result.error.message;
+  if (result.error?.code) return result.error.code;
+  return result.status;
+}
+
+function renderTestcase(result: JUnitTestResult, classname: string): string {
+  const outcome = classifyJUnitOutcome(result.status, result.error);
+  const name = escapeXml(result.testId);
+  const cls = escapeXml(classname);
+  const lines = [`    <testcase classname="${cls}" name="${name}" time="0">`];
+
+  if (outcome === 'failure') {
+    const message = escapeXml(failureMessage(result));
+    const type = escapeXml(result.status);
+    const body = escapeXml(
+      [
+        `status: ${result.status}`,
+        result.runId ? `runId: ${result.runId}` : undefined,
+        result.error?.code ? `code: ${result.error.code}` : undefined,
+        result.error?.message ? `message: ${result.error.message}` : undefined,
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    );
+    lines.push(`      <failure message="${message}" type="${type}">${body}</failure>`);
+  } else if (outcome === 'error') {
+    const message = escapeXml(failureMessage(result));
+    const type = escapeXml(result.error?.code ?? result.status);
+    const body = escapeXml(
+      [
+        result.error?.code ? `code: ${result.error.code}` : undefined,
+        result.error?.message ? `message: ${result.error.message}` : undefined,
+        result.runId ? `runId: ${result.runId}` : undefined,
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    );
+    lines.push(`      <error message="${message}" type="${type}">${body}</error>`);
+  } else if (outcome === 'skipped') {
+    lines.push(`      <skipped/>`);
+  }
+
+  lines.push('    </testcase>');
+  return lines.join('\n');
+}
+
+/**
+ * Build a JUnit XML document from batch poll results. Duration is `0` in v1
+ * because batch poll envelopes do not carry per-run timing.
+ */
+export function buildJUnitReport(opts: JUnitReportBuildOptions): string {
+  const results = opts.results;
+  let failures = 0;
+  let errors = 0;
+  let skipped = 0;
+
+  for (const result of results) {
+    const outcome = classifyJUnitOutcome(result.status, result.error);
+    if (outcome === 'failure') failures++;
+    else if (outcome === 'error') errors++;
+    else if (outcome === 'skipped') skipped++;
+  }
+
+  const suiteName = escapeXml(opts.suiteName);
+  const testcases = results.map(r => renderTestcase(r, opts.classname)).join('\n');
+
+  return [
+    XML_DECL,
+    '<testsuites>',
+    `  <testsuite name="${suiteName}" tests="${results.length}" failures="${failures}" errors="${errors}" skipped="${skipped}" time="0">`,
+    testcases,
+    '  </testsuite>',
+    '</testsuites>',
+    '',
+  ].join('\n');
+}
+
+async function assertReportFileParent(rawPath: string): Promise<string> {
+  if (typeof rawPath !== 'string' || rawPath.length === 0) {
+    throw localValidationError('report-file', 'must be a non-empty file path');
+  }
+  const resolved = isAbsolute(rawPath) ? rawPath : resolve(process.cwd(), rawPath);
+  if (resolved.endsWith('/') || resolved.endsWith('\\')) {
+    throw localValidationError('report-file', 'must point to a file, not a directory');
+  }
+
+  const parent = dirname(resolved);
+  let parentStat;
+  try {
+    parentStat = await stat(parent);
+  } catch {
+    throw localValidationError('report-file', `parent directory does not exist: ${parent}`);
+  }
+  if (!parentStat.isDirectory()) {
+    throw localValidationError('report-file', `parent path is not a directory: ${parent}`);
+  }
+
+  let targetStat;
+  try {
+    targetStat = await stat(resolved);
+  } catch {
+    return resolved;
+  }
+  if (targetStat.isDirectory()) {
+    throw localValidationError('report-file', `must point to a file, not a directory: ${resolved}`);
+  }
+  return resolved;
+}
+
+/**
+ * Atomically write JUnit XML to `--report-file` (temp sibling + rename).
+ */
+export async function writeJUnitReportFile(rawPath: string, xml: string): Promise<void> {
+  const resolved = await assertReportFileParent(rawPath);
+  const parent = dirname(resolved);
+  const tmpPath = join(parent, `.${basename(resolved)}.tmp-${randomUUID()}`);
+
+  await new Promise<void>((resolvePromise, reject) => {
+    const stream = createWriteStream(tmpPath, { encoding: 'utf8' });
+    let streamError: Error | null = null;
+    stream.on('error', err => {
+      streamError = err instanceof Error ? err : new Error(String(err));
+    });
+    stream.write(xml, err => {
+      if (err) {
+        streamError = err instanceof Error ? err : new Error(String(err));
+      }
+      stream.end(() => {
+        if (streamError) {
+          unlink(tmpPath).catch(() => undefined);
+          reject(new TransportError(`Failed to write --report-file ${resolved}: ${streamError.message}`));
+          return;
+        }
+        rename(tmpPath, resolved)
+          .then(() => resolvePromise())
+          .catch(renameErr => {
+            unlink(tmpPath).catch(() => undefined);
+            reject(
+              new TransportError(
+                `Failed to write --report-file ${resolved}: ${renameErr instanceof Error ? renameErr.message : String(renameErr)}`,
+              ),
+            );
+          });
+      });
+    });
+  });
+}

--- a/src/lib/junit-report.ts
+++ b/src/lib/junit-report.ts
@@ -221,7 +221,9 @@ export async function writeJUnitReportFile(rawPath: string, xml: string): Promis
       stream.end(() => {
         if (streamError) {
           unlink(tmpPath).catch(() => undefined);
-          reject(new TransportError(`Failed to write --report-file ${resolved}: ${streamError.message}`));
+          reject(
+            new TransportError(`Failed to write --report-file ${resolved}: ${streamError.message}`),
+          );
           return;
         }
         rename(tmpPath, resolved)

--- a/test/__snapshots__/help.snapshot.test.ts.snap
+++ b/test/__snapshots__/help.snapshot.test.ts.snap
@@ -392,37 +392,40 @@ Exit codes:
 On failure/blocked/cancelled, run: testsprite test artifact get <run-id>
 
 Options:
-  --all                    rerun all tests in the resolved project (requires
-                           --project) (default: false)
-  --project <id>           project id (required with --all; returned by
-                           \`testsprite project list\`)
-  --skip-terminal          with --all: skip tests already in a terminal status
-                           (passed|failed|blocked|cancelled) (default: false)
-  --status <list>          with --all: only dispatch tests whose status matches
-                           one of these values (comma-separated; accepted:
-                           draft|ready|queued|running|passed|failed|blocked|cancelled|unknown)
-  --filter <substr>        with --all: only rerun tests whose name contains
-                           this substring (case-insensitive)
-  --wait                   block until terminal status or --timeout elapses
-                           (default: false)
-  --timeout <s>            with --wait, max seconds to wait (1–3600, default
-                           600)
-  --no-auto-heal           opt out of AI heal-on-drift for this FE rerun
-                           (default: auto-heal is ON). Costs 0.2 credits per
-                           engage when a step has drifted. Ignored for backend
-                           tests.
-  --skip-dependencies      BE only: rerun only the named test without expanding
-                           the producer/teardown closure (default: false)
-  --max-concurrency <n>    with --wait, max in-flight polls at once (1-100,
-                           default: 50)
-  --idempotency-key <key>  opaque key for safe retries (1–256 chars). Printed
-                           to stderr at --verbose if auto-generated.
-  --report <format>        with batch --wait: write a JUnit XML sidecar
-                           report after polling (accepted: junit)
-  --report-file <path>     output path for --report (atomic write)
+  --all                       rerun all tests in the resolved project (requires
+                              --project) (default: false)
+  --project <id>              project id (required with --all; returned by
+                              \`testsprite project list\`)
+  --skip-terminal             with --all: skip tests already in a terminal
+                              status (passed|failed|blocked|cancelled)
+                              (default: false)
+  --status <list>             with --all: only dispatch tests whose status
+                              matches one of these values (comma-separated;
+                              accepted:
+                              draft|ready|queued|running|passed|failed|blocked|cancelled|unknown)
+  --filter <substr>           with --all: only rerun tests whose name contains
+                              this substring (case-insensitive)
+  --wait                      block until terminal status or --timeout elapses
+                              (default: false)
+  --timeout <s>               with --wait, max seconds to wait (1–3600, default
+                              600)
+  --no-auto-heal              opt out of AI heal-on-drift for this FE rerun
+                              (default: auto-heal is ON). Costs 0.2 credits per
+                              engage when a step has drifted. Ignored for
+                              backend tests.
+  --skip-dependencies         BE only: rerun only the named test without
+                              expanding the producer/teardown closure (default:
+                              false)
+  --max-concurrency <n>       with --wait, max in-flight polls at once (1-100,
+                              default: 50)
+  --idempotency-key <key>     opaque key for safe retries (1–256 chars).
+                              Printed to stderr at --verbose if auto-generated.
+  --report <format>           with batch --wait: write a JUnit XML sidecar
+                              report after polling (accepted: junit)
+  --report-file <path>        output path for --report (atomic write)
   --report-suite-name <name>  optional JUnit <testsuite name=...> override
-                           (default: testsprite:<projectId>)
-  -h, --help               display help for command
+                              (default: testsprite:<projectId>)
+  -h, --help                  display help for command
 
 Notes:
   • rerun replays a saved run/script and is MORE LENIENT than a fresh \`test run\`
@@ -495,29 +498,29 @@ Exit codes:
 On failure/blocked/cancelled, run: testsprite test artifact get <run-id>
 
 Options:
-  --target-url <url>       override the project default env URL for this run
-                           (http/https only, no localhost/private IPs)
-  --wait                   poll until terminal status or --timeout elapses
-                           (default: false)
-  --timeout <s>            with --wait, max seconds to wait (1–3600, default
-                           600)
-  --idempotency-key <key>  opaque key for safe retries (1–256 chars). Printed
-                           to stderr at --debug if auto-generated.
-  --all                    run all BE tests in the project (wave-ordered fresh
-                           run; requires --project). Mutually exclusive with
-                           <test-id>. (default: false)
-  --project <id>           project id (required with --all; returned by
-                           \`testsprite project list\`)
-  --filter <substr>        with --all: only run tests whose name contains this
-                           substring (case-insensitive)
-  --max-concurrency <n>    with --all --wait, max in-flight polls at once
-                           (1-100, default: 50)
-  --report <format>        with --all --wait: write a JUnit XML sidecar
-                           report after polling (accepted: junit)
-  --report-file <path>     output path for --report (atomic write)
+  --target-url <url>          override the project default env URL for this run
+                              (http/https only, no localhost/private IPs)
+  --wait                      poll until terminal status or --timeout elapses
+                              (default: false)
+  --timeout <s>               with --wait, max seconds to wait (1–3600, default
+                              600)
+  --idempotency-key <key>     opaque key for safe retries (1–256 chars).
+                              Printed to stderr at --debug if auto-generated.
+  --all                       run all BE tests in the project (wave-ordered
+                              fresh run; requires --project). Mutually
+                              exclusive with <test-id>. (default: false)
+  --project <id>              project id (required with --all; returned by
+                              \`testsprite project list\`)
+  --filter <substr>           with --all: only run tests whose name contains
+                              this substring (case-insensitive)
+  --max-concurrency <n>       with --all --wait, max in-flight polls at once
+                              (1-100, default: 50)
+  --report <format>           with --all --wait: write a JUnit XML sidecar
+                              report after polling (accepted: junit)
+  --report-file <path>        output path for --report (atomic write)
   --report-suite-name <name>  optional JUnit <testsuite name=...> override
-                           (default: testsprite:<projectId>)
-  -h, --help               display help for command
+                              (default: testsprite:<projectId>)
+  -h, --help                  display help for command
 
 Dependency-aware fresh run (M4):
   testsprite test run --all --project <id>           run all BE tests in wave order

--- a/test/__snapshots__/help.snapshot.test.ts.snap
+++ b/test/__snapshots__/help.snapshot.test.ts.snap
@@ -417,6 +417,11 @@ Options:
                            default: 50)
   --idempotency-key <key>  opaque key for safe retries (1–256 chars). Printed
                            to stderr at --verbose if auto-generated.
+  --report <format>        with batch --wait: write a JUnit XML sidecar
+                           report after polling (accepted: junit)
+  --report-file <path>     output path for --report (atomic write)
+  --report-suite-name <name>  optional JUnit <testsuite name=...> override
+                           (default: testsprite:<projectId>)
   -h, --help               display help for command
 
 Notes:
@@ -507,11 +512,17 @@ Options:
                            substring (case-insensitive)
   --max-concurrency <n>    with --all --wait, max in-flight polls at once
                            (1-100, default: 50)
+  --report <format>        with --all --wait: write a JUnit XML sidecar
+                           report after polling (accepted: junit)
+  --report-file <path>     output path for --report (atomic write)
+  --report-suite-name <name>  optional JUnit <testsuite name=...> override
+                           (default: testsprite:<projectId>)
   -h, --help               display help for command
 
 Dependency-aware fresh run (M4):
   testsprite test run --all --project <id>           run all BE tests in wave order
   testsprite test run --all --project <id> --filter <substr>  name-glob subset
+  testsprite test run --all --project <id> --wait --report junit --report-file ./results.xml
 
 BE tests can declare --produces/--needs at create time to drive wave ordering
 (see \`testsprite test create --help\` for details).


### PR DESCRIPTION
## Summary

Adds JUnit XML sidecar export for **batch `--wait`** runs so CI systems (GitHub Actions, Jenkins, GitLab, Azure DevOps) can ingest standard test results without changing `--output json`.

```bash
testsprite test run --all --project <id> --wait \
  --report junit --report-file ./results.xml --output json

testsprite test rerun --all --project <id> --wait \
  --report junit --report-file ./results.xml --output json
```

`test rerun` also supports batch mode with multiple explicit test ids (`test rerun id1 id2 --wait ...`).

## Motivation

Today the CLI prints a JSON envelope on stdout. That's great for agents, but most CI dashboards expect JUnit XML on disk. This PR adds an opt-in sidecar artifact for the two highest-volume batch paths agents use in pipelines.

## What changed

| Area | Change |
|------|--------|
| **New module** | `src/lib/junit-report.ts` — XML builder, escaping, validation, atomic file write |
| **Commands** | `--report junit`, `--report-file <path>`, optional `--report-suite-name <name>` on `test run` and `test rerun` |
| **Integration** | Report written after batch polling completes, **before** non-zero exit throws (so failed batches still produce XML) |
| **Dry-run** | `sampleJUnitReportXml()` in `src/lib/dry-run/samples.ts` writes canned XML without network |
| **Docs** | `CHANGELOG.md`, `DOCUMENTATION.md`, help snapshots |

## Design decisions

- **Sidecar only** — `--output json` stdout contract is unchanged.
- **Batch + `--wait` required** — single `test run <id>` / single `test rerun <id>` reject `--report` early with `VALIDATION_ERROR` (exit 5).
- **Atomic write** — temp sibling + rename (same safety model as `--out`).
- **No new dependencies** — hand-rolled XML; no `fast-xml-parser` / `xmlbuilder`.
- **Duration `0` in v1** — batch poll envelopes don't carry per-run timing; testcase `time="0"` is honest until a future API field lands.
- **Status mapping** — `passed` → clean testcase; `failed`/`blocked`/`cancelled`/`timeout` → `<failure>`; API `error` / auth (`exitCode 3`) → `<error>`; `testId` as `name`, `projectId` as `classname`.

## Validation rules

- `--report` accepts only `junit` (unknown format → exit 5).
- `--report` requires `--report-file`.
- `--report-file` must be a file path (rejects directories / missing parent).
- `--report` without `--wait` → exit 5.

## Test plan

- [x] `src/lib/junit-report.test.ts` — 25 tests (escaping, counts, status mapping, atomic write guards)
- [x] `src/lib/dry-run/samples.test.ts` — canned XML sample shape
- [x] `src/commands/test.run.spec.ts` — writes XML on pass **and** on batch failure (exit 1), dry-run sample, validation
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Help snapshots updated (`test run`, `test rerun`)

## Screenshots / samples

Dry-run sample testcase ids mirror the existing batch-run fixtures (`test_fresh_wave_01`, `test_fresh_wave_02`) so agents learning via `--dry-run` see coherent shapes across JSON + XML.

## Checklist

- [x] No breaking changes to existing JSON envelopes
- [x] Report still written when batch exits non-zero (CI needs the artifact)
- [x] No overlap with open triage / credentials / Windows-fix PRs

Solve Issue #95 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added JUnit XML sidecar export for batch `test run` and `test rerun` via `--report junit --report-file`, with optional `--report-suite-name`.
  * Reports are generated after batch `--wait` polling completes, remain available in `--dry-run` (sample XML), and are written even when the batch exits non-zero.
  * Keeps existing JSON output behavior unchanged.

* **Documentation**
  * Updated command reference and changelog with batch CI examples and suite-name guidance.

* **Tests**
  * Added end-to-end and unit coverage for validation, XML contents/escaping, and atomic report-file writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->