### PR TITLE
fix(project): reject blank inline passwords

### DIFF
--- a/src/commands/project.test.ts
+++ b/src/commands/project.test.ts
@@ -596,6 +596,33 @@ describe('runCreate', () => {
     ).rejects.toMatchObject({ exitCode: 5, code: 'VALIDATION_ERROR' });
     expect(fetchImpl).not.toHaveBeenCalled();
   });
+  it('rejects a whitespace-only --password with VALIDATION_ERROR (exit 5), no network', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('should not hit network - validation must fire client-side');
+    });
+
+    await expect(
+      runCreate(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          type: 'frontend',
+          name: 'Password Guard Project',
+          targetUrl: 'https://example.com',
+          password: '   ',
+        },
+        {
+          credentialsPath,
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          stdout: () => {},
+          stderr: () => {},
+        },
+      ),
+    ).rejects.toMatchObject({ exitCode: 5, code: 'VALIDATION_ERROR' });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -698,6 +725,30 @@ describe('runUpdate', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it('rejects a whitespace-only --password with VALIDATION_ERROR (exit 5), no network', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('should not be called');
+    });
+    await expect(
+      runUpdate(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          projectId: 'proj_abc',
+          password: '   ',
+        },
+        {
+          credentialsPath,
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          stdout: () => {},
+          stderr: () => {},
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
   it('P7 — dry-run returns canned shape without network call', async () => {
     resetDryRunBannerForTesting();
     const { credentialsPath } = makeCreds();

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -150,6 +150,9 @@ export async function runCreate(
   if (opts.name !== undefined && opts.name.trim().length === 0) {
     throw localValidationError('--name must not be empty or whitespace-only');
   }
+  if (opts.password !== undefined && opts.password.trim().length === 0) {
+    throw localValidationError('--password must not be empty or whitespace-only');
+  }
 
   // P1-3: client-side length checks matching server limits.
   if (opts.name !== undefined && opts.name.length > 200) {
@@ -263,6 +266,9 @@ export async function runUpdate(
   // P1-3: client-side length checks matching server limits.
   if (opts.name !== undefined && opts.name.trim().length === 0) {
     throw localValidationError('--name must not be empty or whitespace-only');
+  }
+  if (opts.password !== undefined && opts.password.trim().length === 0) {
+    throw localValidationError('--password must not be empty or whitespace-only');
   }
   if (opts.name !== undefined && opts.name.length > 200) {
     throw localValidationError('--name must be at most 200 characters');


### PR DESCRIPTION
Refs #88

Discord: npall_805

## Summary
- Reject inline `project create --password ""` / whitespace-only values before creating the HTTP client.
- Reject inline `project update --password ""` / whitespace-only values before dry-run or network paths can treat it as a mutable update.
- Preserve valid non-empty passwords exactly as supplied; this only checks `trim().length === 0` for validation.

## Validation
- `npm test -- src/commands/project.test.ts` -> 34 passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `npm run build` -> passed
- `npx prettier --check src/commands/project.ts src/commands/project.test.ts` -> passed
- `git diff --check` -> clean apart from Windows LF/CRLF working-copy warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI now rejects empty or whitespace-only `--password` values during create and update commands.
  * Invalid passwords are caught locally with a validation error before any request is sent.
* **Tests**
  * Added coverage for whitespace-only password validation in both create and update flows.
  * Confirmed no network request is made when validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->