### PR TITLE
fix: reject malformed api keys before fetch

### DIFF
--- a/src/lib/client-factory.test.ts
+++ b/src/lib/client-factory.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   DRY_RUN_API_KEY,
   DRY_RUN_BANNER,
+  assertValidApiKeyHeaderValue,
   assertValidEndpointUrl,
   emitDryRunBanner,
   makeHttpClient,
@@ -330,6 +331,58 @@ describe('makeHttpClient — real path (regression)', () => {
 // ---------------------------------------------------------------------------
 // assertValidEndpointUrl — endpoint syntax guard (NOT an SSRF guard)
 // ---------------------------------------------------------------------------
+
+describe('makeHttpClient - API key validation', () => {
+  it.each([
+    ['newline', 'sk-user-abc\ndef'],
+    ['carriage return', 'sk-user-abc\rdef'],
+    ['smart dash', 'sk-user-abc\u2013def'],
+    ['smart quote', 'sk-user-\u201cabc\u201d'],
+    ['emoji', 'sk-user-abc\u{1f600}'],
+    ['whitespace-only', '   '],
+  ])('rejects a malformed configured API key with %s before fetch/retry', (_label, apiKey) => {
+    const fetchImpl = vi.fn();
+    let caught: unknown;
+    try {
+      makeHttpClient(
+        { profile: 'default', output: 'json', debug: false, dryRun: false },
+        {
+          env: { TESTSPRITE_API_KEY: apiKey } as NodeJS.ProcessEnv,
+          credentialsPath: NO_CREDS_PATH,
+          fetchImpl,
+        },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(caught).toBeInstanceOf(ApiError);
+    const apiErr = caught as ApiError;
+    expect(apiErr.code).toBe('VALIDATION_ERROR');
+    expect(apiErr.exitCode).toBe(5);
+    expect(apiErr.nextAction).toContain('api-key');
+  });
+});
+
+describe('assertValidApiKeyHeaderValue', () => {
+  it('accepts a normal ASCII API key value', () => {
+    expect(() => assertValidApiKeyHeaderValue('sk-user-abc-def_123')).not.toThrow();
+  });
+
+  it('throws a VALIDATION_ERROR (exit 5) for a key that cannot be sent as x-api-key', () => {
+    let caught: unknown;
+    try {
+      assertValidApiKeyHeaderValue('sk-user-abc\u2013def');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ApiError);
+    const apiErr = caught as ApiError;
+    expect(apiErr.code).toBe('VALIDATION_ERROR');
+    expect(apiErr.exitCode).toBe(5);
+    expect(apiErr.nextAction).toContain('api-key');
+  });
+});
 
 describe('assertValidEndpointUrl', () => {
   it('accepts http(s) URLs, including private / localhost hosts (self-hosted, dev, mock)', () => {

--- a/src/lib/client-factory.ts
+++ b/src/lib/client-factory.ts
@@ -180,6 +180,22 @@ export function assertValidEndpointUrl(rawUrl: string): void {
   }
 }
 
+export function assertValidApiKeyHeaderValue(apiKey: string): void {
+  const reason =
+    'must be a non-empty HTTP header value; paste the raw key without smart punctuation, emoji, or line breaks';
+
+  if (apiKey.trim().length === 0) {
+    throw localValidationError('api-key', reason, undefined, 'field');
+  }
+
+  for (let i = 0; i < apiKey.length; i += 1) {
+    const code = apiKey.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f || code > 0xff) {
+      throw localValidationError('api-key', reason, undefined, 'field');
+    }
+  }
+}
+
 /**
  * Parse the `--request-timeout <seconds>` flag value into milliseconds.
  *
@@ -251,6 +267,7 @@ export function makeHttpClient(opts: CommonOptions, deps: ClientFactoryDeps = {}
   // VALIDATION_ERROR rather than an opaque URL throw or a retried "fetch failed".
   assertValidEndpointUrl(config.apiUrl);
   if (!config.apiKey) throw ApiError.authRequired();
+  assertValidApiKeyHeaderValue(config.apiKey);
   return new HttpClient({
     baseUrl: facadeBaseUrl(config.apiUrl),
     apiKey: config.apiKey,


### PR DESCRIPTION
Refs #93

Discord: npall_805

Summary:
- validate the configured API key before constructing HttpClient
- reject whitespace-only keys, HTTP control characters, and non-ByteString characters such as smart punctuation and emoji as local VALIDATION_ERROR exit 5
- add regression coverage for malformed env/config API keys before fetch/retry

Validation:
- npm test -- src/lib/client-factory.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npx prettier --check src/lib/client-factory.ts src/lib/client-factory.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for API keys before creating network clients, helping catch invalid keys earlier.
  * Improved error reporting when an API key is missing or not usable, with clearer guidance on the affected field.

* **Bug Fixes**
  * Prevented requests from being attempted when the configured API key is invalid.
  * Added coverage to ensure valid keys are accepted and invalid ones fail consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->