### PR TITLE
ci: test and build against Node 20 and 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,18 @@ jobs:
       - run: npm run typecheck
 
   test:
-    name: Unit Tests
+    name: Unit Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       - run: npm ci
@@ -60,15 +63,18 @@ jobs:
           CI: true
 
   build:
-    name: Build
+    name: Build (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       - run: npm ci


### PR DESCRIPTION
## What

Run the Unit Tests and Build CI jobs across a Node version matrix of 20 and 22, instead of only 22.

## Why

package.json declares engines.node >= 20 and the README/quickstart advertise Node 20 as supported, but CI only exercises Node 22. A regression that breaks on Node 20 (the advertised minimum) would pass CI today and only surface for users on 20. Testing the floor closes that gap.

## Change

- Add a strategy.matrix.node-version of [20, 22] to the test and build jobs.
- Parameterize setup-node with matrix.node-version.
- Name the jobs 'Unit Tests (Node <v>)' / 'Build (Node <v>)' so each leg is distinguishable in the checks UI.

No source changes; CI-only. Both legs run on ubuntu-latest with npm caching unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI pipeline to run tests and builds against multiple Node.js versions.
  * Improved validation coverage across supported Node.js releases, helping catch environment-specific issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->