### PR TITLE
feat(cli): add 'test flaky' repeat-run flaky-test detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ All notable changes to `@testsprite/testsprite-cli` are documented here. The for
 
 ### Added
 
+<<<<<<< HEAD
 - **JUnit XML report export for batch `--wait` runs.** `test run --all` and batch `test rerun` (`--all` or multiple test ids) accept `--report junit --report-file <path>` to write a CI-friendly XML sidecar after polling completes. `--output json` is unchanged; the report is written even when the batch exits non-zero. `--dry-run` writes a canned sample without network calls.
 - **`testsprite test flaky <test-id>`** — repeat-run flaky-test detector. Replays a test N times (`--runs <n>`, default 5), aggregates the outcomes, and reports a stability verdict (`stable` / `flaky` / `failing`) plus the `runId` and `failureKind` of every attempt that did not pass. Replays run with auto-heal OFF (strict verbatim) so a healed drift can't mask a nondeterministic pass/fail. Exit code is 0 only when every attempt passed, so CI can gate a merge on flakiness (`testsprite test flaky <id> --runs 5 || exit 1`). Flags: `--runs <n>` (1–100), `--until-fail` (stop at the first non-passing attempt), `--timeout <s>` (per-attempt), and `--output json` for a machine-readable stability report. Frontend replays are free verbatim script replays; a one-line advisory is printed for backend tests, whose closure reruns may cost credits.
