### PR TITLE
fix(rerun): emit partial stdout on TimeoutError in single-FE rerun --wait

### DIFF
--- a/src/commands/test.rerun.spec.ts
+++ b/src/commands/test.rerun.spec.ts
@@ -4630,3 +4630,78 @@ describe('rerun --wait — dashboardUrl on terminal output', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// TimeoutError on single FE rerun --wait: partial stdout + exit 7
+// ---------------------------------------------------------------------------
+
+describe('[finding-4] single FE rerun --wait: TimeoutError writes partial JSON to stdout', () => {
+  it('exit 7 AND stdout contains {runId, status:"running"} when --timeout polling deadline is exceeded', async () => {
+    const creds = makeCreds();
+    const rerunResp = makeFeRerunResp();
+
+    let fetchCallCount = 0;
+    const fetchImpl: typeof globalThis.fetch = async (input, _init) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as { url: string }).url;
+      fetchCallCount++;
+      if (url.includes('/tests/test_fe_01/runs/rerun')) {
+        return new Response(JSON.stringify(rerunResp), {
+          status: 202,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.includes('/runs/')) {
+        const runningRun: RunResponse = {
+          ...makeTerminalRun(rerunResp.runId, 'passed'),
+          status: 'running',
+          finishedAt: null,
+        };
+        return new Response(JSON.stringify(runningRun), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ error: { code: 'NOT_FOUND' } }), { status: 404 });
+    };
+
+    const stdoutLines: string[] = [];
+
+    const err = await runTestRerun(
+      {
+        testIds: ['test_fe_01'],
+        all: false,
+        wait: true,
+        timeoutSeconds: 0,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 10,
+        output: 'json',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+      },
+      {
+        ...creds,
+        sleep: instantSleep,
+        fetchImpl: fetchImpl as unknown as FetchImpl,
+        stdout: line => stdoutLines.push(line),
+        stderr: () => undefined,
+      },
+    ).catch(e => e);
+
+    expect(err).toMatchObject({ exitCode: 7 });
+    expect(stdoutLines.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(stdoutLines.join('\n')) as { runId: string; status: string };
+    expect(parsed.runId).toBe(rerunResp.runId);
+    expect(parsed.status).toBe('running');
+
+    void fetchCallCount;
+  });
+});

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -6099,6 +6099,18 @@ export async function runTestRerun(
     } catch (err) {
       if (err instanceof TimeoutError) {
         ticker.finalize(`Run ${rerunResp.runId} — timed out after ${opts.timeoutSeconds}s`);
+        // Mirror the RequestTimeoutError path: emit a partial run to stdout so
+        // JSON consumers and AI agents can grab the runId and chain into
+        // `testsprite test wait <runId>` without parsing the stderr error envelope.
+        const timeoutPartial = { runId: rerunResp.runId, status: 'running' as const };
+        out.print(timeoutPartial, data => {
+          const p = data as typeof timeoutPartial;
+          return [
+            `runId       ${p.runId}`,
+            `status      ${p.status} (timed out after ${opts.timeoutSeconds}s)`,
+            `hint        Re-attach with: testsprite test wait ${p.runId}`,
+          ].join('\n');
+        });
         throw ApiError.fromEnvelope({
           error: {
             code: 'UNSUPPORTED',


### PR DESCRIPTION
## What does this PR do?

Fixes an asymmetry in `testsprite test rerun --wait` (single FE rerun path):
when the overall `--timeout` polling deadline is exceeded, the CLI now emits a
partial `{ runId, status: "running" }` object to **stdout** before throwing
exit 7 — matching the behavior already present for `RequestTimeoutError` and
the recently fixed `test run --wait` / `test wait` paths.

**Before:** `TimeoutError` → throw `ApiError` immediately → stdout empty in
`--output json` mode → AI agents must scrape stderr to recover the runId.

**After:** `TimeoutError` → `out.print({ runId, status: "running" })` → throw
→ caller can programmatically chain into `testsprite test wait <runId>`.

## Related issue

Hackathon CLI Improvement — agent recovery on polling timeout (complements
the `test run --wait` / `test wait` TimeoutError fix; this covers the
remaining single-FE `test rerun --wait` path).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [x] PR targets the `main` branch.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
      (`feat(...)`, `fix(...)`, `docs(...)`, …).
- [x] `npm run lint` and `npm run format:check` pass.
- [x] `npm run typecheck` passes.
- [x] `npm test` passes and coverage stays at or above the 80% gate.
- [x] New behavior is covered by unit tests (mock-based; no network or
      credentials required).
- [x] No secrets, API keys, internal endpoints, or personal data are included.
- [x] User-facing changes are reflected in `README.md` / `DOCUMENTATION.md` where
      relevant. *(N/A — internal error-handling parity fix, no CLI surface change.)*

## Notes for reviewers

### Root cause

In `runTestRerun` (single FE rerun, no BE closure), the `TimeoutError` catch
block at ~line 6132 called `ticker.finalize()` then threw `ApiError` without
any `out.print()`. The adjacent `RequestTimeoutError` branch already emitted
a partial run to stdout — this was simply a missed mirror.

### Scope

- **Changed:** single-FE `test rerun --wait` `TimeoutError` path only (~12 lines).
- **Not changed:** BE closure fan-out paths — those already aggregate runIds
  into the batch result object on timeout; `test run --wait` / `test wait`
  were fixed in a prior PR.

### Test added

`[finding-4]` in `test.rerun.spec.ts`:
- triggers `TimeoutError` via `timeoutSeconds: 0` (immediate deadline)
- asserts exit code 7
- asserts stdout contains parseable JSON `{ runId, status: "running" }`

### Verification
npm test → 1571 passed npm run typecheck → clean npm run lint:fix → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `--wait` behavior for single rerun tests when polling times out.
  * On timeout, the command now prints a partial “running” result to stdout, including the rerun ID and a hint to re-attach later.
  * The command still exits with the expected timeout error code, making the failure state clearer while preserving machine-readable output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->