### PR TITLE
fix(http): clear per-attempt timeout timers

### DIFF
--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -449,6 +449,52 @@ describe('HttpClient per-request timeout', () => {
     expect(callCount).toBe(1);
   });
 
+  it('clears the per-attempt timeout after a successful response body is read', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const fetchImpl = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      capturedSignal = init?.signal ?? undefined;
+      return jsonResponse({ ok: true });
+    });
+    const client = new HttpClient({
+      baseUrl: 'https://api.example.com/api/cli/v1',
+      apiKey: 'sk-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: () => Promise.resolve(),
+      random: () => 0,
+      requestTimeoutMs: 25,
+    });
+
+    await expect(client.get('/me')).resolves.toEqual({ ok: true });
+    expect(capturedSignal?.aborted).toBe(false);
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(capturedSignal?.aborted).toBe(false);
+  });
+
+  it('clears a failed attempt timeout before retry backoff sleeps', async () => {
+    const attemptSignals: AbortSignal[] = [];
+    let calls = 0;
+    const fetchImpl = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      if (init?.signal) attemptSignals.push(init.signal);
+      calls += 1;
+      if (calls === 1) return errorEnvelopeResponse(500, 'INTERNAL');
+      return jsonResponse({ ok: true });
+    });
+    const client = new HttpClient({
+      baseUrl: 'https://api.example.com/api/cli/v1',
+      apiKey: 'sk-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: () => new Promise(resolve => setTimeout(resolve, 50)),
+      random: () => 0,
+      requestTimeoutMs: 25,
+    });
+
+    await expect(client.get('/me')).resolves.toEqual({ ok: true });
+    expect(attemptSignals).toHaveLength(2);
+    expect(attemptSignals.every(signal => signal.aborted === false)).toBe(true);
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(attemptSignals.every(signal => signal.aborted === false)).toBe(true);
+  });
+
   it('caller-supplied AbortSignal still propagates as AbortError (not RequestTimeoutError)', async () => {
     const controller = new AbortController();
     // Abort immediately

--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -521,6 +521,33 @@ describe('HttpClient per-request timeout', () => {
     expect((err as Error).name).toBe('AbortError');
   });
 
+  it('preserves RequestTimeoutError when the caller aborts after the request timeout wins', async () => {
+    const controller = new AbortController();
+    const fetchImpl = vi.fn(async (_input: unknown, init?: { signal?: AbortSignal }) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const reason = init.signal?.reason;
+          controller.abort(new Error('caller aborted after timeout'));
+          const err = new Error(reason?.message ?? 'timed out');
+          err.name = reason?.name ?? 'TimeoutError';
+          reject(err);
+        });
+      });
+    });
+    const client = new HttpClient({
+      baseUrl: 'https://api.example.com/api/cli/v1',
+      apiKey: 'sk-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: () => Promise.resolve(),
+      random: () => 0,
+      requestTimeoutMs: 1,
+    });
+    const err = await client.get('/me', { signal: controller.signal }).catch(e => e);
+    expect(err).toBeInstanceOf(RequestTimeoutError);
+    expect((err as RequestTimeoutError).exitCode).toBe(7);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it('defaults to REQUEST_TIMEOUT_DEFAULT_MS when no requestTimeoutMs is supplied', () => {
     // Verify the default is wired without actually waiting 120s.
     // We test via the exported constant rather than exercising the stall.

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -395,9 +395,15 @@ export class HttpClient {
     timeoutSignal: AbortSignal,
     callerSignal: AbortSignal | undefined,
     requestId: string,
+    effectiveSignal: AbortSignal = timeoutSignal,
   ): void {
     if (isAbortError(err) || isTimeoutError(err)) {
-      if (timeoutSignal.aborted && (callerSignal == null || !callerSignal.aborted)) {
+      const timeoutWon =
+        timeoutSignal.aborted &&
+        (callerSignal == null ||
+          !callerSignal.aborted ||
+          effectiveSignal.reason === timeoutSignal.reason);
+      if (timeoutWon) {
         throw new RequestTimeoutError(this.requestTimeoutMs, requestId);
       }
       throw err;
@@ -451,7 +457,7 @@ export class HttpClient {
           // the caller hadn't already aborted, surface a clear RequestTimeoutError.
           // A timeout/abort during the fetch itself: classify it (RequestTimeoutError
           // when our deadline fired; otherwise rethrow the caller's abort unmodified).
-          this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId);
+          this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId, effectiveSignal);
           // If a RequestTimeoutError already propagated from somewhere (e.g. from a
           // nested call or from a test-injected fetchImpl), pass it through unchanged
           // rather than re-wrapping it as a TransportError.
@@ -500,8 +506,14 @@ export class HttpClient {
             return { body: (await response.json()) as T, requestId, status: response.status };
           } catch (err) {
             // A timeout/abort can fire mid-body-read (headers received, stream stalls).
-            this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId);
-            throw err;
+            this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId, effectiveSignal);
+            // Otherwise the successful response body was not valid JSON — a
+            // misconfigured endpoint, a proxy / captive-portal / login page that
+            // returns HTML with a 200 status, or an empty body. Surface a typed
+            // error carrying the requestId instead of letting the raw SyntaxError
+            // escape to index.ts, where it would print a bare `{"error":"..."}`
+            // and break the --output json envelope contract.
+            throw malformedResponseError(response, requestId, err);
           }
         }
 
@@ -511,14 +523,8 @@ export class HttpClient {
         } catch (err) {
           // safeReadJson rethrows aborts/timeouts (it swallows only non-abort parse
           // errors), so a timeout fired mid-body-read on a non-OK response lands here.
-          this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId);
-          // Otherwise the successful response body was not valid JSON — a
-          // misconfigured endpoint, a proxy / captive-portal / login page that
-          // returns HTML with a 200 status, or an empty body. Surface a typed
-          // error carrying the requestId instead of letting the raw SyntaxError
-          // escape to index.ts, where it would print a bare `{"error":"..."}`
-          // and break the --output json envelope contract.
-          throw malformedResponseError(response, requestId, err);
+          this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId, effectiveSignal);
+          throw err;
         }
 
         // Edge proxies / load balancers return 408/502/504 without our error

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -428,75 +428,89 @@ export class HttpClient {
       // signal. The polling path supplies its own deadline-aware signal per
       // iteration — this timeout (120s default) is safely larger than any single
       // long-poll window (<=25s via ?waitSeconds), so it never bites polling.
-      const timeoutSignal = AbortSignal.timeout(this.requestTimeoutMs);
+      const requestTimeout = createRequestTimeout(this.requestTimeoutMs);
+      const timeoutSignal = requestTimeout.signal;
       const effectiveSignal =
         options.signal != null ? AbortSignal.any([timeoutSignal, options.signal]) : timeoutSignal;
 
       try {
-        response = await this.fetchImpl(url, {
-          method,
-          headers: this.buildHeaders(requestId, options),
-          body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
-          signal: effectiveSignal,
-        });
-      } catch (err) {
-        // Distinguish a client-side request timeout from a caller-supplied abort.
-        //
-        // Node 22 `AbortSignal.timeout()` throws a `DOMException` with
-        // `name === 'TimeoutError'` (not 'AbortError') when the signal fires.
-        // A caller-supplied abort sets `name === 'AbortError'`.
-        // We treat both abort variants together: if the timeout signal fired and
-        // the caller hadn't already aborted, surface a clear RequestTimeoutError.
-        // A timeout/abort during the fetch itself: classify it (RequestTimeoutError
-        // when our deadline fired; otherwise rethrow the caller's abort unmodified).
-        this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId);
-        // If a RequestTimeoutError already propagated from somewhere (e.g. from a
-        // nested call or from a test-injected fetchImpl), pass it through unchanged
-        // rather than re-wrapping it as a TransportError.
-        if (err instanceof RequestTimeoutError) throw err;
-        const message = err instanceof Error ? err.message : String(err);
-        this.debug({
-          kind: 'error',
-          method,
-          url,
-          attempt,
-          requestId,
-          errorCode: 'TRANSPORT',
-          durationMs: Date.now() - startedAt,
-        });
-        const decision = transportRetryDecision(attempt, this.random);
-        if (!decision.retry) throw new TransportError(message, requestId);
-        this.transition(
-          `Network error on ${shortPath(path)} — retrying in ${Math.round(decision.delayMs / 1000)}s (attempt ${attempt})`,
-        );
-        this.debug({
-          kind: 'retry',
-          method,
-          url,
-          attempt,
-          requestId,
-          errorCode: 'TRANSPORT',
-          delayMs: decision.delayMs,
-        });
-        await this.sleep(decision.delayMs);
-        continue;
-      }
-
-      const durationMs = Date.now() - startedAt;
-      if (response.ok) {
-        this.debug({
-          kind: 'response',
-          method,
-          url,
-          attempt,
-          status: response.status,
-          requestId,
-          durationMs,
-        });
         try {
-          return { body: (await response.json()) as T, requestId, status: response.status };
+          response = await this.fetchImpl(url, {
+            method,
+            headers: this.buildHeaders(requestId, options),
+            body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+            signal: effectiveSignal,
+          });
         } catch (err) {
-          // A timeout/abort can fire mid-body-read (headers received, stream stalls).
+          // Distinguish a client-side request timeout from a caller-supplied abort.
+          //
+          // The request-timeout controller aborts with an Error/DOMException whose
+          // `name === 'TimeoutError'` (not 'AbortError') when the signal fires.
+          // A caller-supplied abort sets `name === 'AbortError'`.
+          // We treat both abort variants together: if the timeout signal fired and
+          // the caller hadn't already aborted, surface a clear RequestTimeoutError.
+          // A timeout/abort during the fetch itself: classify it (RequestTimeoutError
+          // when our deadline fired; otherwise rethrow the caller's abort unmodified).
+          this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId);
+          // If a RequestTimeoutError already propagated from somewhere (e.g. from a
+          // nested call or from a test-injected fetchImpl), pass it through unchanged
+          // rather than re-wrapping it as a TransportError.
+          if (err instanceof RequestTimeoutError) throw err;
+          const message = err instanceof Error ? err.message : String(err);
+          this.debug({
+            kind: 'error',
+            method,
+            url,
+            attempt,
+            requestId,
+            errorCode: 'TRANSPORT',
+            durationMs: Date.now() - startedAt,
+          });
+          const decision = transportRetryDecision(attempt, this.random);
+          if (!decision.retry) throw new TransportError(message, requestId);
+          this.transition(
+            `Network error on ${shortPath(path)} — retrying in ${Math.round(decision.delayMs / 1000)}s (attempt ${attempt})`,
+          );
+          this.debug({
+            kind: 'retry',
+            method,
+            url,
+            attempt,
+            requestId,
+            errorCode: 'TRANSPORT',
+            delayMs: decision.delayMs,
+          });
+          requestTimeout.clear();
+          await this.sleep(decision.delayMs);
+          continue;
+        }
+
+        const durationMs = Date.now() - startedAt;
+        if (response.ok) {
+          this.debug({
+            kind: 'response',
+            method,
+            url,
+            attempt,
+            status: response.status,
+            requestId,
+            durationMs,
+          });
+          try {
+            return { body: (await response.json()) as T, requestId, status: response.status };
+          } catch (err) {
+            // A timeout/abort can fire mid-body-read (headers received, stream stalls).
+            this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId);
+            throw err;
+          }
+        }
+
+        let rawBody: unknown;
+        try {
+          rawBody = await safeReadJson(response);
+        } catch (err) {
+          // safeReadJson rethrows aborts/timeouts (it swallows only non-abort parse
+          // errors), so a timeout fired mid-body-read on a non-OK response lands here.
           this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId);
           // Otherwise the successful response body was not valid JSON — a
           // misconfigured endpoint, a proxy / captive-portal / login page that