+=======
+- **`testsprite test flaky <test-id>`** — repeat-run flaky-test detector. Replays a test N times (`--runs <n>`, default 5), aggregates the outcomes, and reports a stability verdict (`stable` / `flaky` / `failing`) plus the `runId` and `failureKind` of every attempt that did not pass. Replays run with auto-heal OFF (strict verbatim) so a healed drift can't mask a nondeterministic pass/fail. Exit code is 0 only when every attempt passed, so CI can gate a merge on flakiness (`testsprite test flaky <id> --runs 5 || exit 1`). Flags: `--runs <n>` (1–10), `--until-fail` (stop at the first non-passing attempt), `--timeout <s>` (per-attempt), and `--output json` for a machine-readable stability report. Frontend replays are free verbatim script replays; a one-line advisory is printed for backend tests, whose closure reruns may cost credits.
+>>>>>>> d6a959a (fix(flaky): cap --runs at 10 per maintainer scope (#115))
 
 ## [0.2.0] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,8 @@ All notable changes to `@testsprite/testsprite-cli` are documented here. The for
 
 ### Added
 
-<<<<<<< HEAD
 - **JUnit XML report export for batch `--wait` runs.** `test run --all` and batch `test rerun` (`--all` or multiple test ids) accept `--report junit --report-file <path>` to write a CI-friendly XML sidecar after polling completes. `--output json` is unchanged; the report is written even when the batch exits non-zero. `--dry-run` writes a canned sample without network calls.
-- **`testsprite test flaky <test-id>`** — repeat-run flaky-test detector. Replays a test N times (`--runs <n>`, default 5), aggregates the outcomes, and reports a stability verdict (`stable` / `flaky` / `failing`) plus the `runId` and `failureKind` of every attempt that did not pass. Replays run with auto-heal OFF (strict verbatim) so a healed drift can't mask a nondeterministic pass/fail. Exit code is 0 only when every attempt passed, so CI can gate a merge on flakiness (`testsprite test flaky <id> --runs 5 || exit 1`). Flags: `--runs <n>` (1–100), `--until-fail` (stop at the first non-passing attempt), `--timeout <s>` (per-attempt), and `--output json` for a machine-readable stability report. Frontend replays are free verbatim script replays; a one-line advisory is printed for backend tests, whose closure reruns may cost credits.
-=======
 - **`testsprite test flaky <test-id>`** — repeat-run flaky-test detector. Replays a test N times (`--runs <n>`, default 5), aggregates the outcomes, and reports a stability verdict (`stable` / `flaky` / `failing`) plus the `runId` and `failureKind` of every attempt that did not pass. Replays run with auto-heal OFF (strict verbatim) so a healed drift can't mask a nondeterministic pass/fail. Exit code is 0 only when every attempt passed, so CI can gate a merge on flakiness (`testsprite test flaky <id> --runs 5 || exit 1`). Flags: `--runs <n>` (1–10), `--until-fail` (stop at the first non-passing attempt), `--timeout <s>` (per-attempt), and `--output json` for a machine-readable stability report. Frontend replays are free verbatim script replays; a one-line advisory is printed for backend tests, whose closure reruns may cost credits.
->>>>>>> d6a959a (fix(flaky): cap --runs at 10 per maintainer scope (#115))
 
 ## [0.2.0] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `@testsprite/testsprite-cli` are documented here. The for
 ### Added
 
 - **JUnit XML report export for batch `--wait` runs.** `test run --all` and batch `test rerun` (`--all` or multiple test ids) accept `--report junit --report-file <path>` to write a CI-friendly XML sidecar after polling completes. `--output json` is unchanged; the report is written even when the batch exits non-zero. `--dry-run` writes a canned sample without network calls.
+- **`testsprite test flaky <test-id>`** — repeat-run flaky-test detector. Replays a test N times (`--runs <n>`, default 5), aggregates the outcomes, and reports a stability verdict (`stable` / `flaky` / `failing`) plus the `runId` and `failureKind` of every attempt that did not pass. Replays run with auto-heal OFF (strict verbatim) so a healed drift can't mask a nondeterministic pass/fail. Exit code is 0 only when every attempt passed, so CI can gate a merge on flakiness (`testsprite test flaky <id> --runs 5 || exit 1`). Flags: `--runs <n>` (1–100), `--until-fail` (stop at the first non-passing attempt), `--timeout <s>` (per-attempt), and `--output json` for a machine-readable stability report. Frontend replays are free verbatim script replays; a one-line advisory is printed for backend tests, whose closure reruns may cost credits.
 
 ## [0.2.0] - 2026-06-29
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -411,7 +411,7 @@ Detect a **flaky** test by replaying it several times and reporting how often it
 testsprite test flaky test_xxxxxxxx --runs 10
 
 # Fast "is it flaky at all?" — stop at the first non-passing attempt
-testsprite test flaky test_xxxxxxxx --runs 20 --until-fail
+testsprite test flaky test_xxxxxxxx --runs 10 --until-fail
 
 # Machine-readable stability report for CI
 testsprite test flaky test_xxxxxxxx --runs 10 --output json
@@ -419,7 +419,7 @@ testsprite test flaky test_xxxxxxxx --runs 10 --output json
 
 Flags:
 
-- `--runs <n>` — number of replays (1–100, default 5).
+- `--runs <n>` — number of replays (1–10, default 5).
 - `--until-fail` — stop at the first attempt that does not pass.
 - `--timeout <s>` — per-attempt polling deadline (same semantics as `test wait`).
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -402,6 +402,29 @@ Flags:
 
 A batch rerun returns `accepted[]` (one `runId` per dispatched test) plus `deferred[]` for any test shed by the per-key run-rate limit; under `--wait`, a non-empty `deferred[]` exits 7 with a `nextAction` you can retry with a fresh idempotency key.
 
+#### `testsprite test flaky <test-id>`
+
+Detect a **flaky** test by replaying it several times and reporting how often it passes. Each attempt is a rerun with auto-heal **off** (a strict verbatim replay), so healed drift can't disguise a nondeterministic pass/fail — this measures the replay stability of the saved script against the configured URL. Frontend replays are free verbatim script replays; backend tests re-run their dependency closure and may cost credits (a one-line stderr advisory is printed before the run).
+
+```bash
+# Replay 10 times and print a stability score
+testsprite test flaky test_xxxxxxxx --runs 10
+
+# Fast "is it flaky at all?" — stop at the first non-passing attempt
+testsprite test flaky test_xxxxxxxx --runs 20 --until-fail
+
+# Machine-readable stability report for CI
+testsprite test flaky test_xxxxxxxx --runs 10 --output json
+```
+
+Flags:
+
+- `--runs <n>` — number of replays (1–100, default 5).
+- `--until-fail` — stop at the first attempt that does not pass.
+- `--timeout <s>` — per-attempt polling deadline (same semantics as `test wait`).
+
+`--output json` emits `{ testId, runs, passed, failed, stableRatio, verdict, failures: [{ attempt, runId, outcome, failureKind }] }`. Exit codes: **0** when every observed attempt passed (`stable`); **1** when any attempt did not pass (`flaky` or `failing`); **4** when the test has no replayable run (trigger `testsprite test run <id>` first); **5** on a validation error.
+
 #### `testsprite test wait <run-id>`
 
 Block until a run reaches a terminal status. Same exit-code matrix as `test run --wait`. Used to resume polling after a timed-out `test run --wait`, or when an agent already has a `runId` from a previous invocation.

--- a/src/commands/test.flaky.spec.ts
+++ b/src/commands/test.flaky.spec.ts
@@ -1,0 +1,368 @@
+/**
+ * Unit tests for `test flaky` — the repeat-run flaky-test detector.
+ *
+ * All HTTP is mocked via `makeFlakyFetch`. The polling loop's sleep is injected
+ * through `TestDeps.sleep` to avoid real delays. Each rerun POST returns a
+ * unique runId; each run GET returns a terminal status scripted per attempt,
+ * so a test can assert stable / flaky / failing verdicts deterministically.
+ */
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { CLIError, ApiError } from '../lib/errors.js';
+import type { FlakyReport } from '../lib/flaky.js';
+import type { FetchImpl } from '../lib/http.js';
+import { runFlaky } from './test.js';
+
+type FetchInput = Parameters<typeof globalThis.fetch>[0];
+type RunStatus = 'passed' | 'failed' | 'blocked' | 'cancelled';
+
+function urlOf(input: FetchInput): string {
+  return typeof input === 'string'
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : (input as { url: string }).url;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/**
+ * Build a fetch that:
+ *  - GET  /tests/{id}                → the test record ('frontend' | 'backend')
+ *  - POST /tests/{id}/runs/rerun     → a queued rerun with runId run_<n> (n increments)
+ *  - GET  /runs/run_<k>              → a terminal run with statuses[k-1]
+ *
+ * `notFoundOnTrigger` makes the rerun POST return 404 (no replayable run).
+ */
+function makeFlakyFetch(opts: {
+  statuses: RunStatus[];
+  testType?: 'frontend' | 'backend';
+  notFoundOnTrigger?: boolean;
+}): { fetchImpl: FetchImpl; triggerCount: () => number } {
+  let triggers = 0;
+  const testType = opts.testType ?? 'frontend';
+  const fetchImpl = (async (input: FetchInput, init: RequestInit = {}) => {
+    const url = urlOf(input);
+    const method = (init.method ?? 'GET').toUpperCase();
+
+    if (method === 'GET' && /\/tests\/[^/]+$/.test(url.split('?')[0]!)) {
+      return jsonResponse(200, {
+        id: 'test_x',
+        projectId: 'project_abc',
+        name: 'sample',
+        type: testType,
+        createdFrom: 'portal',
+        status: 'passed',
+        createdAt: '2026-06-01T10:00:00.000Z',
+        updatedAt: '2026-06-01T10:00:00.000Z',
+      });
+    }
+
+    if (method === 'POST' && url.includes('/runs/rerun')) {
+      if (opts.notFoundOnTrigger) {
+        return jsonResponse(404, {
+          error: {
+            code: 'NOT_FOUND',
+            message: 'no replayable run',
+            nextAction: 'run it',
+            requestId: 'req_1',
+            details: {},
+          },
+        });
+      }
+      triggers += 1;
+      return jsonResponse(200, {
+        runId: `run_${triggers}`,
+        status: 'queued',
+        enqueuedAt: '2026-06-03T10:00:00.000Z',
+        codeVersion: 'v1',
+        autoHeal: false,
+      });
+    }
+
+    const runMatch = /\/runs\/(run_\d+)/.exec(url);
+    if (method === 'GET' && runMatch) {
+      const runId = runMatch[1]!;
+      const idx = Number(runId.replace('run_', '')) - 1;
+      const status = opts.statuses[idx] ?? 'passed';
+      return jsonResponse(200, {
+        runId,
+        testId: 'test_x',
+        projectId: 'project_abc',
+        userId: 'user_1',
+        status,
+        source: 'cli',
+        createdAt: '2026-06-03T10:00:00.000Z',
+        startedAt: '2026-06-03T10:00:01.000Z',
+        finishedAt: '2026-06-03T10:00:30.000Z',
+        codeVersion: 'v1',
+        targetUrl: 'https://example.com',
+        createdFrom: 'rerun:prior',
+        failedStepIndex: status === 'passed' ? null : 2,
+        failureKind: status === 'passed' ? null : 'assertion',
+        error: null,
+        videoUrl: null,
+        stepSummary: { total: 5, completed: 5, passedCount: 5, failedCount: 0 },
+      });
+    }
+
+    return jsonResponse(404, {
+      error: { code: 'NOT_FOUND', message: 'unmatched', requestId: 'x', details: {} },
+    });
+  }) as FetchImpl;
+
+  return { fetchImpl, triggerCount: () => triggers };
+}
+
+function makeCreds(): { credentialsPath: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'cli-flaky-'));
+  const credentialsPath = join(dir, 'credentials');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    credentialsPath,
+    `[default]\napi_url = http://localhost:13509\napi_key = sk-user-test\n`,
+    {
+      mode: 0o600,
+    },
+  );
+  return { credentialsPath };
+}
+
+const instantSleep = (): Promise<void> => Promise.resolve();
+
+function makeDeps(fetchImpl: FetchImpl): {
+  deps: {
+    credentialsPath: string;
+    fetchImpl: FetchImpl;
+    sleep: () => Promise<void>;
+    stdout: (l: string) => void;
+    stderr: (l: string) => void;
+  };
+  stdout: string[];
+  stderr: string[];
+} {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const { credentialsPath } = makeCreds();
+  return {
+    deps: {
+      credentialsPath,
+      fetchImpl,
+      sleep: instantSleep,
+      stdout: (l: string) => stdout.push(l),
+      stderr: (l: string) => stderr.push(l),
+    },
+    stdout,
+    stderr,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Surface
+// ---------------------------------------------------------------------------
+
+describe('createTestCommand — flaky subcommand exposed', () => {
+  it('exposes flaky with its flags', async () => {
+    const { createTestCommand } = await import('./test.js');
+    const test = createTestCommand();
+    const flaky = test.commands.find(c => c.name() === 'flaky');
+    expect(flaky).toBeDefined();
+    const flagNames = flaky!.options.map(o => o.long);
+    expect(flagNames).toContain('--runs');
+    expect(flagNames).toContain('--until-fail');
+    expect(flagNames).toContain('--timeout');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Behavior
+// ---------------------------------------------------------------------------
+
+describe('runFlaky', () => {
+  it('reports STABLE and exits 0 when every attempt passes', async () => {
+    const { fetchImpl, triggerCount } = makeFlakyFetch({
+      statuses: ['passed', 'passed', 'passed'],
+    });
+    const { deps } = makeDeps(fetchImpl);
+    const report = (await runFlaky(
+      {
+        profile: 'default',
+        output: 'text',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+        testId: 'test_x',
+        runs: 3,
+        untilFail: false,
+        timeoutSeconds: 600,
+      },
+      deps,
+    )) as FlakyReport;
+    expect(report.verdict).toBe('stable');
+    expect(report.runs).toBe(3);
+    expect(triggerCount()).toBe(3);
+  });
+
+  it('reports FLAKY and throws exit 1 on a mix of pass/fail', async () => {
+    const { fetchImpl } = makeFlakyFetch({ statuses: ['passed', 'failed', 'passed'] });
+    const { deps } = makeDeps(fetchImpl);
+    const err = await runFlaky(
+      {
+        profile: 'default',
+        output: 'text',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+        testId: 'test_x',
+        runs: 3,
+        untilFail: false,
+        timeoutSeconds: 600,
+      },
+      deps,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(CLIError);
+    expect((err as CLIError).exitCode).toBe(1);
+    expect((err as CLIError).message).toContain('flaky');
+  });
+
+  it('reports FAILING and throws exit 1 when no attempt passes', async () => {
+    const { fetchImpl } = makeFlakyFetch({ statuses: ['failed', 'failed'] });
+    const { deps } = makeDeps(fetchImpl);
+    const err = await runFlaky(
+      {
+        profile: 'default',
+        output: 'text',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+        testId: 'test_x',
+        runs: 2,
+        untilFail: false,
+        timeoutSeconds: 600,
+      },
+      deps,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(CLIError);
+    expect((err as CLIError).message).toContain('failing');
+  });
+
+  it('--until-fail stops at the first non-passing attempt', async () => {
+    const { fetchImpl, triggerCount } = makeFlakyFetch({
+      statuses: ['passed', 'failed', 'passed', 'passed', 'passed'],
+    });
+    const { deps } = makeDeps(fetchImpl);
+    const err = await runFlaky(
+      {
+        profile: 'default',
+        output: 'text',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+        testId: 'test_x',
+        runs: 5,
+        untilFail: true,
+        timeoutSeconds: 600,
+      },
+      deps,
+    ).catch((e: unknown) => e);
+    // Stopped after attempt 2 (the failure) — only 2 triggers fired.
+    expect(triggerCount()).toBe(2);
+    expect(err).toBeInstanceOf(CLIError);
+  });
+
+  it('prints a backend credit advisory to stderr', async () => {
+    const { fetchImpl } = makeFlakyFetch({ statuses: ['passed', 'passed'], testType: 'backend' });
+    const { deps, stderr } = makeDeps(fetchImpl);
+    await runFlaky(
+      {
+        profile: 'default',
+        output: 'text',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+        testId: 'test_x',
+        runs: 2,
+        untilFail: false,
+        timeoutSeconds: 600,
+      },
+      deps,
+    );
+    expect(stderr.some(l => l.includes('backend test') && l.includes('credits'))).toBe(true);
+  });
+
+  it('emits a machine-readable JSON stability report', async () => {
+    const { fetchImpl } = makeFlakyFetch({ statuses: ['passed', 'failed', 'passed'] });
+    const { deps, stdout } = makeDeps(fetchImpl);
+    await runFlaky(
+      {
+        profile: 'default',
+        output: 'json',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+        testId: 'test_x',
+        runs: 3,
+        untilFail: false,
+        timeoutSeconds: 600,
+      },
+      deps,
+    ).catch(() => undefined); // swallow the exit-1 throw; we only assert stdout
+    const parsed = JSON.parse(stdout.join('\n')) as FlakyReport;
+    expect(parsed.testId).toBe('test_x');
+    expect(parsed.runs).toBe(3);
+    expect(parsed.passed).toBe(2);
+    expect(parsed.verdict).toBe('flaky');
+    expect(parsed.failures).toHaveLength(1);
+    expect(parsed.failures[0]!.failureKind).toBe('assertion');
+  });
+
+  it('throws exit 4 when the test has no replayable run', async () => {
+    const { fetchImpl } = makeFlakyFetch({ statuses: [], notFoundOnTrigger: true });
+    const { deps } = makeDeps(fetchImpl);
+    const err = await runFlaky(
+      {
+        profile: 'default',
+        output: 'text',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+        testId: 'test_x',
+        runs: 3,
+        untilFail: false,
+        timeoutSeconds: 600,
+      },
+      deps,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).code).toBe('NOT_FOUND');
+  });
+
+  it('rejects --runs outside 1..100 with a validation error (exit 5)', async () => {
+    const { fetchImpl } = makeFlakyFetch({ statuses: [] });
+    const { deps } = makeDeps(fetchImpl);
+    const err = await runFlaky(
+      {
+        profile: 'default',
+        output: 'text',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+        testId: 'test_x',
+        runs: 0,
+        untilFail: false,
+        timeoutSeconds: 600,
+      },
+      deps,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).exitCode).toBe(5);
+  });
+});

--- a/src/commands/test.flaky.spec.ts
+++ b/src/commands/test.flaky.spec.ts
@@ -345,7 +345,7 @@ describe('runFlaky', () => {
     expect((err as ApiError).code).toBe('NOT_FOUND');
   });
 
-  it('rejects --runs outside 1..100 with a validation error (exit 5)', async () => {
+  it('rejects --runs below the range (0) with a validation error (exit 5)', async () => {
     const { fetchImpl } = makeFlakyFetch({ statuses: [] });
     const { deps } = makeDeps(fetchImpl);
     const err = await runFlaky(
@@ -357,6 +357,27 @@ describe('runFlaky', () => {
         verbose: false,
         testId: 'test_x',
         runs: 0,
+        untilFail: false,
+        timeoutSeconds: 600,
+      },
+      deps,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).exitCode).toBe(5);
+  });
+
+  it('rejects --runs above the cap (11) with a validation error (exit 5)', async () => {
+    const { fetchImpl } = makeFlakyFetch({ statuses: [] });
+    const { deps } = makeDeps(fetchImpl);
+    const err = await runFlaky(
+      {
+        profile: 'default',
+        output: 'text',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+        testId: 'test_x',
+        runs: 11,
         untilFail: false,
         timeoutSeconds: 600,
       },

--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -124,6 +124,7 @@ describe('createTestCommand — surface', () => {
       'delete-batch',
       'diff',
       'failure',
+      'flaky',
       'get',
       'list',
       'plan',

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -75,6 +75,14 @@ import { createTicker } from '../lib/ticker.js';
 import { RateThrottle } from '../lib/rate-throttle.js';
 import { resolvePortalBase, resolvePortalUrl } from '../lib/facade.js';
 import { loadConfig } from '../lib/config.js';
+import {
+  flakyExitCode,
+  renderFlakyText,
+  summarizeFlaky,
+  type FlakyAttempt,
+  type FlakyOutcome,
+  type FlakyReport,
+} from '../lib/flaky.js';
 
 /**
  * `details` debug block per the CLI OpenAPI `Test` schema
@@ -8117,12 +8125,238 @@ export function createTestCommand(deps: TestDeps = {}): Command {
       );
     });
 
+  // -------------------------------------------------------------------------
+  // `test flaky` — repeat-run flaky-test detector
+  // -------------------------------------------------------------------------
+
+  test
+    .command('flaky <test-id>')
+    .description(
+      'Repeatedly replay a test to measure stability and surface flakiness.\n' +
+        'Replays run with auto-heal OFF (strict verbatim) so healed drift cannot mask nondeterministic pass/fail.\n' +
+        '\nExit codes:\n' +
+        '  0  stable (every attempt passed)\n' +
+        '  1  flaky or failing (at least one attempt did not pass)\n' +
+        '  3  auth error\n' +
+        '  4  test not found (no replayable run — trigger `testsprite test run <id>` first)\n' +
+        '  5  validation error',
+    )
+    .option(
+      '--runs <n>',
+      `number of replays to run (1-${MAX_FLAKY_RUNS}, default ${DEFAULT_FLAKY_RUNS})`,
+    )
+    .option(
+      '--until-fail',
+      'stop at the first non-passing attempt (fast "is it flaky at all?" check)',
+      false,
+    )
+    .option(
+      '--timeout <s>',
+      `per-attempt max seconds to wait (1-${MAX_RUN_TIMEOUT_SECONDS}, default ${DEFAULT_RUN_TIMEOUT_SECONDS})`,
+    )
+    .addHelpText(
+      'after',
+      '\nNotes:\n' +
+        '  • Frontend replays are free verbatim script replays (no credit); backend replays\n' +
+        '    re-run the dependency closure and may cost credits — a one-line advisory is printed.\n' +
+        '  • Replays use auto-heal OFF so a flaky test is not silently "healed" into a pass;\n' +
+        '    this measures replay stability of the saved script against the configured URL.\n' +
+        '  • `--output json` emits a machine-readable stability report for CI gating.',
+    )
+    .addHelpText('after', GLOBAL_OPTS_HINT)
+    .action(
+      async (
+        testIdArg: string,
+        cmdOpts: { runs?: string; untilFail?: boolean; timeout?: string },
+        command: Command,
+      ) => {
+        await runFlaky(
+          {
+            ...resolveCommonOptions(command),
+            testId: testIdArg,
+            runs: parseNumericFlag(cmdOpts.runs, 'runs') ?? DEFAULT_FLAKY_RUNS,
+            untilFail: cmdOpts.untilFail === true,
+            timeoutSeconds: parseTimeoutFlag(cmdOpts.timeout, 'timeout'),
+          },
+          deps,
+        );
+      },
+    );
+
   test.addCommand(createTestCodeCommand(deps));
   test.addCommand(createTestPlanCommand(deps));
   test.addCommand(createTestFailureCommand(deps));
   test.addCommand(createTestArtifactCommand(deps));
 
   return test;
+}
+
+// ---------------------------------------------------------------------------
+// `test flaky` — repeat-run flaky-test detector
+// ---------------------------------------------------------------------------
+
+/** Upper bound on `--runs` so a typo can't spawn thousands of replays. */
+const MAX_FLAKY_RUNS = 100;
+/** Default replay count when `--runs` is omitted. */
+const DEFAULT_FLAKY_RUNS = 5;
+
+interface RunTestFlakyOptions extends CommonOptions {
+  testId: string;
+  /** Number of replays to run (1..MAX_FLAKY_RUNS). */
+  runs: number;
+  /** Stop at the first non-passing attempt. */
+  untilFail: boolean;
+  /** Per-attempt polling deadline in seconds. */
+  timeoutSeconds: number;
+}
+
+/**
+ * `test flaky <test-id>` — replay a test N times and report a stability score.
+ *
+ * Each attempt is a `POST /tests/{id}/runs/rerun` with auto-heal OFF (a strict
+ * verbatim replay) followed by `pollRunUntilTerminal`. Frontend replays are
+ * free verbatim script replays; backend replays re-run the dependency closure
+ * (a one-line credit advisory is printed). The pure scoring lives in
+ * `lib/flaky.ts`; this function is the I/O orchestrator.
+ *
+ * Exit code: 0 when every observed attempt passed (stable), else 1 — so CI can
+ * gate a merge on flakiness.
+ */
+export async function runFlaky(
+  opts: RunTestFlakyOptions,
+  deps: TestDeps = {},
+): Promise<FlakyReport | undefined> {
+  const stderrFn = deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
+  const out = makeOutput(opts.output, deps);
+
+  if (typeof opts.testId !== 'string' || opts.testId.length === 0) {
+    throw localValidationError('test-id', 'is required');
+  }
+  if (!Number.isInteger(opts.runs) || opts.runs < 1 || opts.runs > MAX_FLAKY_RUNS) {
+    throw localValidationError('runs', `must be an integer between 1 and ${MAX_FLAKY_RUNS}`);
+  }
+
+  if (opts.dryRun) {
+    out.print({
+      dryRun: true,
+      command: 'test flaky',
+      testId: opts.testId,
+      runs: opts.runs,
+      untilFail: opts.untilFail,
+      method: 'POST',
+      path: `/api/cli/v1/tests/${opts.testId}/runs/rerun`,
+      note: `Would replay the test up to ${opts.runs}x with auto-heal OFF and report a stability score.`,
+    });
+    return undefined;
+  }
+
+  // Under the implicit wait, raise the per-request timeout to cover --timeout
+  // so a slow trigger / long-poll under load isn't cut at the 120s default.
+  const client = makeClient(
+    { ...opts, requestTimeoutMs: resolveWaitRequestTimeoutMs({ ...opts, wait: true }) },
+    deps,
+  );
+
+  // Best-effort test-type detection for the credit advisory. A probe failure
+  // never blocks the run — we just skip the advisory.
+  let isBackend = false;
+  try {
+    const test = await client.get<CliTest>(`/tests/${encodeURIComponent(opts.testId)}`);
+    isBackend = test.type === 'backend';
+  } catch {
+    // best-effort — proceed without the advisory.
+  }
+  if (isBackend) {
+    stderrFn(
+      `[advisory] ${opts.testId} is a backend test — each replay re-runs its dependency closure ` +
+        `and may cost credits. Frontend replays are free verbatim script replays; backend replays are not.`,
+    );
+  }
+
+  const ticker = createTicker(stderrFn, opts.output === 'json' ? false : undefined);
+  const attempts: FlakyAttempt[] = [];
+
+  for (let i = 1; i <= opts.runs; i++) {
+    const idempotencyKey = `cli-flaky-${randomUUID()}`;
+
+    let rerunResp: RerunResponse;
+    try {
+      // auto-heal is intentionally OFF: flaky detection needs a strict verbatim
+      // replay so healed drift cannot mask a nondeterministic pass/fail.
+      rerunResp = await client.triggerRerun(opts.testId, { source: 'cli' }, { idempotencyKey });
+    } catch (err) {
+      // A missing replayable run is fatal for the whole command (mirror rerun):
+      // there is nothing to repeat, so point the user at a fresh `test run`.
+      if (err instanceof ApiError && err.code === 'NOT_FOUND') {
+        throw ApiError.fromEnvelope({
+          error: {
+            code: 'NOT_FOUND',
+            message: `Test ${opts.testId} has no replayable run (unknown/cross-tenant id, or it has never completed a clean run).`,
+            nextAction: `Trigger a fresh run first: testsprite test run ${opts.testId}`,
+            requestId: err.requestId ?? 'local',
+            details: { testId: opts.testId, reason: 'no_replayable_run' },
+          },
+        });
+      }
+      // Any other trigger error is recorded as an errored attempt so a single
+      // transient blip doesn't abort a long stability probe.
+      const code = err instanceof ApiError ? err.code : 'ERROR';
+      attempts.push({ attempt: i, runId: null, outcome: 'error', failureKind: code });
+      ticker.update(`Attempt ${i}/${opts.runs} — error (${code})`);
+      if (opts.untilFail) break;
+      continue;
+    }
+
+    const runId = rerunResp.runId;
+    // Backend run rows never finalize server-side; resolve the verdict from the
+    // testId-scoped result on non-terminal ticks (same fallback as `test rerun`).
+    const resolveAlternate = makeBackendWaitFallback({
+      client,
+      resolveTestId: () => opts.testId,
+      resolveNotBefore: () => rerunResp.enqueuedAt,
+    });
+
+    let outcome: FlakyOutcome;
+    let failureKind: string | null = null;
+    try {
+      const finalRun = await pollRunUntilTerminal(client, runId, {
+        timeoutSeconds: opts.timeoutSeconds,
+        sleep: deps.sleep,
+        onTransition: opts.verbose ? (msg: string) => stderrFn(`[verbose] ${msg}`) : undefined,
+        resolveAlternate,
+      });
+      outcome = finalRun.status as FlakyOutcome;
+      failureKind = finalRun.failureKind;
+    } catch (err) {
+      // A per-attempt deadline (poll TimeoutError) or a client-side request
+      // timeout both count as a non-passing "timeout" outcome for this attempt.
+      if (err instanceof TimeoutError || err instanceof RequestTimeoutError) {
+        outcome = 'timeout';
+      } else {
+        throw err;
+      }
+    }
+
+    attempts.push({ attempt: i, runId, outcome, failureKind });
+    const passedSoFar = attempts.filter(a => a.outcome === 'passed').length;
+    ticker.update(`Attempt ${i}/${opts.runs} — ${outcome} (${passedSoFar} passed so far)`);
+
+    if (opts.untilFail && outcome !== 'passed') break;
+  }
+
+  ticker.finalize();
+
+  const report = summarizeFlaky(opts.testId, attempts);
+  out.print(report, data => renderFlakyText(data as FlakyReport));
+
+  const exitCode = flakyExitCode(report);
+  if (exitCode !== 0) {
+    throw new CLIError(
+      `Test ${opts.testId} is ${report.verdict} — ${report.passed}/${report.runs} attempts passed`,
+      exitCode,
+    );
+  }
+  return report;
 }
 
 interface RunFlagOpts {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -8195,8 +8195,8 @@ export function createTestCommand(deps: TestDeps = {}): Command {
 // `test flaky` — repeat-run flaky-test detector
 // ---------------------------------------------------------------------------
 
-/** Upper bound on `--runs` so a typo can't spawn thousands of replays. */
-const MAX_FLAKY_RUNS = 100;
+/** Upper bound on `--runs` so a repeat-runner can't amplify free FE replays. */
+const MAX_FLAKY_RUNS = 10;
 /** Default replay count when `--runs` is omitted. */
 const DEFAULT_FLAKY_RUNS = 5;
 

--- a/src/lib/flaky.test.ts
+++ b/src/lib/flaky.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { flakyExitCode, renderFlakyText, summarizeFlaky, type FlakyAttempt } from './flaky.js';
+
+function pass(attempt: number): FlakyAttempt {
+  return { attempt, runId: `run_${attempt}`, outcome: 'passed' };
+}
+function fail(attempt: number, failureKind = 'assertion'): FlakyAttempt {
+  return { attempt, runId: `run_${attempt}`, outcome: 'failed', failureKind };
+}
+
+describe('summarizeFlaky', () => {
+  it('reports STABLE when every attempt passed', () => {
+    const report = summarizeFlaky('test_x', [pass(1), pass(2), pass(3)]);
+    expect(report.verdict).toBe('stable');
+    expect(report.runs).toBe(3);
+    expect(report.passed).toBe(3);
+    expect(report.failed).toBe(0);
+    expect(report.stableRatio).toBe(1);
+    expect(report.failures).toEqual([]);
+    expect(flakyExitCode(report)).toBe(0);
+  });
+
+  it('reports FLAKY on a mix of pass and fail', () => {
+    const report = summarizeFlaky('test_x', [pass(1), fail(2), pass(3)]);
+    expect(report.verdict).toBe('flaky');
+    expect(report.passed).toBe(2);
+    expect(report.failed).toBe(1);
+    expect(report.stableRatio).toBe(0.6667);
+    expect(report.failures).toEqual([
+      { attempt: 2, runId: 'run_2', outcome: 'failed', failureKind: 'assertion' },
+    ]);
+    expect(flakyExitCode(report)).toBe(1);
+  });
+
+  it('reports FAILING when no attempt passed', () => {
+    const report = summarizeFlaky('test_x', [fail(1), fail(2)]);
+    expect(report.verdict).toBe('failing');
+    expect(report.passed).toBe(0);
+    expect(report.stableRatio).toBe(0);
+    expect(flakyExitCode(report)).toBe(1);
+  });
+
+  it('treats an empty attempt list as FAILING with a 0 ratio', () => {
+    const report = summarizeFlaky('test_x', []);
+    expect(report.verdict).toBe('failing');
+    expect(report.runs).toBe(0);
+    expect(report.stableRatio).toBe(0);
+    expect(flakyExitCode(report)).toBe(1);
+  });
+
+  it('counts timeout and error outcomes as non-passing', () => {
+    const attempts: FlakyAttempt[] = [
+      pass(1),
+      { attempt: 2, runId: 'run_2', outcome: 'timeout' },
+      { attempt: 3, runId: null, outcome: 'error', failureKind: 'UNAVAILABLE' },
+    ];
+    const report = summarizeFlaky('test_x', attempts);
+    expect(report.verdict).toBe('flaky');
+    expect(report.passed).toBe(1);
+    expect(report.failed).toBe(2);
+    expect(report.failures.map(f => f.outcome)).toEqual(['timeout', 'error']);
+    // error attempt with no runId is preserved as null in the report
+    expect(report.failures[1]).toEqual({
+      attempt: 3,
+      runId: null,
+      outcome: 'error',
+      failureKind: 'UNAVAILABLE',
+    });
+  });
+
+  it('rounds stableRatio to 4 decimal places', () => {
+    const report = summarizeFlaky('test_x', [pass(1), pass(2), fail(3)]);
+    expect(report.stableRatio).toBe(0.6667);
+  });
+
+  it('reflects a short-circuited (--until-fail) run — fewer runs than requested', () => {
+    // Only two attempts were observed before the probe stopped at the failure.
+    const report = summarizeFlaky('test_x', [pass(1), fail(2)]);
+    expect(report.runs).toBe(2);
+    expect(report.verdict).toBe('flaky');
+  });
+});
+
+describe('renderFlakyText', () => {
+  it('summarizes a stable run on one line with no failure list', () => {
+    const text = renderFlakyText(summarizeFlaky('test_login', [pass(1), pass(2)]));
+    expect(text).toBe('Ran test_login 2x — 2 passed, 0 failed → STABLE (100% stable)');
+  });
+
+  it('lists failing attempts with runId and failureKind', () => {
+    const text = renderFlakyText(
+      summarizeFlaky('test_login', [pass(1), fail(2, 'network_timeout')]),
+    );
+    expect(text).toContain('→ FLAKY (50% stable)');
+    expect(text).toContain('failed attempts:');
+    expect(text).toContain('#2  run_2  failed failureKind=network_timeout');
+  });
+
+  it('shows (no runId) when an errored attempt never got a runId', () => {
+    const text = renderFlakyText(
+      summarizeFlaky('test_login', [{ attempt: 1, runId: null, outcome: 'error' }]),
+    );
+    expect(text).toContain('#1  (no runId)  error');
+  });
+});

--- a/src/lib/flaky.ts
+++ b/src/lib/flaky.ts
@@ -1,0 +1,133 @@
+/**
+ * Pure aggregation + rendering for `test flaky` — the repeat-run flaky-test
+ * detector. This module performs no I/O: the orchestrator in
+ * `commands/test.ts` feeds it the per-attempt outcomes, and it returns a
+ * machine-readable stability report plus the text rendering and exit code.
+ *
+ * Keeping the scoring logic pure makes it trivially unit-testable in isolation
+ * (deterministic, no network / credentials), matching the repo's mock-based
+ * test convention.
+ */
+
+/**
+ * Outcome of a single flaky-detector attempt. The first four mirror the
+ * terminal `RunStatus` values; `timeout` and `error` are orchestration
+ * outcomes (per-attempt deadline exceeded, or a non-fatal trigger/transport
+ * error that was recorded rather than aborting the whole probe).
+ */
+export type FlakyOutcome = 'passed' | 'failed' | 'blocked' | 'cancelled' | 'timeout' | 'error';
+
+/** Overall stability verdict across all observed attempts. */
+export type FlakyVerdict = 'stable' | 'flaky' | 'failing';
+
+/** One recorded attempt in a flaky run. */
+export interface FlakyAttempt {
+  /** 1-based attempt index. */
+  attempt: number;
+  /** The runId of this attempt, or `null` when the trigger never returned one. */
+  runId: string | null;
+  outcome: FlakyOutcome;
+  /**
+   * Server `failureKind` for non-passing runs (or the error code for `error`
+   * outcomes). `null` / omitted when the attempt passed or the kind is unknown.
+   */
+  failureKind?: string | null;
+}
+
+/** A single non-passing attempt as surfaced in the report. */
+export interface FlakyFailure {
+  attempt: number;
+  runId: string | null;
+  outcome: FlakyOutcome;
+  failureKind: string | null;
+}
+
+/**
+ * Machine-readable stability report. This is also the exact `--output json`
+ * shape, so dashboards / agents / CI can consume it directly.
+ */
+export interface FlakyReport {
+  testId: string;
+  /**
+   * Attempts actually observed. May be fewer than requested when
+   * `--until-fail` short-circuits on the first non-passing attempt.
+   */
+  runs: number;
+  passed: number;
+  failed: number;
+  /** `passed / runs`, rounded to 4 decimal places. `0` when `runs === 0`. */
+  stableRatio: number;
+  verdict: FlakyVerdict;
+  /** Non-passing attempts, in attempt order. */
+  failures: FlakyFailure[];
+}
+
+/**
+ * Aggregate per-attempt outcomes into a stability report.
+ *
+ * Verdict rules:
+ *   - every attempt passed        → `stable`
+ *   - no attempt passed           → `failing`
+ *   - a mix of pass and non-pass  → `flaky`
+ * An empty attempt list (no runs observed) is reported as `failing` with a
+ * `0` ratio — there is no evidence the test is stable.
+ */
+export function summarizeFlaky(testId: string, attempts: FlakyAttempt[]): FlakyReport {
+  const runs = attempts.length;
+  const passed = attempts.filter(a => a.outcome === 'passed').length;
+  const failed = runs - passed;
+  const stableRatio = runs === 0 ? 0 : Math.round((passed / runs) * 10000) / 10000;
+  const verdict: FlakyVerdict =
+    runs > 0 && passed === runs ? 'stable' : passed === 0 ? 'failing' : 'flaky';
+  const failures: FlakyFailure[] = attempts
+    .filter(a => a.outcome !== 'passed')
+    .map(a => ({
+      attempt: a.attempt,
+      runId: a.runId,
+      outcome: a.outcome,
+      failureKind: a.failureKind ?? null,
+    }));
+  return { testId, runs, passed, failed, stableRatio, verdict, failures };
+}
+
+/**
+ * Exit code for the command: `0` only when the verdict is `stable` (every
+ * observed attempt passed). Anything else is non-zero so CI can gate a merge
+ * on flakiness (`testsprite test flaky <id> --runs 5 || exit 1`).
+ */
+export function flakyExitCode(report: FlakyReport): number {
+  return report.verdict === 'stable' ? 0 : 1;
+}
+
+/** Human-readable label for a verdict. */
+function verdictLabel(verdict: FlakyVerdict): string {
+  switch (verdict) {
+    case 'stable':
+      return 'STABLE';
+    case 'flaky':
+      return 'FLAKY';
+    case 'failing':
+      return 'FAILING';
+  }
+}
+
+/**
+ * Render a report to human-readable text. JSON-mode callers ship the report
+ * verbatim via `out.print`; this is the text-mode rendering.
+ */
+export function renderFlakyText(report: FlakyReport): string {
+  const pct = Math.round(report.stableRatio * 100);
+  const lines: string[] = [
+    `Ran ${report.testId} ${report.runs}x — ${report.passed} passed, ${report.failed} failed → ` +
+      `${verdictLabel(report.verdict)} (${pct}% stable)`,
+  ];
+  if (report.failures.length > 0) {
+    lines.push('  failed attempts:');
+    for (const f of report.failures) {
+      const kind = f.failureKind ? ` failureKind=${f.failureKind}` : '';
+      const rid = f.runId ?? '(no runId)';
+      lines.push(`    #${f.attempt}  ${rid}  ${f.outcome}${kind}`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/test/__snapshots__/help.snapshot.test.ts.snap
+++ b/test/__snapshots__/help.snapshot.test.ts.snap
@@ -270,6 +270,15 @@ Commands:
    11  rate limited — honor Retry-After
   
   On failure/blocked/cancelled, run: testsprite test artifact get <run-id>
+  flaky [options] <test-id>             Repeatedly replay a test to measure stability and surface flakiness.
+  Replays run with auto-heal OFF (strict verbatim) so healed drift cannot mask nondeterministic pass/fail.
+  
+  Exit codes:
+    0  stable (every attempt passed)
+    1  flaky or failing (at least one attempt did not pass)
+    3  auth error
+    4  test not found (no replayable run — trigger \`testsprite test run <id>\` first)
+    5  validation error
   code                                  Inspect and edit generated test code
   plan                                  Manage FE test plan-steps (FE-only)
   failure                               Export the latest-failure agent bundle
@@ -341,6 +350,38 @@ Options:
   -h, --help     display help for command
 
 Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
+  testsprite --help
+"
+`;
+
+exports[`--help snapshots > test flaky 1`] = `
+"Usage: testsprite test flaky [options] <test-id>
+
+Repeatedly replay a test to measure stability and surface flakiness.
+Replays run with auto-heal OFF (strict verbatim) so healed drift cannot mask nondeterministic pass/fail.
+
+Exit codes:
+  0  stable (every attempt passed)
+  1  flaky or failing (at least one attempt did not pass)
+  3  auth error
+  4  test not found (no replayable run — trigger \`testsprite test run <id>\` first)
+  5  validation error
+
+Options:
+  --runs <n>     number of replays to run (1-10, default 5)
+  --until-fail   stop at the first non-passing attempt (fast "is it flaky at
+                 all?" check) (default: false)
+  --timeout <s>  per-attempt max seconds to wait (1-3600, default 600)
+  -h, --help     display help for command
+
+Notes:
+  • Frontend replays are free verbatim script replays (no credit); backend replays
+    re-run the dependency closure and may cost credits — a one-line advisory is printed.
+  • Replays use auto-heal OFF so a flaky test is not silently "healed" into a pass;
+    this measures replay stability of the saved script against the configured URL.
+  • \`--output json\` emits a machine-readable stability report for CI gating.
+
+Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
   testsprite --help
 "
 `;

--- a/test/__snapshots__/help.snapshot.test.ts.snap
+++ b/test/__snapshots__/help.snapshot.test.ts.snap
@@ -381,7 +381,7 @@ Notes:
     this measures replay stability of the saved script against the configured URL.
   • \`--output json\` emits a machine-readable stability report for CI gating.
 
-Global options (--dry-run, --output, --profile, --endpoint-url, --verbose, --debug):
+Global options (--dry-run, --output, --profile, --endpoint-url, --request-timeout, --verbose, --debug):
   testsprite --help
 "
 `;

--- a/test/help.snapshot.test.ts
+++ b/test/help.snapshot.test.ts
@@ -39,6 +39,7 @@ const cases: Array<[string, string[]]> = [
   ['test result', ['test', 'result', '--help']],
   ['test failure get', ['test', 'failure', 'get', '--help']],
   ['test rerun', ['test', 'rerun', '--help']],
+  ['test flaky', ['test', 'flaky', '--help']],
   // R5: regression guard for commands that gained new flag wording
   ['test create-batch', ['test', 'create-batch', '--help']],
   ['test run', ['test', 'run', '--help']],


### PR DESCRIPTION
Closes #115

## What

Adds a new command, testsprite test flaky <test-id>, that replays a single test N times, aggregates the outcomes, and reports a stability verdict: stable / flaky / failing.

## Why

A test that passes once can still be nondeterministic. There is currently no first-class way to surface that from the CLI. flaky lets a human (or CI) quantify stability before trusting -- or gating a merge on -- a result.

## Behavior

- --runs <n> (default 5, range 1-10): number of replays.
- --until-fail: stop at the first non-passing attempt.
- --timeout <s>: per-attempt timeout.
- --output json: machine-readable stability report (verdict + each attempt's runId and failureKind).
- Replays run with auto-heal OFF (strict verbatim) so a healed drift can't mask a nondeterministic pass/fail.
- Exit code is 0 only when every attempt passed, so CI can gate: testsprite test flaky <id> --runs 5 || exit 1.
- Frontend replays are free verbatim script replays; a one-line advisory is printed for backend tests, whose closure reruns may cost credits.

## Tests

19 tests across src/lib/flaky.test.ts (aggregation/verdict logic, exit codes, until-fail, runs bounds) and src/commands/test.flaky.spec.ts (command wiring, flag parsing, JSON output). All pass. typecheck + prettier clean. CHANGELOG and DOCUMENTATION updated; help snapshot refreshed for the new subcommand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `testsprite test flaky <test-id>` to replay a test multiple times and classify stability as **stable/flaky/failing** using strict verbatim replays (auto-heal disabled).
  * Supports `--runs` (capped), `--timeout`, `--until-fail`, `--output json`, and `--dry-run`.
  * Implements clear exit codes (0 stable, 1 non-stable, 4 not replayable yet, 5 validation error) and includes per-attempt failure details (e.g., `runId`, `failureKind`).
* **Documentation**
  * Added CLI reference with flags, JSON output shape, and exit-code mapping.
* **Tests**
  * Added unit coverage for flaky verdict aggregation/rendering, command behavior (including NOT_FOUND/non-replayable handling), and help snapshot for `test flaky --help`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->