### PR TITLE
fix(test): stop run --all --wait from polling queued runs past the shared deadline

### DIFF
--- a/src/commands/test.run.spec.ts
+++ b/src/commands/test.run.spec.ts
@@ -2487,6 +2487,61 @@ describe('runTestRunAll — batch fresh run', () => {
     expect(payload.accepted.every(r => r.status === 'passed')).toBe(true);
   });
 
+  it('run --all --wait: does not start a fresh poll for a queued run after the shared deadline expired', async () => {
+    const { credentialsPath } = makeCreds();
+    const baseNow = new Date('2026-06-09T10:00:00.000Z').getTime();
+    let nowMs = baseNow;
+    const runFetches: string[] = [];
+    const stdoutLines: string[] = [];
+    let caughtError: unknown;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
+
+    const fetchImpl = makeFetch((url, init) => {
+      const method = init.method ?? 'GET';
+      if (method === 'POST') return { body: BATCH_FRESH_RESP };
+
+      const runId = url.split('/runs/')[1]?.split('?')[0] ?? 'run_unknown';
+      runFetches.push(runId);
+      if (runId === 'run_fresh_01') {
+        nowMs = baseNow + 2000;
+        return { body: makePassedRun(runId, 'test_be_01') };
+      }
+      return { body: makePassedRun(runId, 'test_be_02') };
+    });
+
+    try {
+      await runTestRunAll(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          projectId: 'project_be',
+          wait: true,
+          timeoutSeconds: 1,
+          maxConcurrency: 1,
+        },
+        {
+          credentialsPath,
+          fetchImpl,
+          stdout: line => stdoutLines.push(line),
+          stderr: () => undefined,
+          sleep: instantSleep,
+        },
+      );
+    } catch (err) {
+      caughtError = err;
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    const payload = JSON.parse(stdoutLines.join('\n')) as {
+      accepted: Array<{ runId: string; status: string }>;
+    };
+    expect(runFetches).toEqual(['run_fresh_01']);
+    expect(payload.accepted.find(r => r.runId === 'run_fresh_02')?.status).toBe('timeout');
+    expect((caughtError as { exitCode?: number } | undefined)?.exitCode).toBe(7);
+  });
+
   it('--wait with a failed run → exit 1', async () => {
     const { credentialsPath } = makeCreds();
     const fetchImpl = makeFetch((url, init) => {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -5421,7 +5421,20 @@ export async function runTestRunAll(
 
   async function pollFreshAccepted(entry: BatchRunFreshAccepted): Promise<CliBatchRunFreshResult> {
     const runId = entry.runId;
-    const remainingSeconds = Math.max(1, Math.ceil((batchDeadlineMs - Date.now()) / 1000));
+    const remainingMs = batchDeadlineMs - Date.now();
+    if (remainingMs <= 0) {
+      return {
+        testId: entry.testId,
+        runId,
+        status: 'timeout',
+        error: {
+          code: 'UNSUPPORTED',
+          message: `Timed out after ${opts.timeoutSeconds}s`,
+          exitCode: 7,
+        },
+      };
+    }
+    const remainingSeconds = Math.ceil(remainingMs / 1000);
     const resolveAlternate = makeBackendWaitFallback({
       client,
       resolveTestId: () => entry.testId,


### PR DESCRIPTION
## What does this PR do?

`test run --all --wait` documents a single shared `--timeout` deadline for the whole batch, but the per-member poll helper computes its budget as `Math.max(1, ceil((batchDeadlineMs - Date.now()) / 1000))`. Because of the `Math.max(1, ...)` floor, a member whose turn arrives *after* the shared deadline has already expired still gets a fresh >= 1s poll. With `--max-concurrency` bounding the fan-out, the batch can overshoot the documented deadline and report a late `passed` for a member that should have been reported as `timeout` (exit 7) — in CI that's the difference between a gate firing and silently passing late.

The sibling `create-batch --run --wait` path already guards exactly this case (compute remaining ms first; if exhausted, return the timeout-shaped member result without polling). This PR applies the same guard to `runTestRunAll`'s poll helper, reusing the helper's existing timeout member shape (`status: 'timeout'`, `code: 'UNSUPPORTED'`, `exitCode: 7`) so downstream accounting and the exit matrix are unchanged.

## Related issue

None — small parity fix with the sibling batch path, opened directly as a PR per CONTRIBUTING.md.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [x] PR targets the `main` branch.
- [x] Commits follow Conventional Commits (`fix(test): ...`).
- [x] `npm run lint` and `npm run format:check` pass.
- [x] `npm run typecheck` passes.
- [x] `npm test` passes (1569/1569) and coverage stays at or above the 80% gate.
- [x] New behavior is covered by unit tests (mock-based; no network or credentials required).
- [x] No secrets, API keys, internal endpoints, or personal data are included.
- [x] User-facing changes are reflected in docs where relevant (no doc change needed — behavior now matches the documented shared deadline).

## Notes for reviewers

- Red-first: the regression test fails on `main` (`expected ['run_fresh_01','run_fresh_02'] to deeply equal ['run_fresh_01']` — the second member was polled past the deadline) and passes with the fix.
- The test drives `Date.now` past the shared deadline during the first member's poll (`--max-concurrency 1`) and asserts the queued member is never fetched, is reported as `timeout`, and the batch exits 7.
- Track B / CLI Improvement Bonus: Discord `ahndohun`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `run --all --wait` timeout handling so polling stops once the overall deadline is exceeded.
  * Tests now cover the case where remaining runs are marked as timed out instead of starting extra polling.
  * Error handling for this timeout path is verified to return the expected exit code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->