@@ -506,112 +520,108 @@ export class HttpClient {
           // and break the --output json envelope contract.
           throw malformedResponseError(response, requestId, err);
         }
-      }
 
-      let rawBody: unknown;
-      try {
-        rawBody = await safeReadJson(response);
-      } catch (err) {
-        // safeReadJson rethrows aborts/timeouts (it swallows only non-abort parse
-        // errors), so a timeout fired mid-body-read on a non-OK response lands here.
-        this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId);
-        throw err;
-      }
+        // Edge proxies / load balancers return 408/502/504 without our error
+        // envelope on transient outages. Per the CLI error spec §7 these are
+        // transport-level retries, not facade errors — fold them in here so
+        // we get the bounded backoff budget instead of a single INTERNAL bail.
+        if (rawBody === null && isTransportEdgeStatus(response.status)) {
+          this.debug({
+            kind: 'error',
+            method,
+            url,
+            attempt,
+            status: response.status,
+            requestId,
+            errorCode: 'TRANSPORT',
+            durationMs,
+          });
+          const decision = transportRetryDecision(attempt, this.random);
+          if (!decision.retry) {
+            throw new TransportError(`HTTP ${response.status} from ${url}`, requestId);
+          }
+          this.transition(
+            `HTTP ${response.status} from ${shortPath(path)} — transport error, retrying in ${Math.round(decision.delayMs / 1000)}s (attempt ${attempt})`,
+          );
+          this.debug({
+            kind: 'retry',
+            method,
+            url,
+            attempt,
+            requestId,
+            errorCode: 'TRANSPORT',
+            delayMs: decision.delayMs,
+          });
+          requestTimeout.clear();
+          await this.sleep(decision.delayMs);
+          continue;
+        }
 
