### PR TITLE
fix: handle non-json 200 responses

### DIFF
--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -108,6 +108,29 @@ describe('HttpClient happy path', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it('maps a 200 non-JSON body to a typed UNAVAILABLE error', async () => {
+    const events: DebugEvent[] = [];
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('<!DOCTYPE html>', { status: 200, headers: { 'content-type': 'text/html' } }),
+    );
+    const client = makeClient(fetchImpl as unknown as typeof fetch, {
+      onDebug: e => events.push(e),
+    });
+    const err = await client.get('/projects').catch(e => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err).toMatchObject({
+      code: 'UNAVAILABLE',
+      exitCode: 10,
+      httpStatus: 200,
+      details: { status: 200, contentType: 'text/html' },
+    });
+    expect((err as ApiError).nextAction).toContain('TESTSPRITE_API_URL');
+    expect((err as Error).message).not.toContain('<!DOCTYPE');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(events.map(e => e.kind)).toEqual(['request', 'response', 'error']);
+  });
+
   it('sends User-Agent header as testsprite-cli/<version>', async () => {
     const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
       const headers = new Headers(init?.headers);

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -498,7 +498,18 @@ export class HttpClient {
         } catch (err) {
           // A timeout/abort can fire mid-body-read (headers received, stream stalls).
           this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId);
-          throw err;
+          const apiError = nonJsonSuccessResponseError(response, requestId);
+          this.debug({
+            kind: 'error',
+            method,
+            url,
+            attempt,
+            status: response.status,
+            errorCode: apiError.code,
+            requestId,
+            durationMs: Date.now() - startedAt,
+          });
+          throw apiError;
         }
       }
 
@@ -679,6 +690,21 @@ export function buildUrl(
 
 function newRequestId(): string {
   return `cli_${randomUUID()}`;
+}
+
+function nonJsonSuccessResponseError(response: Response, requestId: string): ApiError {
+  const contentType = response.headers.get('content-type') ?? 'unknown';
+  return new ApiError(
+    {
+      code: 'UNAVAILABLE',
+      message: `Expected JSON response but received HTTP ${response.status} with content-type ${contentType}.`,
+      nextAction:
+        'Check --endpoint-url or TESTSPRITE_API_URL. The endpoint may be returning an HTML login page, captive portal, or proxy response instead of the TestSprite API.',
+      requestId,
+      details: { status: response.status, contentType },
+    },
+    response.status,
+  );
 }
 
 async function safeReadJson(response: Response): Promise<unknown> {


### PR DESCRIPTION
Refs #94

Discord: npall_805

Summary:
- map HTTP 200 non-JSON success bodies to a typed UNAVAILABLE ApiError instead of leaking SyntaxError
- preserve abort/timeout classification during body reads
- add regression coverage for text/html 200 responses without retrying or leaking the HTML body

Validation:
- npm test -- src/lib/http.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npx prettier --check src/lib/http.ts src/lib/http.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when a request succeeds but returns non-JSON content.
  * `client.get()` now reports a clearer API error instead of exposing a raw parsing failure.
  * Added richer error details, including HTTP status and response content type, plus guidance for checking endpoint configuration.
  * Debug logging now follows the expected request → response → error sequence for this case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->