### PR TITLE
fix(test): emit auto-minted idempotency-key under --output json in rerun and run --all

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -346,7 +346,7 @@ testsprite test run test_xxxxxxxx --target-url https://staging.example.com \
 testsprite test run test_xxxxxxxx --dry-run --output json
 ```
 
-`--target-url` must be a publicly reachable URL — the CLI pre-flights it against local addresses (`localhost`, `127.x`, `::1`, `0.0.0.0`, `169.254.x`, RFC1918) and the backend resolves it via DNS. For testing against localhost, use the [TestSprite MCP plugin](https://www.testsprite.com/docs), which handles the local tunnel. The CLI auto-mints an idempotency key (printed to stderr at `--verbose`); pass `--idempotency-key <uuid>` to control it explicitly.
+`--target-url` must be a publicly reachable URL — the CLI pre-flights it against local addresses (`localhost`, `127.x`, `::1`, `0.0.0.0`, `169.254.x`, RFC1918) and the backend resolves it via DNS. For testing against localhost, use the [TestSprite MCP plugin](https://www.testsprite.com/docs), which handles the local tunnel. The CLI auto-mints an idempotency key (printed to stderr under `--output json`, `--verbose`, or `--debug`); pass `--idempotency-key <uuid>` to control it explicitly.
 
 #### `testsprite test rerun [test-id...]`
 
@@ -376,7 +376,7 @@ Flags:
 - `--auto-heal` / `--no-auto-heal` — frontend AI heal-on-drift, **on by default** for FE reruns; opt out with `--no-auto-heal`. Verbatim-replay passes are free; a heal engage costs a small amount of credit. Ignored for backend tests.
 - `--skip-dependencies` — backend only: rerun just the named test without expanding the producer/teardown closure.
 - `--max-concurrency <n>` — with `--wait`, cap on in-flight polls during a batch rerun.
-- `--idempotency-key <key>` — auto-minted when omitted.
+- `--idempotency-key <key>` — auto-minted when omitted (the minted key is printed to stderr under `--output json`, `--verbose`, or `--debug`).
 
 A batch rerun returns `accepted[]` (one `runId` per dispatched test) plus `deferred[]` for any test shed by the per-key run-rate limit; under `--wait`, a non-empty `deferred[]` exits 7 with a `nextAction` you can retry with a fresh idempotency key.
 

--- a/src/commands/test.rerun.spec.ts
+++ b/src/commands/test.rerun.spec.ts
@@ -1637,6 +1637,74 @@ describe('--idempotency-key passthrough', () => {
 
     expect(receivedKey).toBe('my-custom-key-abc');
   });
+
+  it('emits the auto-minted idempotency-key on stderr in JSON output mode (parity with test run)', async () => {
+    const creds = makeCreds();
+    const rerunResp = makeFeRerunResp();
+    const stderrLines: string[] = [];
+
+    const fetchImpl = makeFetch(url => {
+      if (url.includes('/tests/test_fe_01/runs/rerun')) {
+        return { body: rerunResp };
+      }
+      return errorBody('NOT_FOUND');
+    });
+
+    await runTestRerun(
+      {
+        testIds: ['test_fe_01'],
+        all: false,
+        wait: false,
+        timeoutSeconds: 600,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 10,
+        output: 'json',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+      },
+      { ...creds, sleep: instantSleep, fetchImpl, stderr: line => stderrLines.push(line) },
+    );
+
+    expect(stderrLines.some(l => l.startsWith('idempotency-key:'))).toBe(true);
+  });
+
+  it('does NOT emit an idempotency-key line in default text mode', async () => {
+    const creds = makeCreds();
+    const rerunResp = makeFeRerunResp();
+    const stderrLines: string[] = [];
+
+    const fetchImpl = makeFetch(url => {
+      if (url.includes('/tests/test_fe_01/runs/rerun')) {
+        return { body: rerunResp };
+      }
+      return errorBody('NOT_FOUND');
+    });
+
+    await runTestRerun(
+      {
+        testIds: ['test_fe_01'],
+        all: false,
+        wait: false,
+        timeoutSeconds: 600,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 10,
+        output: 'text',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+      },
+      { ...creds, sleep: instantSleep, fetchImpl, stderr: line => stderrLines.push(line) },
+    );
+
+    expect(stderrLines.some(l => l.includes('idempotency-key:'))).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/test.run.spec.ts
+++ b/src/commands/test.run.spec.ts
@@ -3470,6 +3470,39 @@ describe('dashboardUrl on run completion', () => {
     );
   });
 
+  it('run --all: emits the auto-minted idempotency-key on stderr in JSON output mode (parity with test run)', async () => {
+    const { credentialsPath } = makeCreds('sk-user-test', PROD_API);
+    const batchResp: BatchRunFreshResponse = {
+      accepted: [
+        { testId: 'test_be_01', runId: 'run_f_01', enqueuedAt: '2026-06-10T10:00:00.000Z' },
+      ],
+      conflicts: [],
+      deferred: [],
+      skippedFrontend: [],
+      skippedIntegration: [],
+    };
+    const stderrLines: string[] = [];
+    await runTestRunAll(
+      {
+        profile: 'default',
+        output: 'json',
+        debug: false,
+        projectId: 'project_be',
+        wait: false,
+        timeoutSeconds: 600,
+        maxConcurrency: 10,
+      },
+      {
+        credentialsPath,
+        fetchImpl: makeFetch(() => ({ body: batchResp })),
+        stdout: () => undefined,
+        stderr: line => stderrLines.push(line),
+        sleep: instantSleep,
+      },
+    );
+    expect(stderrLines.some(l => l.startsWith('idempotency-key:'))).toBe(true);
+  });
+
   it('run --all --wait (prod endpoint): summary items carry dashboardUrl + stderr Dashboard line', async () => {
     const { credentialsPath } = makeCreds('sk-user-test', PROD_API);
     const batchResp: BatchRunFreshResponse = {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -5136,11 +5136,8 @@ export async function runTestRunAll(
   };
 
   const idempotencyKey = opts.idempotencyKey ?? `cli-batch-run-fresh-${randomUUID()}`;
-  if (opts.idempotencyKey === undefined && opts.debug) {
+  if (opts.idempotencyKey === undefined && (opts.output === 'json' || opts.verbose || opts.debug)) {
     stderrFn(`idempotency-key: ${idempotencyKey}`);
-  }
-  if (opts.idempotencyKey === undefined && opts.verbose) {
-    stderrFn(`[verbose] auto-minted idempotency-key: ${idempotencyKey}`);
   }
 
   // Resolve testIds: fetch all BE tests in the project, apply --filter.
@@ -5704,11 +5701,8 @@ export async function runTestRerun(
   // slow rerun trigger / long-poll under load isn't cut at the 120s default.
   const client = makeClient({ ...opts, requestTimeoutMs: resolveWaitRequestTimeoutMs(opts) }, deps);
   const idempotencyKey = opts.idempotencyKey ?? `cli-rerun-${randomUUID()}`;
-  if (opts.idempotencyKey === undefined && opts.debug) {
+  if (opts.idempotencyKey === undefined && (opts.output === 'json' || opts.verbose || opts.debug)) {
     stderrFn(`idempotency-key: ${idempotencyKey}`);
-  }
-  if (opts.idempotencyKey === undefined && opts.verbose) {
-    stderrFn(`[verbose] auto-minted idempotency-key: ${idempotencyKey}`);
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`test rerun` and `test run --all` auto-mint an idempotency key when `--idempotency-key` is omitted, but only echoed it to stderr under `--debug` / `--verbose`. Every other minting site in the CLI (`test run`, `test create`, `test create-batch`, `test plan put`, `test code put`, `test update`, `test delete`) also echoes the key under `--output json`, precisely so JSON-mode automation can capture the key and retry a request safely with the same key (see the rationale comment above the `test create` guard).

This PR aligns the two stragglers with the shared guard (`--output json` / `--verbose` / `--debug`), so CI flows using `testsprite test rerun ... --output json` or `testsprite test run --all ... --output json` no longer silently lose the minted key. Also updates the two `DOCUMENTATION.md` mentions to match.

Failure mode before this fix: a JSON-mode CI job that needs to replay a rerun after a transport failure has no way to reuse the original key (it was sent on the wire but never surfaced), so the retry mints a fresh key and can double-dispatch the run.

## Related issue

None — small parity fix, opened directly as a PR per CONTRIBUTING.md ("Small fixes and improvements: just open a pull request").

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [x] PR targets the `main` branch.
- [x] Commits follow Conventional Commits (`fix(test): ...`).
- [x] `npm run lint` and `npm run format:check` pass.
- [x] `npm run typecheck` passes.
- [x] `npm test` passes (1571/1571) and coverage stays at or above the 80% gate.
- [x] New behavior is covered by unit tests (mock-based; no network or credentials required).
- [x] No secrets, API keys, internal endpoints, or personal data are included.
- [x] User-facing changes are reflected in `DOCUMENTATION.md`.

## Notes for reviewers

- Red-first: both new JSON-mode tests fail on `main` and pass with the fix; a third test pins the default text-mode silence so the guard doesn't over-emit.
- The `[verbose] auto-minted idempotency-key:` variant line in the two touched paths is replaced by the standard `idempotency-key: <key>` line used everywhere else (one line per invocation instead of a possible two under `--verbose --debug`). No test relied on the old format.
- Track B / CLI Improvement Bonus: Discord `ahndohun`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved idempotency-key handling so the auto-generated key is now shown in stderr for JSON output, as well as verbose and debug modes.
  * Standardized the displayed message across test run and rerun flows.

* **Documentation**
  * Updated command help docs to clarify when an auto-generated idempotency key is printed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->