### PR TITLE
fix(project): reject blank inline passwords

### DIFF
--- a/src/commands/project.test.ts
+++ b/src/commands/project.test.ts
@@ -484,6 +484,65 @@ describe('runCreate', () => {
     expect(result.type).toBe('backend');
   });
 
+  it('P6 — rejects a blank inline --password before POSTing', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('should not hit network — validation must fire client-side');
+    });
+
+    await expect(
+      runCreate(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          type: 'backend',
+          name: 'Auth Project',
+          password: '   ',
+        },
+        {
+          credentialsPath,
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          stdout: () => {},
+          stderr: () => {},
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('P6 — preserves surrounding spaces in a non-empty inline --password', async () => {
+    const { credentialsPath } = makeCreds();
+    const sentBodies: unknown[] = [];
+    const createdProject: CliProject = {
+      ...PROJECT_FIXTURE,
+      id: 'proj_password_spaces',
+      type: 'backend',
+      name: 'Password Spaces',
+    };
+    const fetchImpl = (async (_input: Parameters<typeof fetch>[0], init: RequestInit = {}) => {
+      if (init.body) sentBodies.push(JSON.parse(init.body as string) as unknown);
+      return new Response(JSON.stringify(createdProject), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    await runCreate(
+      {
+        profile: 'default',
+        output: 'json',
+        debug: false,
+        type: 'backend',
+        name: 'Password Spaces',
+        password: '  keep spaces  ',
+      },
+      { credentialsPath, fetchImpl, stdout: () => {}, stderr: () => {} },
+    );
+
+    expect((sentBodies[0] as Record<string, unknown>).password).toBe('  keep spaces  ');
+  });
+
   it('P6 — dry-run returns canned shape without hitting the network', async () => {
     const { credentialsPath } = makeCreds();
     const fetchImpl = vi.fn(async () => {
@@ -629,6 +688,32 @@ describe('runUpdate', () => {
           debug: false,
           projectId: 'proj_abc',
           // no mutable fields
+        },
+        {
+          credentialsPath,
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          stdout: () => {},
+          stderr: () => {},
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('P7 — rejects an empty inline --password before PATCHing', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('should not hit network — validation must fire client-side');
+    });
+
+    await expect(
+      runUpdate(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          projectId: 'proj_abc',
+          password: '',
         },
         {
           credentialsPath,

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -10,7 +10,7 @@ import type { FetchImpl } from '../lib/http.js';
 import type { HttpClient } from '../lib/http.js';
 import { GLOBAL_OPTS_HINT, Output, type OutputMode } from '../lib/output.js';
 import { assertNotLocal } from '../lib/target-url.js';
-import { assertIdempotencyKey } from '../lib/validate.js';
+import { assertIdempotencyKey, requireString } from '../lib/validate.js';
 import {
   fetchSinglePage,
   paginate,
@@ -128,6 +128,25 @@ interface CreateOptions extends CommonOptions {
   idempotencyKey?: string;
 }
 
+function validateInlinePassword(password: string | undefined): void {
+  if (password !== undefined) {
+    requireString('password', password, { kind: 'flag' });
+  }
+}
+
+function resolvePassword(opts: { password?: string; passwordFile?: string }): string | undefined {
+  validateInlinePassword(opts.password);
+  if (opts.password !== undefined) {
+    return opts.password;
+  }
+  if (opts.passwordFile !== undefined) {
+    const password = readFileSync(opts.passwordFile, 'utf8').trim();
+    requireString('passwordFile', password, { kind: 'flag' });
+    return password;
+  }
+  return undefined;
+}
+
 export async function runCreate(
   opts: CreateOptions,
   deps: ProjectDeps = {},
@@ -158,6 +177,8 @@ export async function runCreate(
     throw localValidationError('--url is required for --type frontend');
   }
 
+  validateInlinePassword(opts.password);
+
   if (opts.dryRun) {
     const idempotencyKey = opts.idempotencyKey ?? `cli-proj-create-${randomUUID()}`;
     // P2-6: gate idempotency-key output behind --verbose/--debug/json (matches
@@ -182,11 +203,8 @@ export async function runCreate(
     return sample;
   }
 
-  // Resolve password: flag > file > none
-  let password = opts.password;
-  if (password === undefined && opts.passwordFile !== undefined) {
-    password = readFileSync(opts.passwordFile, 'utf8').trim();
-  }
+  // Resolve password: flag > file > none.
+  const password = resolvePassword(opts);
 
   const idempotencyKey = opts.idempotencyKey ?? `cli-proj-create-${randomUUID()}`;
   if (opts.idempotencyKey === undefined && (opts.output === 'json' || opts.verbose || opts.debug)) {
@@ -254,11 +272,8 @@ export async function runUpdate(
     throw localValidationError('--description must be at most 2000 characters');
   }
 
-  // Resolve password
-  let password = opts.password;
-  if (password === undefined && opts.passwordFile !== undefined) {
-    password = readFileSync(opts.passwordFile, 'utf8').trim();
-  }
+  // Resolve password: flag > file > none.
+  const password = resolvePassword(opts);
 
   // P2-7: guard --url against localhost/RFC1918/non-http(s).
   if (opts.targetUrl !== undefined) {


### PR DESCRIPTION
## Summary

- reject blank or whitespace-only inline `--password` values for `project create` and `project update` before any request is sent
- keep non-empty passwords byte-for-byte, including surrounding spaces
- reuse the existing `requireString` validation path and add regression coverage

Fixes #88.

## Testing

- `npm test -- --run src/commands/project.test.ts`
- `npm run typecheck`
- `npm run lint`

## CLI improvement bounty

If this qualifies for the CLI improvement bounty, preferred payout address is USDT on BSC/BEP20: `0x440415590cce63257067a4c3a0b46e5f1b041a08`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for inline password input during project creation and update.
  * Empty or whitespace-only passwords are now rejected with a validation error before any request is sent.
  * Non-empty passwords keep their surrounding spaces when submitted, matching what was entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->