### PR TITLE
fix(steps): surface run-scoped step errors

### DIFF
--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -2522,11 +2522,81 @@ describe('runSteps', () => {
     // timestamps come from RunStepDto.createdAt
     expect(first.capturedAt).toBe('2026-06-01T10:00:05.000Z');
     expect(first.updatedAt).toBe('2026-06-01T10:00:05.000Z');
+    expect(first.stepType).toBe('action');
+    expect(first.error).toBeNull();
     // outcomeContributesToFailure: null when run passed (failedStepIndex is null)
     expect(first.outcomeContributesToFailure).toBeNull();
     // JSON output should be parseable with 2 items
-    const printed = JSON.parse(out[0]!) as { items: unknown[] };
+    const printed = JSON.parse(out[0]!) as {
+      items: Array<{ stepType?: string; error?: string | null }>;
+    };
     expect(printed.items).toHaveLength(2);
+    expect(printed.items[0]!.stepType).toBe('action');
+    expect(printed.items[0]!.error).toBeNull();
+  });
+
+  it('--run-id preserves per-step error text in JSON output', async () => {
+    const { credentialsPath } = makeCreds();
+    const runWithStepError = {
+      ...RUN_WITH_STEPS,
+      status: 'failed' as const,
+      failedStepIndex: 2,
+      stepSummary: { total: 2, completed: 2, passedCount: 1, failedCount: 1 },
+      steps: RUN_WITH_STEPS.steps.map(step =>
+        step.stepIndex === '0002'
+          ? {
+              ...step,
+              status: 'failed' as const,
+              error: 'AssertionError: expected heading to be visible',
+            }
+          : step,
+      ),
+    };
+    const fetchImpl = makeFetch(() => ({ body: runWithStepError }));
+    const out: string[] = [];
+
+    await runSteps(
+      { profile: 'default', output: 'json', debug: false, testId: 'test_fe', runId: 'run_scoped' },
+      { credentialsPath, fetchImpl, stdout: line => out.push(line) },
+    );
+
+    const printed = JSON.parse(out[0]!) as {
+      items: Array<{ stepIndex: number; stepType?: string; error?: string | null }>;
+    };
+    const failedStep = printed.items.find(step => step.stepIndex === 2)!;
+    expect(failedStep.stepType).toBe('assertion');
+    expect(failedStep.error).toBe('AssertionError: expected heading to be visible');
+  });
+
+  it('--run-id prints per-step error text under failed rows in text mode', async () => {
+    const { credentialsPath } = makeCreds();
+    const runWithStepError = {
+      ...RUN_WITH_STEPS,
+      status: 'failed' as const,
+      failedStepIndex: 2,
+      stepSummary: { total: 2, completed: 2, passedCount: 1, failedCount: 1 },
+      steps: RUN_WITH_STEPS.steps.map(step =>
+        step.stepIndex === '0002'
+          ? {
+              ...step,
+              status: 'failed' as const,
+              error: 'AssertionError: expected heading to be visible',
+            }
+          : step,
+      ),
+    };
+    const fetchImpl = makeFetch(() => ({ body: runWithStepError }));
+    const out: string[] = [];
+
+    await runSteps(
+      { profile: 'default', output: 'text', debug: false, testId: 'test_fe', runId: 'run_scoped' },
+      { credentialsPath, fetchImpl, stdout: line => out.push(line) },
+    );
+
+    const block = out.join('\n');
+    expect(block).toContain('assert heading');
+    expect(block).toContain('failed');
+    expect(block).toContain('  error: AssertionError: expected heading to be visible');
   });
 
   it('--run-id: outcomeContributesToFailure=true on the failedStepIndex step', async () => {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -159,9 +159,16 @@ export interface CliTestCode {
 export interface CliTestStep {
   testId: string;
   stepIndex: number;
+  /**
+   * Run-scoped steps expose the backend's original plan-step type. Optional so
+   * the cumulative /tests/{id}/steps response remains backward-compatible.
+   */
+  stepType?: 'action' | 'assertion';
   action: string;
   description: string;
   status: 'passed' | 'failed' | null;
+  /** Per-step failure text already returned by GET /runs/{id}?includeSteps=true. */
+  error?: string | null;
   screenshotUrl: string | null;
   htmlSnapshotUrl: string | null;
   runIdIfAvailable: string | null;
@@ -3612,9 +3619,11 @@ function mapRunStepToCliTestStep(step: RunStepDto, run: RunResponse): CliTestSte
   return {
     testId: run.testId,
     stepIndex: numericIndex,
+    stepType: step.type,
     action: step.action,
     description: step.description ?? '',
     status: step.status,
+    error: step.error,
     screenshotUrl: step.screenshotUrl,
     htmlSnapshotUrl: step.htmlSnapshotUrl,
     runIdIfAvailable: run.runId,
@@ -8232,9 +8241,9 @@ function renderStepsText(page: Page<CliTestStep>): string {
     '  ' +
     'UPDATED';
 
-  const rows = page.items.map(s => {
+  const rows = page.items.flatMap(s => {
     const marker = s.outcomeContributesToFailure === true ? '* ' : '  ';
-    return [
+    const row = [
       marker,
       pad(String(s.stepIndex), indexWidth),
       pad(s.action, actionWidth),
@@ -8242,6 +8251,8 @@ function renderStepsText(page: Page<CliTestStep>): string {
       pad(descOf(s), descWidth),
       s.updatedAt,
     ].join('  ');
+    const error = s.error?.trim();
+    return error ? [row, `  error: ${error}`] : [row];
   });
 
   const lines: string[] = [header, ...rows, ''];

--- a/src/lib/dry-run/samples.test.ts
+++ b/src/lib/dry-run/samples.test.ts
@@ -405,6 +405,22 @@ describe('findSample', () => {
     expect(body.stepSummary.failedCount).toBe(0);
   });
 
+  it('GET /runs/{runId} sample includes a failed run step with backend error text', () => {
+    const e = findSample(
+      'GET',
+      'https://api.testsprite.com/api/cli/v1/runs/run_xyz?includeSteps=true',
+    );
+    expect(e?.operationId).toBe('getRun');
+    const body = e?.body() as {
+      steps: Array<{ type: string; status: string; error: string | null }>;
+    };
+    const failedStep = body.steps.find(step => step.status === 'failed');
+    expect(failedStep).toMatchObject({
+      type: 'assertion',
+      error: expect.stringContaining('AssertionError'),
+    });
+  });
+
   it('getTest sample carries priority field (G1a)', () => {
     const e = findSample('GET', 'https://api.testsprite.com/api/cli/v1/tests/test_abc');
     expect(e?.operationId).toBe('getTest');

--- a/src/lib/dry-run/samples.test.ts
+++ b/src/lib/dry-run/samples.test.ts
@@ -412,8 +412,10 @@ describe('findSample', () => {
     );
     expect(e?.operationId).toBe('getRun');
     const body = e?.body() as {
+      failedStepIndex: number | null;
       steps: Array<{ type: string; status: string; error: string | null }>;
     };
+    expect(body.failedStepIndex).toBe(3);
     const failedStep = body.steps.find(step => step.status === 'failed');
     expect(failedStep).toMatchObject({
       type: 'assertion',

--- a/src/lib/dry-run/samples.ts
+++ b/src/lib/dry-run/samples.ts
@@ -713,6 +713,17 @@ const ENTRIES: DryRunSampleEntry[] = [
         htmlSnapshotUrl: null,
         createdAt: '2026-05-15T19:32:20.000Z',
       },
+      {
+        stepIndex: '0003',
+        type: 'assertion',
+        action: 'assert_visible',
+        status: 'failed',
+        description: 'Confirmation toast is visible',
+        error: 'AssertionError: confirmation toast did not appear before timeout',
+        screenshotUrl: 'https://s3-presigned.example.com/snap/run-step-0003.png?X-Amz-dryrun',
+        htmlSnapshotUrl: 'https://s3-presigned.example.com/snap/run-step-0003.html?X-Amz-dryrun',
+        createdAt: '2026-05-15T19:32:30.000Z',
+      },
     ],
   } satisfies RunResponse),
 ];

--- a/src/lib/dry-run/samples.ts
+++ b/src/lib/dry-run/samples.ts
@@ -677,7 +677,7 @@ const ENTRIES: DryRunSampleEntry[] = [
     codeVersion: 'v1',
     targetUrl: SAMPLE_TARGET_URL,
     createdFrom: null,
-    failedStepIndex: null,
+    failedStepIndex: 3,
     failureKind: null,
     error: null,
     videoUrl: null,


### PR DESCRIPTION
## Summary
- carry `RunStepDto.type` into `CliTestStep.stepType`
- carry per-step `RunStepDto.error` into JSON output for `test steps --run-id`
- render an indented `error:` sub-line below steps that include backend failure text

Fixes #126.

## Tests
- npm test -- src/commands/test.test.ts -t=run-id
- npm run lint
- npm run typecheck
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test step output now includes step type details and surfaces step-specific error messages in both JSON and text formats.
  * Text output now displays an additional indented `error:` line under the failed step row when an error is present.

* **Bug Fixes**
  * Improved `--run-id` output validation to consistently report per-step fields, including correct failure-related information.
  * JSON output now preserves the exact per-step error text for failed steps.

* **Tests**
  * Added coverage for `--run-id` when a specific failed step includes an error string, plus updated dry-run sample assertions for failed assertion steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->