-      // Edge proxies / load balancers return 408/502/504 without our error
-      // envelope on transient outages. Per the CLI error spec §7 these are
-      // transport-level retries, not facade errors — fold them in here so
-      // we get the bounded backoff budget instead of a single INTERNAL bail.
-      if (rawBody === null && isTransportEdgeStatus(response.status)) {
+        const retryAfterSec = parseRetryAfter(response.headers.get('retry-after'));
+        // Clamp server-directed Retry-After to [1s, 300s] and surface on the
+        // thrown error so outer callers (e.g. runBatchRun outer retry loop)
+        // can honor it without re-reading the now-consumed HTTP response.
+        const retryAfterMsForError =
+          retryAfterSec !== undefined
+            ? Math.min(Math.max(retryAfterSec, 1), 300) * 1000
+            : undefined;
+        const apiError = ApiError.fromEnvelope(
+          rawBody,
+          response.status,
+          retryAfterMsForError,
+          // Lets synthesized nextAction text (e.g. INSUFFICIENT_CREDITS billing
+          // links) resolve the environment-correct portal domain.
+          this.baseUrl,
+        );
         this.debug({
           kind: 'error',
           method,
           url,
           attempt,
           status: response.status,
+          errorCode: apiError.code,
           requestId,
-          errorCode: 'TRANSPORT',
           durationMs,
         });
-        const decision = transportRetryDecision(attempt, this.random);
-        if (!decision.retry) {
-          throw new TransportError(`HTTP ${response.status} from ${url}`, requestId);
-        }
-        this.transition(
-          `HTTP ${response.status} from ${shortPath(path)} — transport error, retrying in ${Math.round(decision.delayMs / 1000)}s (attempt ${attempt})`,
+        const retryOnConflict = options.retryOnConflict !== false;
+        const retryOnRateLimit = options.retryOnRateLimit !== false;
+        const decision = apiRetryDecision(
+          apiError.code,
+          attempt,
+          retryAfterSec,
+          this.random,
+          retryOnConflict,
+          retryOnRateLimit,
         );
+        if (!decision.retry) throw apiError;
+        const delaySec = Math.round(decision.delayMs / 1000);
+        if (apiError.code === 'RATE_LIMITED') {
+          this.transition(
+            `Rate limited (HTTP 429) — waiting ${delaySec}s before retry (attempt ${attempt})`,
+          );
+        } else if (apiError.code === 'INTERNAL') {
+          this.transition(
+            `Server error (HTTP 5xx, requestId: ${requestId}) — retrying in ${delaySec}s (attempt ${attempt})`,
+          );
+        } else if (apiError.code === 'UNAVAILABLE') {
+          this.transition(
+            `Service unavailable (HTTP 503) — retrying in ${delaySec}s (attempt ${attempt})`,
+          );
+        }
         this.debug({
           kind: 'retry',
           method,
           url,
           attempt,
           requestId,
-          errorCode: 'TRANSPORT',
+          errorCode: apiError.code,
           delayMs: decision.delayMs,
         });
+        requestTimeout.clear();
         await this.sleep(decision.delayMs);
-        continue;
+      } finally {
+        requestTimeout.clear();
       }
-
-      const retryAfterSec = parseRetryAfter(response.headers.get('retry-after'));
-      // Clamp server-directed Retry-After to [1s, 300s] and surface on the
-      // thrown error so outer callers (e.g. runBatchRun outer retry loop)
-      // can honor it without re-reading the now-consumed HTTP response.
-      const retryAfterMsForError =
-        retryAfterSec !== undefined ? Math.min(Math.max(retryAfterSec, 1), 300) * 1000 : undefined;
-      const apiError = ApiError.fromEnvelope(
-        rawBody,
-        response.status,
-        retryAfterMsForError,
-        // Lets synthesized nextAction text (e.g. INSUFFICIENT_CREDITS billing
-        // links) resolve the environment-correct portal domain.
-        this.baseUrl,
-      );
-      this.debug({
-        kind: 'error',
-        method,
-        url,
-        attempt,
-        status: response.status,
-        errorCode: apiError.code,
-        requestId,
-        durationMs,
-      });
-      const retryOnConflict = options.retryOnConflict !== false;
-      const retryOnRateLimit = options.retryOnRateLimit !== false;
-      const decision = apiRetryDecision(
-        apiError.code,
-        attempt,
-        retryAfterSec,
-        this.random,
-        retryOnConflict,
-        retryOnRateLimit,
-      );
-      if (!decision.retry) throw apiError;
-      const delaySec = Math.round(decision.delayMs / 1000);
-      if (apiError.code === 'RATE_LIMITED') {
-        this.transition(
-          `Rate limited (HTTP 429) — waiting ${delaySec}s before retry (attempt ${attempt})`,
-        );
-      } else if (apiError.code === 'INTERNAL') {
-        this.transition(
-          `Server error (HTTP 5xx, requestId: ${requestId}) — retrying in ${delaySec}s (attempt ${attempt})`,
-        );
-      } else if (apiError.code === 'UNAVAILABLE') {
-        this.transition(
-          `Service unavailable (HTTP 503) — retrying in ${delaySec}s (attempt ${attempt})`,
-        );
-      }
-      this.debug({
-        kind: 'retry',
-        method,
-        url,
-        attempt,
-        requestId,
-        errorCode: apiError.code,
-        delayMs: decision.delayMs,
-      });
-      await this.sleep(decision.delayMs);
     }
   }
 
