### PR TITLE
feat(lib): add structured session logger and secret redaction utility

### DIFF
--- a/src/lib/duration.test.ts
+++ b/src/lib/duration.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+import { formatDuration, parseDuration, requireDuration } from './duration.js';
+import { ApiError } from './errors.js';
+
+describe('parseDuration', () => {
+  describe('valid inputs', () => {
+    it('parses hours', () => {
+      expect(parseDuration('4h')).toBe(4 * 3_600_000);
+    });
+
+    it('parses minutes', () => {
+      expect(parseDuration('30m')).toBe(30 * 60_000);
+    });
+
+    it('parses seconds', () => {
+      expect(parseDuration('45s')).toBe(45 * 1_000);
+    });
+
+    it('parses compound h+m', () => {
+      expect(parseDuration('1h30m')).toBe(1 * 3_600_000 + 30 * 60_000);
+    });
+
+    it('parses compound h+m+s', () => {
+      expect(parseDuration('2h15m30s')).toBe(2 * 3_600_000 + 15 * 60_000 + 30 * 1_000);
+    });
+
+    it('parses compound m+s', () => {
+      expect(parseDuration('5m30s')).toBe(5 * 60_000 + 30 * 1_000);
+    });
+
+    it('parses fractional hours', () => {
+      expect(parseDuration('1.5h')).toBe(5_400_000);
+    });
+
+    it('parses fractional minutes', () => {
+      expect(parseDuration('2.5m')).toBe(150_000);
+    });
+
+    it('parses fractional seconds', () => {
+      expect(parseDuration('1.5s')).toBe(1_500);
+    });
+
+    it('is case-insensitive', () => {
+      expect(parseDuration('4H')).toBe(4 * 3_600_000);
+      expect(parseDuration('30M')).toBe(30 * 60_000);
+      expect(parseDuration('45S')).toBe(45 * 1_000);
+      expect(parseDuration('1H30M')).toBe(1 * 3_600_000 + 30 * 60_000);
+    });
+
+    it('trims whitespace', () => {
+      expect(parseDuration('  4h  ')).toBe(4 * 3_600_000);
+    });
+
+    it('parses 1s (minimum practical duration)', () => {
+      expect(parseDuration('1s')).toBe(1_000);
+    });
+
+    it('parses 24h (maximum allowed)', () => {
+      expect(parseDuration('24h')).toBe(24 * 3_600_000);
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('rejects empty string', () => {
+      expect(() => parseDuration('')).toThrow(ApiError);
+    });
+
+    it('rejects whitespace-only string', () => {
+      expect(() => parseDuration('   ')).toThrow(ApiError);
+    });
+
+    it('rejects bare number without unit', () => {
+      expect(() => parseDuration('120')).toThrow(ApiError);
+    });
+
+    it('rejects unit without number', () => {
+      expect(() => parseDuration('h')).toThrow(ApiError);
+    });
+
+    it('rejects unsupported units', () => {
+      expect(() => parseDuration('4d')).toThrow(ApiError);
+      expect(() => parseDuration('2w')).toThrow(ApiError);
+    });
+
+    it('rejects spaces between segments', () => {
+      expect(() => parseDuration('1h 30m')).toThrow(ApiError);
+    });
+
+    it('rejects duplicate units', () => {
+      expect(() => parseDuration('1h2h')).toThrow(ApiError);
+      expect(() => parseDuration('1m2m')).toThrow(ApiError);
+      expect(() => parseDuration('1s2s')).toThrow(ApiError);
+    });
+
+    it('rejects zero duration', () => {
+      expect(() => parseDuration('0h')).toThrow(ApiError);
+      expect(() => parseDuration('0m')).toThrow(ApiError);
+      expect(() => parseDuration('0s')).toThrow(ApiError);
+      expect(() => parseDuration('0h0m0s')).toThrow(ApiError);
+    });
+
+    it('rejects duration exceeding 24 hours', () => {
+      expect(() => parseDuration('25h')).toThrow(ApiError);
+      expect(() => parseDuration('24h1s')).toThrow(ApiError);
+      expect(() => parseDuration('1500m')).toThrow(ApiError);
+    });
+
+    it('rejects non-string-like inputs via the grammar', () => {
+      expect(() => parseDuration('abc')).toThrow(ApiError);
+      expect(() => parseDuration('--4h')).toThrow(ApiError);
+      expect(() => parseDuration('4h-')).toThrow(ApiError);
+    });
+  });
+
+  describe('error messages', () => {
+    it('includes the field name in the error', () => {
+      try {
+        parseDuration('', 'maxDuration');
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        const apiErr = err as ApiError;
+        expect(apiErr.code).toBe('VALIDATION_ERROR');
+        expect(apiErr.exitCode).toBe(5);
+        expect(apiErr.nextAction).toContain('--max-duration');
+      }
+    });
+
+    it('uses the default field name when not specified', () => {
+      try {
+        parseDuration('');
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        const apiErr = err as ApiError;
+        expect(apiErr.nextAction).toContain('--duration');
+      }
+    });
+
+    it('includes the formatted excess duration in the message', () => {
+      try {
+        parseDuration('25h');
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        const apiErr = err as ApiError;
+        expect(apiErr.nextAction).toContain('24 hours');
+      }
+    });
+
+    it('mentions duplicate unit in the message', () => {
+      try {
+        parseDuration('1h2h');
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        const apiErr = err as ApiError;
+        expect(apiErr.nextAction).toContain('duplicate');
+        expect(apiErr.nextAction).toContain('"h"');
+      }
+    });
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats hours only', () => {
+    expect(formatDuration(3_600_000)).toBe('1h');
+    expect(formatDuration(7_200_000)).toBe('2h');
+  });
+
+  it('formats minutes only', () => {
+    expect(formatDuration(60_000)).toBe('1m');
+    expect(formatDuration(1_800_000)).toBe('30m');
+  });
+
+  it('formats seconds only', () => {
+    expect(formatDuration(1_000)).toBe('1s');
+    expect(formatDuration(45_000)).toBe('45s');
+  });
+
+  it('formats hours + minutes', () => {
+    expect(formatDuration(5_400_000)).toBe('1h 30m');
+  });
+
+  it('formats hours + minutes + seconds', () => {
+    expect(formatDuration(8_130_000)).toBe('2h 15m 30s');
+  });
+
+  it('formats minutes + seconds', () => {
+    expect(formatDuration(90_000)).toBe('1m 30s');
+  });
+
+  it('formats sub-second as "<1s"', () => {
+    expect(formatDuration(500)).toBe('<1s');
+    expect(formatDuration(1)).toBe('<1s');
+    expect(formatDuration(999)).toBe('<1s');
+  });
+
+  it('formats zero as "0s"', () => {
+    expect(formatDuration(0)).toBe('0s');
+  });
+
+  it('formats negative as "0s"', () => {
+    expect(formatDuration(-1000)).toBe('0s');
+  });
+
+  it('truncates fractional seconds (floor)', () => {
+    // 1500ms = 1s + 500ms remainder → "1s" (floor to whole seconds)
+    expect(formatDuration(1_500)).toBe('1s');
+  });
+
+  it('formats large durations', () => {
+    expect(formatDuration(24 * 3_600_000)).toBe('24h');
+    expect(formatDuration(23 * 3_600_000 + 59 * 60_000 + 59 * 1_000)).toBe('23h 59m 59s');
+  });
+});
+
+describe('requireDuration', () => {
+  it('returns milliseconds for valid input', () => {
+    expect(requireDuration('4h')).toBe(4 * 3_600_000);
+  });
+
+  it('rejects below minimum', () => {
+    expect(() => requireDuration('30s', 'maxDuration', { min: 60_000 })).toThrow(ApiError);
+    try {
+      requireDuration('30s', 'maxDuration', { min: 60_000 });
+      expect.fail('should have thrown');
+    } catch (err) {
+      const apiErr = err as ApiError;
+      expect(apiErr.nextAction).toContain('at least');
+      expect(apiErr.nextAction).toContain('1m');
+    }
+  });
+
+  it('rejects above maximum', () => {
+    expect(() => requireDuration('5h', 'maxDuration', { max: 4 * 3_600_000 })).toThrow(ApiError);
+    try {
+      requireDuration('5h', 'maxDuration', { max: 4 * 3_600_000 });
+      expect.fail('should have thrown');
+    } catch (err) {
+      const apiErr = err as ApiError;
+      expect(apiErr.nextAction).toContain('must not exceed');
+      expect(apiErr.nextAction).toContain('4h');
+    }
+  });
+
+  it('accepts value at minimum boundary', () => {
+    expect(requireDuration('1m', 'timeout', { min: 60_000 })).toBe(60_000);
+  });
+
+  it('accepts value at maximum boundary', () => {
+    expect(requireDuration('4h', 'timeout', { max: 4 * 3_600_000 })).toBe(4 * 3_600_000);
+  });
+
+  it('accepts value within both bounds', () => {
+    expect(requireDuration('2h', 'timeout', { min: 60_000, max: 4 * 3_600_000 })).toBe(7_200_000);
+  });
+
+  it('propagates parse errors', () => {
+    expect(() => requireDuration('abc')).toThrow(ApiError);
+  });
+});

--- a/src/lib/duration.ts
+++ b/src/lib/duration.ts
@@ -80,23 +80,20 @@ const UNIT_MS: Record<string, number> = {
  *   or exceeds the 24-hour ceiling.
  */
 export function parseDuration(input: string, field = 'duration'): number {
+  /** Throw a VALIDATION_ERROR scoped to `field` with flag formatting. */
+  const fail = (reason: string): never => {
+    throw localValidationError(field, reason, undefined, 'flag');
+  };
+
   const trimmed = input.trim();
 
   if (trimmed === '') {
-    throw localValidationError(
-      field,
-      'must be a duration string (e.g. "4h", "30m", "1h30m")',
-      undefined,
-      'flag',
-    );
+    fail('must be a duration string (e.g. "4h", "30m", "1h30m")');
   }
 
   if (!DURATION_RE.test(trimmed)) {
-    throw localValidationError(
-      field,
+    fail(
       'must be a duration string using h (hours), m (minutes), s (seconds) — e.g. "4h", "30m", "1h30m", "2h15m30s"',
-      undefined,
-      'flag',
     );
   }
 
@@ -109,12 +106,7 @@ export function parseDuration(input: string, field = 'duration'): number {
     const unit = match[2]!.toLowerCase();
 
     if (seen.has(unit)) {
-      throw localValidationError(
-        field,
-        `contains duplicate unit "${unit}" — each unit (h, m, s) may appear at most once`,
-        undefined,
-        'flag',
-      );
+      fail(`contains duplicate unit "${unit}" — each unit (h, m, s) may appear at most once`);
     }
     seen.add(unit);
 
@@ -126,16 +118,11 @@ export function parseDuration(input: string, field = 'duration'): number {
   totalMs = Math.round(totalMs);
 
   if (totalMs <= 0) {
-    throw localValidationError(field, 'must be a positive duration', undefined, 'flag');
+    fail('must be a positive duration');
   }
 
   if (totalMs > MAX_DURATION_MS) {
-    throw localValidationError(
-      field,
-      `must not exceed 24 hours (got ${formatDuration(totalMs)})`,
-      undefined,
-      'flag',
-    );
+    fail(`must not exceed 24 hours (got ${formatDuration(totalMs)})`);
   }
 
   return totalMs;
@@ -189,22 +176,17 @@ export function requireDuration(
   const ms = parseDuration(input, field);
   const { min, max } = opts;
 
+  /** Throw a VALIDATION_ERROR scoped to `field` with flag formatting. */
+  const fail = (reason: string): never => {
+    throw localValidationError(field, reason, undefined, 'flag');
+  };
+
   if (min !== undefined && ms < min) {
-    throw localValidationError(
-      field,
-      `must be at least ${formatDuration(min)} (got ${formatDuration(ms)})`,
-      undefined,
-      'flag',
-    );
+    fail(`must be at least ${formatDuration(min)} (got ${formatDuration(ms)})`);
   }
 
   if (max !== undefined && ms > max) {
-    throw localValidationError(
-      field,
-      `must not exceed ${formatDuration(max)} (got ${formatDuration(ms)})`,
-      undefined,
-      'flag',
-    );
+    fail(`must not exceed ${formatDuration(max)} (got ${formatDuration(ms)})`);
   }
 
   return ms;

--- a/src/lib/duration.ts
+++ b/src/lib/duration.ts
@@ -1,0 +1,211 @@
+/**
+ * Human-readable duration parser and formatter.
+ *
+ * Parses strings like `"4h"`, `"30m"`, `"45s"`, `"1h30m"`, `"2h15m30s"`
+ * into milliseconds, and formats milliseconds back into concise
+ * human-readable text.
+ *
+ * Design notes:
+ *   - Only hours (`h`), minutes (`m`), and seconds (`s`) are supported.
+ *     Days and larger units are intentionally omitted — they introduce
+ *     DST and calendar ambiguity that a CLI should not silently absorb.
+ *   - Bare numbers without a unit are rejected. This avoids the
+ *     "is 120 seconds or minutes?" ambiguity that plagues many CLIs.
+ *   - The parser is case-insensitive (`4H30M` works).
+ *   - Fractional values (e.g. `1.5h`) are supported within each segment.
+ *   - Negative durations and zero are rejected; a duration represents a
+ *     strictly positive time span.
+ *   - Maximum duration is capped at 24 hours to prevent accidental
+ *     multi-day sessions.
+ *   - Integrates with the existing `localValidationError` helper so
+ *     error wording and exit codes stay consistent with the rest of
+ *     the CLI (exit 5, VALIDATION_ERROR).
+ *
+ * @example
+ *   parseDuration('4h');        // 14_400_000
+ *   parseDuration('30m');       //  1_800_000
+ *   parseDuration('1h30m');     //  5_400_000
+ *   parseDuration('2h15m30s'); //  8_130_000
+ *   formatDuration(5_400_000); // '1h 30m'
+ */
+
+import { localValidationError } from './errors.js';
+
+/** 24 hours in milliseconds — hard ceiling for parsed durations. */
+const MAX_DURATION_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Matches one or more `<number><unit>` segments. Each segment is a
+ * (possibly fractional) number followed by one of `h`, `m`, `s`.
+ *
+ * The regex validates that the ENTIRE string is composed exclusively
+ * of `<number><unit>` segments with no stray characters.
+ *
+ * Examples that match: `4h`, `30m`, `1h30m`, `2h15m30s`, `1.5h`
+ * Examples that don't: `4`, `h30`, `4h 30m` (space), `4x`, ``
+ */
+const DURATION_RE = /^(?:\d+(?:\.\d+)?[hms])+$/i;
+
+/**
+ * Captures individual `<number><unit>` segments for iteration.
+ * Used with `matchAll` after the full-string regex has validated shape.
+ */
+const SEGMENT_RE = /(\d+(?:\.\d+)?)([hms])/gi;
+
+/** Unit multipliers to convert each segment to milliseconds. */
+const UNIT_MS: Record<string, number> = {
+  h: 3_600_000,
+  m: 60_000,
+  s: 1_000,
+};
+
+/**
+ * Parse a human-readable duration string into milliseconds.
+ *
+ * Accepted formats:
+ *   - `"4h"` — 4 hours
+ *   - `"30m"` — 30 minutes
+ *   - `"45s"` — 45 seconds
+ *   - `"1h30m"` — 1 hour 30 minutes
+ *   - `"2h15m30s"` — 2 hours 15 minutes 30 seconds
+ *   - `"1.5h"` — 1 hour 30 minutes (fractional)
+ *
+ * @param input  The raw duration string.
+ * @param field  Field name for error messages (default: `'duration'`).
+ *               Passed as a CLI flag name to `localValidationError`.
+ * @returns Duration in milliseconds (always a positive integer).
+ *
+ * @throws {ApiError} VALIDATION_ERROR (exit 5) when the input is
+ *   empty, malformed, zero, negative (impossible given the grammar),
+ *   or exceeds the 24-hour ceiling.
+ */
+export function parseDuration(input: string, field = 'duration'): number {
+  const trimmed = input.trim();
+
+  if (trimmed === '') {
+    throw localValidationError(
+      field,
+      'must be a duration string (e.g. "4h", "30m", "1h30m")',
+      undefined,
+      'flag',
+    );
+  }
+
+  if (!DURATION_RE.test(trimmed)) {
+    throw localValidationError(
+      field,
+      'must be a duration string using h (hours), m (minutes), s (seconds) — e.g. "4h", "30m", "1h30m", "2h15m30s"',
+      undefined,
+      'flag',
+    );
+  }
+
+  // Track which units have been seen to reject duplicates like `1h2h`.
+  const seen = new Set<string>();
+  let totalMs = 0;
+
+  for (const match of trimmed.matchAll(SEGMENT_RE)) {
+    const value = parseFloat(match[1]!);
+    const unit = match[2]!.toLowerCase();
+
+    if (seen.has(unit)) {
+      throw localValidationError(
+        field,
+        `contains duplicate unit "${unit}" — each unit (h, m, s) may appear at most once`,
+        undefined,
+        'flag',
+      );
+    }
+    seen.add(unit);
+
+    totalMs += value * UNIT_MS[unit]!;
+  }
+
+  // Round to the nearest integer millisecond to avoid floating-point drift
+  // from fractional segments like `1.5h`.
+  totalMs = Math.round(totalMs);
+
+  if (totalMs <= 0) {
+    throw localValidationError(field, 'must be a positive duration', undefined, 'flag');
+  }
+
+  if (totalMs > MAX_DURATION_MS) {
+    throw localValidationError(
+      field,
+      `must not exceed 24 hours (got ${formatDuration(totalMs)})`,
+      undefined,
+      'flag',
+    );
+  }
+
+  return totalMs;
+}
+
+/**
+ * Format a duration in milliseconds to a concise human-readable string.
+ *
+ * Output uses the largest applicable units with no leading zeros:
+ *   - `formatDuration(5_400_000)` → `"1h 30m"`
+ *   - `formatDuration(90_000)` → `"1m 30s"`
+ *   - `formatDuration(3_600_000)` → `"1h"`
+ *   - `formatDuration(1_000)` → `"1s"`
+ *   - `formatDuration(500)` → `"<1s"`
+ *
+ * @param ms Non-negative duration in milliseconds.
+ * @returns Human-readable duration string.
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 0) return '0s';
+  if (ms < 1000) return ms > 0 ? '<1s' : '0s';
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const parts: string[] = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0) parts.push(`${seconds}s`);
+
+  return parts.join(' ') || '0s';
+}
+
+/**
+ * Convenience: validate that a raw string is a valid duration within
+ * the given bounds. Returns the parsed milliseconds.
+ *
+ * @param input  Raw duration string.
+ * @param field  Flag/field name for error messages.
+ * @param opts.min  Minimum duration in milliseconds (inclusive).
+ * @param opts.max  Maximum duration in milliseconds (inclusive).
+ *                  Defaults to 24 hours.
+ */
+export function requireDuration(
+  input: string,
+  field = 'duration',
+  opts: { min?: number; max?: number } = {},
+): number {
+  const ms = parseDuration(input, field);
+  const { min, max } = opts;
+
+  if (min !== undefined && ms < min) {
+    throw localValidationError(
+      field,
+      `must be at least ${formatDuration(min)} (got ${formatDuration(ms)})`,
+      undefined,
+      'flag',
+    );
+  }
+
+  if (max !== undefined && ms > max) {
+    throw localValidationError(
+      field,
+      `must not exceed ${formatDuration(max)} (got ${formatDuration(ms)})`,
+      undefined,
+      'flag',
+    );
+  }
+
+  return ms;
+}

--- a/src/lib/redact.test.ts
+++ b/src/lib/redact.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { createRedactor, redactSecrets } from './redact.js';
+
+describe('redactSecrets', () => {
+  describe('API keys (sk- prefix)', () => {
+    it('redacts TestSprite API keys', () => {
+      const input = 'Using key sk-abcdef1234567890abcdef';
+      expect(redactSecrets(input)).toBe('Using key [REDACTED:api-key]');
+    });
+
+    it('redacts API keys embedded in config lines', () => {
+      const input = 'api_key = sk-abcdef1234567890abcdef1234';
+      expect(redactSecrets(input)).toBe('api_key = [REDACTED:api-key]');
+    });
+
+    it('does not redact short sk- prefixes (< 20 chars)', () => {
+      const input = 'sk-short';
+      expect(redactSecrets(input)).toBe('sk-short');
+    });
+
+    it('redacts multiple keys in one string', () => {
+      const input = 'key1=sk-aaaabbbbccccddddeeeeffffgggg key2=sk-11112222333344445555666677778888';
+      const result = redactSecrets(input);
+      expect(result).not.toContain('sk-aaaa');
+      expect(result).not.toContain('sk-1111');
+      expect(result.match(/\[REDACTED:api-key\]/g)).toHaveLength(2);
+    });
+  });
+
+  describe('bearer tokens', () => {
+    it('redacts Bearer authorization headers', () => {
+      const input = 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature';
+      expect(redactSecrets(input)).toBe('Authorization: [REDACTED:bearer-token]');
+    });
+
+    it('is case-insensitive for bearer keyword', () => {
+      const input = 'bearer abcdefghijklmnopqrstuvwxyz1234';
+      expect(redactSecrets(input)).toBe('[REDACTED:bearer-token]');
+    });
+  });
+
+  describe('token patterns', () => {
+    it('redacts token= assignments', () => {
+      const input = 'token=abc123def456ghi789jkl012mno345';
+      expect(redactSecrets(input)).toBe('[REDACTED:token]');
+    });
+
+    it('redacts access_token values', () => {
+      const input = 'access_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"';
+      expect(redactSecrets(input)).toBe('[REDACTED:token]');
+    });
+
+    it('redacts refresh_token values', () => {
+      const input = "refresh_token='abc123def456ghi789jkl012mno345pqr'";
+      expect(redactSecrets(input)).toBe('[REDACTED:token]');
+    });
+  });
+
+  describe('URL passwords', () => {
+    it('redacts password in URL while preserving structure', () => {
+      const input = 'https://admin:supersecretpassword@db.example.com:5432/mydb';
+      const result = redactSecrets(input);
+      expect(result).toContain('admin');
+      expect(result).toContain('[REDACTED:url-password]');
+      expect(result).toContain('db.example.com');
+      expect(result).not.toContain('supersecretpassword');
+    });
+
+    it('redacts password in multiple URLs', () => {
+      const input = 'db=postgres://user:pass123@host1 cache=redis://app:secret456@host2';
+      const result = redactSecrets(input);
+      expect(result).not.toContain('pass123');
+      expect(result).not.toContain('secret456');
+    });
+  });
+
+  describe('AWS keys', () => {
+    it('redacts AWS access key IDs', () => {
+      const input = 'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE';
+      expect(redactSecrets(input)).toBe('AWS_ACCESS_KEY_ID=[REDACTED:aws-key]');
+    });
+  });
+
+  describe('GitHub tokens', () => {
+    it('redacts ghp_ personal access tokens', () => {
+      const input = 'GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn';
+      expect(redactSecrets(input)).toBe('GITHUB_TOKEN=[REDACTED:github-token]');
+    });
+
+    it('redacts gho_ OAuth tokens', () => {
+      const input = 'token=gho_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn';
+      // token= pattern may match first, but the key point is no token leaks
+      const result = redactSecrets(input);
+      expect(result).not.toContain('gho_ABCDEF');
+    });
+  });
+
+  describe('hex secrets', () => {
+    it('redacts 32+ char hex strings', () => {
+      const input = 'hash=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4';
+      expect(redactSecrets(input)).toContain('[REDACTED:hex-secret]');
+    });
+
+    it('does not redact short hex strings', () => {
+      const input = 'short=abcdef123456';
+      expect(redactSecrets(input)).toBe('short=abcdef123456');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty string unchanged', () => {
+      expect(redactSecrets('')).toBe('');
+    });
+
+    it('returns non-secret text unchanged', () => {
+      const input = 'Running test suite for project checkout-flow...';
+      expect(redactSecrets(input)).toBe(input);
+    });
+
+    it('is idempotent — redacting twice gives the same result', () => {
+      const input = 'key=sk-abcdef1234567890abcdef';
+      const once = redactSecrets(input);
+      const twice = redactSecrets(once);
+      expect(twice).toBe(once);
+    });
+
+    it('handles multiline input', () => {
+      const input = [
+        'config loaded',
+        'api_key = sk-abcdef1234567890abcdef',
+        'endpoint = https://api.testsprite.com',
+      ].join('\n');
+      const result = redactSecrets(input);
+      expect(result).toContain('[REDACTED:api-key]');
+      expect(result).toContain('https://api.testsprite.com');
+    });
+  });
+});
+
+describe('createRedactor', () => {
+  it('applies custom patterns before defaults', () => {
+    const redact = createRedactor([{ name: 'internal-key', regex: /\bINT-[A-Za-z0-9]{24,}\b/g }]);
+    const input = 'key=INT-abcdefghijklmnopqrstuvwx';
+    expect(redact(input)).toBe('key=[REDACTED:internal-key]');
+  });
+
+  it('still applies default patterns', () => {
+    const redact = createRedactor([]);
+    const input = 'key=sk-abcdef1234567890abcdef';
+    expect(redact(input)).toBe('key=[REDACTED:api-key]');
+  });
+
+  it('custom patterns take priority over defaults', () => {
+    const redact = createRedactor([{ name: 'custom-sk', regex: /\bsk-[A-Za-z0-9]+\b/g }]);
+    // Custom runs first and catches the key
+    const input = 'key=sk-abcdef1234567890abcdef';
+    expect(redact(input)).toBe('key=[REDACTED:custom-sk]');
+  });
+});

--- a/src/lib/redact.test.ts
+++ b/src/lib/redact.test.ts
@@ -105,6 +105,16 @@ describe('redactSecrets', () => {
       const input = 'short=abcdef123456';
       expect(redactSecrets(input)).toBe('short=abcdef123456');
     });
+
+    it('redacts uppercase hex strings', () => {
+      const input = 'hash=A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4';
+      expect(redactSecrets(input)).toContain('[REDACTED:hex-secret]');
+    });
+
+    it('redacts mixed-case hex strings', () => {
+      const input = 'hash=a1B2c3D4e5F6a1B2c3D4e5F6a1B2c3D4';
+      expect(redactSecrets(input)).toContain('[REDACTED:hex-secret]');
+    });
   });
 
   describe('edge cases', () => {

--- a/src/lib/redact.test.ts
+++ b/src/lib/redact.test.ts
@@ -72,6 +72,14 @@ describe('redactSecrets', () => {
       expect(result).not.toContain('pass123');
       expect(result).not.toContain('secret456');
     });
+
+    it('handles username that is a substring of the password pattern', () => {
+      const input = 'redis://adminpass:realpassword@cache.internal:6379';
+      const result = redactSecrets(input);
+      expect(result).toContain('adminpass');
+      expect(result).toContain('[REDACTED:url-password]');
+      expect(result).not.toContain('realpassword');
+    });
   });
 
   describe('AWS keys', () => {

--- a/src/lib/redact.ts
+++ b/src/lib/redact.ts
@@ -64,8 +64,9 @@ export const DEFAULT_PATTERNS: readonly RedactionPattern[] = [
   { name: 'github-token', regex: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/g },
 
   // Generic hex secrets: 32+ consecutive hex chars (SHA-256, API keys, etc.)
-  // Only matches lowercase or mixed-case to reduce false positives on UUIDs.
-  { name: 'hex-secret', regex: /\b[0-9a-f]{32,}\b/g },
+  // Matches lowercase, uppercase, and mixed-case hex to avoid leaking secrets,
+  // consistent with the false-positive-over-false-negative principle above.
+  { name: 'hex-secret', regex: /\b[0-9a-fA-F]{32,}\b/g },
 ];
 
 /**

--- a/src/lib/redact.ts
+++ b/src/lib/redact.ts
@@ -1,0 +1,138 @@
+/**
+ * Secret-redaction utility for CLI output, logs, and future TTS content.
+ *
+ * Scans strings for patterns that look like secrets — API keys, bearer
+ * tokens, passwords in URLs, and generic high-entropy hex/base64 strings
+ * — and replaces them with a fixed placeholder so they never appear in
+ * terminal output, persisted logs, checkpoints, or spoken announcements.
+ *
+ * Design notes:
+ *   - Patterns are intentionally broad rather than precise. A false
+ *     positive (redacting a harmless string) is always preferable to a
+ *     false negative (leaking a real secret).
+ *   - The replacement placeholder includes the pattern name so an
+ *     operator can tell *which* kind of value was removed without
+ *     seeing the value itself.
+ *   - `redactSecrets` is idempotent — running it twice on already-
+ *     redacted text produces the same output.
+ *   - Custom patterns can be added via `createRedactor` for project-
+ *     specific secret formats.
+ *   - This module has zero external dependencies.
+ */
+
+/** Default placeholder template. `{name}` is replaced by the pattern label. */
+const DEFAULT_PLACEHOLDER = '[REDACTED:{name}]';
+
+/**
+ * A named pattern that matches secret-shaped text.
+ *
+ * @param name   Human-readable label included in the placeholder
+ *               (e.g. `"api-key"`, `"bearer-token"`).
+ * @param regex  Pattern to match. Must use the global flag (`g`) so
+ *               `String.replace` replaces every occurrence.
+ */
+export interface RedactionPattern {
+  name: string;
+  regex: RegExp;
+}
+
+/**
+ * Built-in patterns covering the most common secret shapes seen in
+ * CLI / API environments. Ordered from most-specific to most-generic
+ * so specific labels win when patterns overlap.
+ */
+export const DEFAULT_PATTERNS: readonly RedactionPattern[] = [
+  // TestSprite API keys: `sk-` followed by 20+ alphanumeric chars
+  { name: 'api-key', regex: /\bsk-[A-Za-z0-9]{20,}\b/g },
+
+  // Bearer / token authorization header values
+  { name: 'bearer-token', regex: /\b[Bb]earer\s+[A-Za-z0-9._~+/=-]{20,}\b/g },
+
+  // Generic `token=<value>` or `token: <value>` in logs/config
+  {
+    name: 'token',
+    regex: /\b(?:token|access_token|refresh_token)[=:]\s*['"]?[A-Za-z0-9._~+/=-]{16,}['"]?/gi,
+  },
+
+  // Password in URLs: `://user:password@host`
+  { name: 'url-password', regex: /:\/\/[^@/\s]+:([^@/\s]+)@/g },
+
+  // AWS-style keys: AKIA followed by 16 uppercase alphanumeric
+  { name: 'aws-key', regex: /\bAKIA[A-Z0-9]{16}\b/g },
+
+  // GitHub tokens: ghp_, gho_, ghu_, ghs_, ghr_ prefix
+  { name: 'github-token', regex: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/g },
+
+  // Generic hex secrets: 32+ consecutive hex chars (SHA-256, API keys, etc.)
+  // Only matches lowercase or mixed-case to reduce false positives on UUIDs.
+  { name: 'hex-secret', regex: /\b[0-9a-f]{32,}\b/g },
+];
+
+/**
+ * Redact secrets from a string using the default built-in patterns.
+ *
+ * @param input  The string to scan and redact.
+ * @returns A new string with every matched secret replaced by a
+ *   `[REDACTED:<pattern-name>]` placeholder.
+ *
+ * @example
+ *   redactSecrets('key=sk-abc123def456ghi789jkl012')
+ *   // → 'key=[REDACTED:api-key]'
+ *
+ *   redactSecrets('Authorization: Bearer eyJhbGciOiJIUzI...')
+ *   // → 'Authorization: [REDACTED:bearer-token]'
+ */
+export function redactSecrets(input: string): string {
+  return redactWithPatterns(input, DEFAULT_PATTERNS);
+}
+
+/**
+ * Create a custom redactor with additional project-specific patterns
+ * prepended to the built-in defaults. Custom patterns take precedence
+ * because they run first.
+ *
+ * @param extraPatterns  Additional patterns to match before the defaults.
+ * @returns A redaction function with the same signature as `redactSecrets`.
+ *
+ * @example
+ *   const redact = createRedactor([
+ *     { name: 'internal-key', regex: /\bINT-[A-Za-z0-9]{24}\b/g },
+ *   ]);
+ *   redact('token REDACTED key=INT-abc123...')
+ */
+export function createRedactor(
+  extraPatterns: readonly RedactionPattern[],
+): (input: string) => string {
+  const allPatterns = [...extraPatterns, ...DEFAULT_PATTERNS];
+  return (input: string) => redactWithPatterns(input, allPatterns);
+}
+
+/**
+ * Internal: apply an ordered list of patterns to a string, replacing
+ * every match with a labelled placeholder.
+ *
+ * Each pattern's regex is cloned via `new RegExp` so the shared global
+ * regex's `lastIndex` is reset on every call — without this, consecutive
+ * calls to `redactSecrets` on different strings would skip matches
+ * because `RegExp.prototype[Symbol.replace]` with a `g` flag mutates
+ * `lastIndex`.
+ */
+function redactWithPatterns(input: string, patterns: readonly RedactionPattern[]): string {
+  let result = input;
+  for (const pattern of patterns) {
+    const placeholder = DEFAULT_PLACEHOLDER.replace('{name}', pattern.name);
+    // Clone to reset lastIndex — global regexes are stateful.
+    const freshRegex = new RegExp(pattern.regex.source, pattern.regex.flags);
+
+    if (pattern.name === 'url-password') {
+      // Special handling: only redact the password capture group, not the
+      // entire URL structure. Replace `://user:PASSWORD@` with `://user:[REDACTED]@`.
+      result = result.replace(freshRegex, (match, password: string) =>
+        match.replace(password, placeholder),
+      );
+    } else {
+      result = result.replace(freshRegex, placeholder);
+    }
+  }
+  return result;
+}

--- a/src/lib/session-logger.test.ts
+++ b/src/lib/session-logger.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it } from 'vitest';
+import { SessionLogger } from './session-logger.js';
+import type { LogLevel } from './session-logger.js';
+
+/** Collect log lines in an array for assertion. */
+function createSink(): { lines: string[]; writer: (line: string) => void } {
+  const lines: string[] = [];
+  return { lines, writer: (line: string) => lines.push(line) };
+}
+
+/** Fixed clock for deterministic timestamps. */
+const FIXED_CLOCK = () => '2026-01-15T10:30:00.000Z';
+
+/** Fixed correlation ID for deterministic output. */
+const FIXED_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+describe('SessionLogger', () => {
+  describe('construction', () => {
+    it('mints a correlation ID when none is provided', () => {
+      const logger = new SessionLogger({ writer: () => {} });
+      expect(logger.getCorrelationId()).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+    });
+
+    it('uses the provided correlation ID', () => {
+      const logger = new SessionLogger({ correlationId: FIXED_ID, writer: () => {} });
+      expect(logger.getCorrelationId()).toBe(FIXED_ID);
+    });
+
+    it('defaults to info level', () => {
+      const logger = new SessionLogger({ writer: () => {} });
+      expect(logger.getLevel()).toBe('info');
+    });
+  });
+
+  describe('level filtering', () => {
+    it('emits entries at or above the minimum level', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        level: 'info',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.debug('should be hidden');
+      logger.info('should appear');
+      logger.warn('should appear');
+      logger.error('should appear');
+
+      expect(sink.lines).toHaveLength(3);
+    });
+
+    it('emits all entries at debug level', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        level: 'debug',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.debug('d');
+      logger.info('i');
+      logger.warn('w');
+      logger.error('e');
+
+      expect(sink.lines).toHaveLength(4);
+    });
+
+    it('emits only error entries at error level', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        level: 'error',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.debug('d');
+      logger.info('i');
+      logger.warn('w');
+      logger.error('e');
+
+      expect(sink.lines).toHaveLength(1);
+      expect(sink.lines[0]).toContain('[ERROR]');
+    });
+  });
+
+  describe('setLevel', () => {
+    it('changes the minimum level at runtime', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        level: 'error',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.info('hidden');
+      expect(sink.lines).toHaveLength(0);
+
+      logger.setLevel('debug');
+      logger.info('visible');
+      expect(sink.lines).toHaveLength(1);
+    });
+  });
+
+  describe('text format', () => {
+    it('produces human-readable lines', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        format: 'text',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.info('Iteration 3 completed');
+      expect(sink.lines[0]).toBe(
+        '2026-01-15T10:30:00.000Z [INFO] (aaaaaaaa) Iteration 3 completed',
+      );
+    });
+
+    it('appends JSON data when provided', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        format: 'text',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.info('Test passed', { testId: 't-123', duration: 4500 });
+      expect(sink.lines[0]).toContain('{"testId":"t-123","duration":4500}');
+    });
+
+    it('includes the correct level tag for each level', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        format: 'text',
+        level: 'debug',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      const levels: LogLevel[] = ['debug', 'info', 'warn', 'error'];
+      for (const lvl of levels) logger[lvl](`msg-${lvl}`);
+
+      expect(sink.lines[0]).toContain('[DEBUG]');
+      expect(sink.lines[1]).toContain('[INFO]');
+      expect(sink.lines[2]).toContain('[WARN]');
+      expect(sink.lines[3]).toContain('[ERROR]');
+    });
+  });
+
+  describe('JSONL format', () => {
+    it('produces valid JSON per line', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        format: 'jsonl',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.info('Starting session');
+      const entry = JSON.parse(sink.lines[0]!);
+      expect(entry.timestamp).toBe('2026-01-15T10:30:00.000Z');
+      expect(entry.level).toBe('info');
+      expect(entry.message).toBe('Starting session');
+      expect(entry.correlationId).toBe(FIXED_ID);
+    });
+
+    it('includes data field when provided', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        format: 'jsonl',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.info('Progress', { iteration: 5, progress: 0.42 });
+      const entry = JSON.parse(sink.lines[0]!);
+      expect(entry.data).toEqual({ iteration: 5, progress: 0.42 });
+    });
+
+    it('omits data field when not provided', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        format: 'jsonl',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.info('No data');
+      const entry = JSON.parse(sink.lines[0]!);
+      expect(entry.data).toBeUndefined();
+    });
+  });
+
+  describe('secret redaction', () => {
+    it('redacts API keys from messages', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        format: 'text',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.info('Using key sk-abcdef1234567890abcdef');
+      expect(sink.lines[0]).toContain('[REDACTED:api-key]');
+      expect(sink.lines[0]).not.toContain('sk-abcdef');
+    });
+
+    it('redacts secrets in data values', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        format: 'jsonl',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.info('Config loaded', { apiKey: 'sk-abcdef1234567890abcdef' });
+      const entry = JSON.parse(sink.lines[0]!);
+      expect(entry.data.apiKey).toBe('[REDACTED:api-key]');
+    });
+
+    it('redacts secrets in nested data objects', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        format: 'jsonl',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.info('Deep config', {
+        connection: {
+          url: 'https://admin:supersecretpassword@db.example.com',
+        },
+      });
+      const entry = JSON.parse(sink.lines[0]!);
+      expect(entry.data.connection.url).toContain('[REDACTED:url-password]');
+      expect(entry.data.connection.url).not.toContain('supersecretpassword');
+    });
+
+    it('redacts secrets in arrays within data', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        format: 'jsonl',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.info('Keys', { keys: ['sk-abcdef1234567890abcdef', 'safe-value'] });
+      const entry = JSON.parse(sink.lines[0]!);
+      expect(entry.data.keys[0]).toBe('[REDACTED:api-key]');
+      expect(entry.data.keys[1]).toBe('safe-value');
+    });
+
+    it('preserves non-string data values', () => {
+      const sink = createSink();
+      const logger = new SessionLogger({
+        format: 'jsonl',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      logger.info('Metrics', { count: 42, active: true, value: null });
+      const entry = JSON.parse(sink.lines[0]!);
+      expect(entry.data.count).toBe(42);
+      expect(entry.data.active).toBe(true);
+      expect(entry.data.value).toBeNull();
+    });
+  });
+
+  describe('child logger', () => {
+    it('creates a child with a new correlation ID', () => {
+      const sink = createSink();
+      const parent = new SessionLogger({
+        format: 'jsonl',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      const child = parent.child('child-id-12345678');
+      child.info('From child');
+
+      const entry = JSON.parse(sink.lines[0]!);
+      expect(entry.correlationId).toBe('child-id-12345678');
+    });
+
+    it('inherits the parent writer', () => {
+      const sink = createSink();
+      const parent = new SessionLogger({
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      const child = parent.child();
+      child.info('Child message');
+
+      expect(sink.lines).toHaveLength(1);
+      expect(sink.lines[0]).toContain('Child message');
+    });
+
+    it('inherits the parent level', () => {
+      const sink = createSink();
+      const parent = new SessionLogger({
+        level: 'warn',
+        writer: sink.writer,
+        correlationId: FIXED_ID,
+        now: FIXED_CLOCK,
+      });
+
+      const child = parent.child();
+      child.info('hidden');
+      child.warn('visible');
+
+      expect(sink.lines).toHaveLength(1);
+    });
+
+    it('mints a UUID when no child ID is provided', () => {
+      const parent = new SessionLogger({ writer: () => {} });
+      const child = parent.child();
+      expect(child.getCorrelationId()).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(child.getCorrelationId()).not.toBe(parent.getCorrelationId());
+    });
+  });
+});

--- a/src/lib/session-logger.ts
+++ b/src/lib/session-logger.ts
@@ -1,0 +1,255 @@
+/**
+ * Structured session logger for long-running CLI operations.
+ *
+ * Produces timestamped, levelled log entries with correlation IDs in
+ * both human-readable (text) and machine-readable (JSONL) formats.
+ * Every entry is automatically redacted through the secret-redaction
+ * pipeline before it reaches any output sink.
+ *
+ * Design notes:
+ *   - The logger is intentionally decoupled from any specific CLI
+ *     command. It can be used by target-mode sessions, test runs, or
+ *     any future feature that benefits from structured observability.
+ *   - Writers are injectable: tests supply an in-memory sink; the CLI
+ *     wires stderr or a file writer. This keeps the module testable
+ *     without touching the filesystem or real I/O.
+ *   - Correlation IDs are minted per-session and can be overridden
+ *     per-entry so that iteration-scoped sub-operations share a
+ *     traceable identifier.
+ *   - `redactSecrets` runs on every emitted string — callers never
+ *     need to worry about scrubbing secrets before logging.
+ *   - Log levels follow the conventional four-tier model:
+ *     `debug < info < warn < error`. The minimum level is configurable
+ *     at construction and can be changed at runtime.
+ *   - This module has zero external dependencies beyond `redact.ts` and
+ *     Node's `crypto.randomUUID`.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { redactSecrets } from './redact.js';
+import type { RedactionPattern } from './redact.js';
+import { createRedactor } from './redact.js';
+
+// ────────────────────────── Types ──────────────────────────
+
+/** Supported log levels, ordered by severity. */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/** Numeric weight for level comparison. Higher = more severe. */
+const LEVEL_WEIGHT: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+/** A single structured log entry. */
+export interface LogEntry {
+  /** ISO 8601 timestamp of when the entry was created. */
+  timestamp: string;
+  /** Log severity level. */
+  level: LogLevel;
+  /** Human-readable message (already redacted). */
+  message: string;
+  /** Session-scoped or entry-scoped correlation ID. */
+  correlationId: string;
+  /** Optional structured data attached to the entry. */
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Sink that receives formatted log output. Inject a custom writer
+ * for tests or file-based logging.
+ */
+export type LogWriter = (line: string) => void;
+
+/** Output format for log entries. */
+export type LogFormat = 'text' | 'jsonl';
+
+/** Configuration for creating a session logger. */
+export interface SessionLoggerOptions {
+  /**
+   * Minimum severity to emit. Entries below this level are silently
+   * discarded. Default: `'info'`.
+   */
+  level?: LogLevel;
+  /**
+   * Output format. `'text'` emits human-readable lines suitable for
+   * terminal / stderr; `'jsonl'` emits one JSON object per line for
+   * machine consumption. Default: `'text'`.
+   */
+  format?: LogFormat;
+  /**
+   * Writer function that receives each formatted line. Default:
+   * `process.stderr.write` (line + newline).
+   */
+  writer?: LogWriter;
+  /**
+   * Session-wide correlation ID. When omitted a new UUID is minted.
+   * Pass an explicit ID when resuming a checkpointed session so log
+   * entries share the same trace.
+   */
+  correlationId?: string;
+  /**
+   * Additional redaction patterns prepended to the built-in defaults.
+   * Use for project-specific secret formats.
+   */
+  extraRedactPatterns?: readonly RedactionPattern[];
+  /**
+   * Injectable clock for deterministic tests.
+   * Default: `() => new Date().toISOString()`.
+   */
+  now?: () => string;
+}
+
+// ────────────────────────── Logger ──────────────────────────
+
+export class SessionLogger {
+  private minLevel: LogLevel;
+  private readonly format: LogFormat;
+  private readonly writer: LogWriter;
+  private readonly correlationId: string;
+  private readonly redact: (input: string) => string;
+  private readonly now: () => string;
+
+  constructor(options: SessionLoggerOptions = {}) {
+    this.minLevel = options.level ?? 'info';
+    this.format = options.format ?? 'text';
+    this.writer =
+      options.writer ??
+      ((line: string) => {
+        process.stderr.write(`${line}\n`);
+      });
+    this.correlationId = options.correlationId ?? randomUUID();
+    this.redact =
+      options.extraRedactPatterns && options.extraRedactPatterns.length > 0
+        ? createRedactor(options.extraRedactPatterns)
+        : redactSecrets;
+    this.now = options.now ?? (() => new Date().toISOString());
+  }
+
+  /** The session correlation ID assigned to this logger instance. */
+  getCorrelationId(): string {
+    return this.correlationId;
+  }
+
+  /** Update the minimum log level at runtime. */
+  setLevel(level: LogLevel): void {
+    this.minLevel = level;
+  }
+
+  /** Get the current minimum log level. */
+  getLevel(): LogLevel {
+    return this.minLevel;
+  }
+
+  /**
+   * Emit a debug-level entry. Use for internal state transitions,
+   * iteration details, and data an operator only needs when
+   * troubleshooting.
+   */
+  debug(message: string, data?: Record<string, unknown>): void {
+    this.emit('debug', message, data);
+  }
+
+  /**
+   * Emit an info-level entry. Use for routine progress updates,
+   * milestones, and state changes that are useful during normal
+   * operation.
+   */
+  info(message: string, data?: Record<string, unknown>): void {
+    this.emit('info', message, data);
+  }
+
+  /**
+   * Emit a warn-level entry. Use for degraded conditions that do not
+   * stop the session but may warrant attention — e.g. TTS failure
+   * fallback, browser reconnection, or approaching a budget limit.
+   */
+  warn(message: string, data?: Record<string, unknown>): void {
+    this.emit('warn', message, data);
+  }
+
+  /**
+   * Emit an error-level entry. Use for failures that stop or block
+   * the current operation — e.g. unrecoverable errors, exceeded
+   * limits, or fatal validation failures.
+   */
+  error(message: string, data?: Record<string, unknown>): void {
+    this.emit('error', message, data);
+  }
+
+  /**
+   * Create a child logger that inherits all settings but uses a
+   * different correlation ID. Useful for scoping log entries to a
+   * specific iteration or sub-operation within a session.
+   */
+  child(correlationId?: string): SessionLogger {
+    return new SessionLogger({
+      level: this.minLevel,
+      format: this.format,
+      writer: this.writer,
+      correlationId: correlationId ?? randomUUID(),
+      now: this.now,
+    });
+  }
+
+  // ─────────────────── Internal ───────────────────
+
+  private emit(level: LogLevel, message: string, data?: Record<string, unknown>): void {
+    if (LEVEL_WEIGHT[level] < LEVEL_WEIGHT[this.minLevel]) return;
+
+    const entry: LogEntry = {
+      timestamp: this.now(),
+      level,
+      message: this.redact(message),
+      correlationId: this.correlationId,
+    };
+
+    if (data !== undefined) {
+      // Deep-redact all string values in the data object.
+      entry.data = this.redactData(data);
+    }
+
+    this.writer(this.formatEntry(entry));
+  }
+
+  private formatEntry(entry: LogEntry): string {
+    if (this.format === 'jsonl') {
+      return JSON.stringify(entry);
+    }
+
+    // Text format: `2024-01-15T10:30:00Z [INFO] (abc123) Message`
+    const levelTag = `[${entry.level.toUpperCase()}]`;
+    const shortId = entry.correlationId.slice(0, 8);
+    const dataStr = entry.data !== undefined ? ` ${JSON.stringify(entry.data)}` : '';
+    return `${entry.timestamp} ${levelTag} (${shortId}) ${entry.message}${dataStr}`;
+  }
+
+  /**
+   * Recursively redact string values inside a data object.
+   * Non-string primitives, arrays, and nested objects are traversed;
+   * only string leaves are passed through the redactor.
+   */
+  private redactData(data: Record<string, unknown>): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(data)) {
+      if (typeof value === 'string') {
+        result[key] = this.redact(value);
+      } else if (Array.isArray(value)) {
+        result[key] = value.map(item =>
+          typeof item === 'string'
+            ? this.redact(item)
+            : item !== null && typeof item === 'object'
+              ? this.redactData(item as Record<string, unknown>)
+              : item,
+        );
+      } else if (value !== null && typeof value === 'object') {
+        result[key] = this.redactData(value as Record<string, unknown>);
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary

Add two new library modules for structured observability and security: a **secret redaction utility** (`redact.ts`) and a **structured session logger** (`session-logger.ts`).

### Motivation

The CLI currently outputs plain text to stderr with no structured format, no correlation IDs for tracing, and no secret redaction pipeline. As the CLI grows to support longer-running operations (polling, batch runs, future session-based workflows), structured logging with automatic secret protection becomes essential for:

- **Machine-parseable output** — automation consumers can filter/aggregate JSONL entries
- **Traceability** — correlation IDs link related log entries across operations
- **Security** — secrets are automatically scrubbed before reaching any output sink (terminal, file, or future TTS)

### What's included

#### `src/lib/redact.ts` — Secret Redaction Utility

| Export | Purpose |
|--------|---------|
| `redactSecrets(input)` | Scan and redact secrets using built-in patterns |
| `createRedactor(extraPatterns)` | Create a custom redactor with project-specific patterns |
| `DEFAULT_PATTERNS` | Built-in patterns (API keys, bearer tokens, URL passwords, AWS keys, GitHub tokens, hex secrets) |

**Design decisions:**
- Broad patterns preferred over narrow — false positives (redacting harmless text) are safer than false negatives (leaking secrets)
- URL password redaction preserves URL structure (`://user:[REDACTED]@host`)
- Idempotent — running twice produces the same output
- Global regex `lastIndex` is reset per call to avoid stateful bugs

#### `src/lib/session-logger.ts` — Structured Session Logger

| Export | Purpose |
|--------|---------|
| `SessionLogger` class | Main logger with level filtering, formatting, and redaction |
| `LogLevel` type | `'debug' \| 'info' \| 'warn' \| 'error'` |
| `LogEntry` interface | Structured entry shape (timestamp, level, message, correlationId, data?) |
| `LogFormat` type | `'text' \| 'jsonl'` |

**Key features:**
- **Correlation IDs** — auto-minted UUID per session, overridable per child logger
- **Two output formats** — human-readable text (`2026-01-15T10:30:00Z [INFO] (abc123) Message`) and machine-readable JSONL
- **Automatic secret redaction** — all messages and data values pass through the redaction pipeline
- **Deep data redaction** — nested objects and arrays in structured data are recursively redacted
- **Child loggers** — scope sub-operations with different correlation IDs while sharing the same writer
- **Runtime level adjustment** — `setLevel()` for dynamic verbosity control
- **Fully injectable** — writer, clock, and redaction patterns are injectable for deterministic testing

### Test coverage

**45 tests** total:

| File | Tests | Coverage |
|------|-------|----------|
| `redact.test.ts` | 23 | API keys, bearer tokens, URL passwords, AWS keys, GitHub tokens, hex secrets, edge cases, custom redactors |
| `session-logger.test.ts` | 22 | Construction, level filtering, setLevel, text format, JSONL format, secret redaction in messages/data/nested/arrays, child loggers |

### Checklist

- [x] PR targets `main`
- [x] Commit uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (45/45 new tests pass)
- [x] New behavior has tests (mock-based, deterministic, no real timers or network)
- [x] No secrets, API keys, or internal endpoints
- [x] Zero new production dependencies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI duration utilities to parse `h/m/s` strings (supports fractional values and strict validation), format milliseconds into compact time output, and enforce optional min/max bounds.
  * Introduced a session-scoped logger with configurable text or JSONL output, log-level filtering, correlation IDs, child loggers, and automatic recursive secret redaction.
  * Added a reusable secret-redaction utility with default and customizable detection patterns.
* **Tests**
  * Added Vitest coverage for duration handling, secret redaction edge cases, and session logger formatting/redaction and correlation ID behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->