### PR TITLE
fix(batch): classify RequestTimeoutError as timeout in --all --wait fan-out

### DIFF
--- a/src/commands/test.rerun.spec.ts
+++ b/src/commands/test.rerun.spec.ts
@@ -4630,3 +4630,66 @@ describe('rerun --wait — dashboardUrl on terminal output', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Batch --all --wait fan-out: RequestTimeoutError must not leave stdout empty
+// ---------------------------------------------------------------------------
+
+describe('[finding-5] batch rerun --wait: RequestTimeoutError during fan-out poll writes JSON stdout + exit 7', () => {
+  it('stdout contains accepted[] with runIds when member polls throw RequestTimeoutError', async () => {
+    const creds = makeCreds();
+    const batchResp: BatchRerunResponse = {
+      accepted: [
+        { testId: 'test_1', runId: 'run_b1', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+        { testId: 'test_2', runId: 'run_b2', enqueuedAt: '2026-06-03T10:00:00.000Z' },
+      ],
+      deferred: [],
+      conflicts: [],
+      closure: { byProject: [] },
+    };
+    const fetchImpl = makeFetch(url => {
+      if (url.includes('/tests/batch/rerun')) {
+        return { status: 202, body: batchResp };
+      }
+      if (url.includes('/runs/')) {
+        throw new RequestTimeoutError(120000, 'req_timeout_batch_rerun');
+      }
+      return errorBody('NOT_FOUND');
+    });
+    const stdoutLines: string[] = [];
+
+    const err = await runTestRerun(
+      {
+        testIds: ['test_1', 'test_2'],
+        all: false,
+        wait: true,
+        timeoutSeconds: 60,
+        autoHeal: false,
+        autoHealExplicit: false,
+        skipDependencies: false,
+        maxConcurrency: 10,
+        output: 'json',
+        profile: 'default',
+        dryRun: false,
+        debug: false,
+        verbose: false,
+      },
+      {
+        ...creds,
+        sleep: instantSleep,
+        fetchImpl: fetchImpl as unknown as FetchImpl,
+        stdout: line => stdoutLines.push(line),
+        stderr: () => undefined,
+      },
+    ).catch(e => e);
+
+    expect(err).toMatchObject({ exitCode: 7 });
+    expect(stdoutLines.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(stdoutLines.join('\n')) as {
+      accepted: Array<{ testId: string; runId: string; status: string }>;
+    };
+    expect(parsed.accepted).toHaveLength(2);
+    expect(parsed.accepted.map(r => r.runId).sort()).toEqual(['run_b1', 'run_b2']);
+    expect(parsed.accepted.every(r => r.status === 'timeout')).toBe(true);
+  });
+});

--- a/src/commands/test.run.spec.ts
+++ b/src/commands/test.run.spec.ts
@@ -3536,3 +3536,59 @@ describe('dashboardUrl on run completion', () => {
     ).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Batch --all --wait fan-out: RequestTimeoutError must not leave stdout empty
+// ---------------------------------------------------------------------------
+
+describe('[finding-5] runTestRunAll --wait: RequestTimeoutError during fan-out poll writes JSON stdout + exit 7', () => {
+  it('stdout contains accepted[] with runIds when member polls throw RequestTimeoutError', async () => {
+    const { credentialsPath } = makeCreds();
+    const batchResp: BatchRunFreshResponse = {
+      accepted: [
+        { testId: 'test_be_01', runId: 'run_fresh_01', enqueuedAt: '2026-06-09T10:00:00.000Z' },
+        { testId: 'test_be_02', runId: 'run_fresh_02', enqueuedAt: '2026-06-09T10:00:01.000Z' },
+      ],
+      conflicts: [],
+      deferred: [],
+      skippedFrontend: [],
+      skippedIntegration: [],
+    };
+    const fetchImpl = makeFetch((url, init) => {
+      if ((init.method ?? 'GET') === 'POST') return { body: batchResp };
+      if (url.includes('/runs/')) {
+        throw new RequestTimeoutError(120000, 'req_timeout_batch_all');
+      }
+      return errorBody('NOT_FOUND');
+    });
+    const stdoutLines: string[] = [];
+
+    const err = await runTestRunAll(
+      {
+        profile: 'default',
+        output: 'json',
+        debug: false,
+        projectId: 'project_be',
+        wait: true,
+        timeoutSeconds: 60,
+        maxConcurrency: 5,
+      },
+      {
+        credentialsPath,
+        fetchImpl,
+        stdout: line => stdoutLines.push(line),
+        stderr: () => undefined,
+        sleep: instantSleep,
+      },
+    ).catch(e => e);
+
+    expect(err).toMatchObject({ exitCode: 7 });
+    expect(stdoutLines.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(stdoutLines.join('\n')) as {
+      accepted: Array<{ testId: string; runId: string; status: string }>;
+    };
+    expect(parsed.accepted).toHaveLength(2);
+    expect(parsed.accepted.map(r => r.runId).sort()).toEqual(['run_fresh_01', 'run_fresh_02']);
+    expect(parsed.accepted.every(r => r.status === 'timeout')).toBe(true);
+  });
+});

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -5456,6 +5456,22 @@ export async function runTestRunAll(
           },
         };
       }
+      if (err instanceof RequestTimeoutError) {
+        // Client-side per-request timeout during polling — classify as timeout
+        // (exit 7) so the fan-out completes and stdout carries every runId.
+        // Without this, RequestTimeoutError rejects the fan-out before out.print(),
+        // leaving JSON consumers with empty stdout (mirrors create-batch --run).
+        return {
+          testId: entry.testId,
+          runId,
+          status: 'timeout',
+          error: {
+            code: 'UNSUPPORTED',
+            message: err.message,
+            exitCode: err.exitCode,
+          },
+        };
+      }
       if (err instanceof ApiError) {
         // Preserve the real exit code + envelope (AUTH_INVALID=3, NOT_FOUND=4,
         // RATE_LIMITED=11, …) instead of flattening every member failure to 1
@@ -6605,6 +6621,22 @@ export async function runTestRerun(
             code: 'UNSUPPORTED',
             message: `Timed out after ${opts.timeoutSeconds}s`,
             exitCode: 7,
+          },
+        };
+      }
+      if (err instanceof RequestTimeoutError) {
+        // Client-side per-request timeout during polling — classify as timeout
+        // (exit 7) so the fan-out completes and stdout carries every runId.
+        // Without this, RequestTimeoutError rejects the fan-out before out.print(),
+        // leaving JSON consumers with empty stdout (mirrors create-batch --run).
+        return {
+          testId: entry.testId,
+          runId: entry.runId,
+          status: 'timeout',
+          error: {
+            code: 'UNSUPPORTED',
+            message: err.message,
+            exitCode: err.exitCode,
           },
         };
       }


### PR DESCRIPTION
## What does this PR do?

Fixes empty stdout in `--output json` mode when `test run --all --wait` or
`test rerun --all --wait` hit a per-request timeout during batch fan-out polling.

**Before:** `RequestTimeoutError` from any member poll rejected the fan-out
promise before `out.print()` — stdout empty, agents could not recover runIds.

**After:** `pollFreshAccepted` / `pollAccepted` classify `RequestTimeoutError`
as `status: 'timeout'` (mirrors `create-batch --run` and existing `TimeoutError`
handling). Fan-out completes, stdout carries every dispatched runId, exit 7
fires with `testsprite test wait <runId>` hints in stderr.

Complements #127 (single-run TimeoutError) and #134 (single rerun TimeoutError).

## Related issue

Hackathon CLI Improvement Bonus — batch `--all --wait` recovery path.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] PR targets the `main` branch.
- [x] Commits follow Conventional Commits.
- [x] `npm run lint` and `npm run typecheck` pass.
- [x] `npm test` passes (1570 tests).
- [x] New behavior covered by unit tests in `test.run.spec.ts` and `test.rerun.spec.ts`.

## Notes for reviewers

- ~30 lines across two catch blocks in `pollFreshAccepted` and `pollAccepted`.
- Same pattern already used in `runBatchRun` (create-batch --run) at ~line 2806.
- BE closure fan-out already had D4 fix for RequestTimeoutError; this closes the
  gap on the `--all --wait` fresh-run and batch-rerun paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch test run and rerun behavior when polling times out.
  * Commands now keep producing JSON output even if one or more runs hit a timeout.
  * Affected runs are marked with `status: "timeout"`, and the command exits with code `7` as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->