@@ -685,6 +695,39 @@ export function buildUrl(
 
 function newRequestId(): string {
   return `cli_${randomUUID()}`;
+}
+
+interface RequestTimeoutHandle {
+  signal: AbortSignal;
+  clear: () => void;
+}
+
+function createRequestTimeout(timeoutMs: number): RequestTimeoutHandle {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort(makeTimeoutReason());
+  }, timeoutMs);
+  unrefTimer(timer);
+
+  return {
+    signal: controller.signal,
+    clear: () => clearTimeout(timer),
+  };
+}
+
+function makeTimeoutReason(): Error {
+  if (typeof DOMException !== 'undefined') {
+    return new DOMException('The operation timed out.', 'TimeoutError');
+  }
+  const err = new Error('The operation timed out.');
+  err.name = 'TimeoutError';
+  return err;
+}
+
+function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
+  if (typeof timer !== 'object' || timer === null || !('unref' in timer)) return;
+  const unref = (timer as { unref?: () => void }).unref;
+  if (typeof unref === 'function') unref.call(timer);
 }
 
 async function safeReadJson(response: Response): Promise<unknown> {


### PR DESCRIPTION
## Summary
- replace per-attempt `AbortSignal.timeout(...)` with an explicit `AbortController` + clearable timer
- clear the attempt timeout after response bodies settle and before retry backoff sleeps
- add regression coverage proving settled attempt signals do not abort later

Fixes #82.

## Tests
- npm test -- src/lib/http.test.ts
- npm run typecheck
- npm run lint
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed per-request timeout behavior so timeouts are cleared after successful responses and don’t interfere across retry/backoff periods.
  * Improved combined caller-abort and timeout handling to ensure the correct error type is surfaced when both could trigger.
  * Refined retry behavior for non-OK responses by honoring a clamped `Retry-After` value during error classification and retry decisions.
* **Tests**
  * Added coverage for per-attempt timeout clearing, retry signal handling, and timeout-vs-caller-abort error precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->