### PR TITLE
fix: redact presigned urls in text output

### DIFF
--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -2737,6 +2737,8 @@ describe('runResult', () => {
     expect(seen[0]).toContain('/tests/test_fe/result');
     expect(got).toEqual(RESULT_FAILED);
     expect(JSON.parse(out[0]!)).toEqual(RESULT_FAILED);
+    expect(out[0]).toContain('video/run_abc.mp4?X');
+    expect(out[0]).toContain('analysis/run_abc.json?X');
   });
 
   it('text mode for a failed run highlights failureKind + failedStepIndex up top', async () => {
@@ -2766,7 +2768,14 @@ describe('runResult', () => {
     expect(block).toContain('verdict:            failed');
     expect(block).toContain('executionStatus:    completed');
     expect(block).toContain('summary:            Failed (assertion) on step 5');
-    expect(block).toContain('failureAnalysisUrl: ');
+    expect(block).toContain(
+      'videoUrl:           https://s3-presigned.example.com/video/run_abc.mp4',
+    );
+    expect(block).toContain(
+      'failureAnalysisUrl: https://s3-presigned.example.com/analysis/run_abc.json',
+    );
+    expect(block).not.toContain('video/run_abc.mp4?X');
+    expect(block).not.toContain('analysis/run_abc.json?X');
   });
 
   it('text mode for a passed run skips failureKind/failedStepIndex/failureAnalysisUrl', async () => {
@@ -3476,6 +3485,7 @@ describe('runFailureGet', () => {
     // their LLM consumer.
     expect(out).toHaveLength(1);
     expect(JSON.parse(out[0]!)).toEqual(ctx);
+    expect(out[0]).toContain('run_abc.mp4?sig');
   });
 
   it('text mode (no --out) prints the human summary block', async () => {
@@ -3502,7 +3512,8 @@ describe('runFailureGet', () => {
     expect(block).toContain('rootCause:        Submit button is disabled.');
     expect(block).toContain('recommendedFix:   kind=unknown');
     expect(block).toContain('evidence:         2 items (snapshot×2)');
-    expect(block).toContain('videoUrl:         https://video.example.com');
+    expect(block).toContain('videoUrl:         https://video.example.com/run_abc.mp4');
+    expect(block).not.toContain('run_abc.mp4?sig');
   });
 
   it('--out writes the §7 layout and prints a one-line confirmation', async () => {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -8255,6 +8255,19 @@ function renderStepsText(page: Page<CliTestStep>): string {
  * compact — JSON mode is the automation contract; this is for an
  * engineer running it interactively.
  */
+function redactUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
 function renderFailureContextText(ctx: CliFailureContext): string {
   const lines: string[] = [];
   lines.push(`status:           ${ctx.result.status}`);
@@ -8288,7 +8301,8 @@ function renderFailureContextText(ctx: CliFailureContext): string {
     const breakdown = [...counts.entries()].map(([k, n]) => `${k}×${n}`).join(', ');
     lines.push(`evidence:         ${ctx.failure.evidence.length} items (${breakdown})`);
   }
-  if (ctx.result.videoUrl !== null) lines.push(`videoUrl:         ${ctx.result.videoUrl}`);
+  if (ctx.result.videoUrl !== null)
+    lines.push(`videoUrl:         ${redactUrl(ctx.result.videoUrl)}`);
   return lines.join('\n');
 }
 
@@ -8408,8 +8422,9 @@ function renderResultText(r: CliLatestResult): string {
   if (r.codeVersion !== null) lines.push(`codeVersion:        ${r.codeVersion}`);
   if (r.targetUrl !== null) lines.push(`targetUrl:          ${r.targetUrl}`);
   lines.push(`summary:            ${r.summary}`);
-  if (r.videoUrl !== null) lines.push(`videoUrl:           ${r.videoUrl}`);
-  if (r.failureAnalysisUrl !== null) lines.push(`failureAnalysisUrl: ${r.failureAnalysisUrl}`);
+  if (r.videoUrl !== null) lines.push(`videoUrl:           ${redactUrl(r.videoUrl)}`);
+  if (r.failureAnalysisUrl !== null)
+    lines.push(`failureAnalysisUrl: ${redactUrl(r.failureAnalysisUrl)}`);
   if (r.analysis !== undefined) {
     // §6.5.1 (M2.1 piece 3) — render the inline analysis block under
     // the result summary. Only fires when the caller passed


### PR DESCRIPTION
Refs #86

Discord: npall_805

Summary:
- redact query strings, fragments, and userinfo from video/failure-analysis URLs in text renderers
- keep --output json unchanged so automation still receives raw presigned URLs
- add regression coverage for test result and failure get text/json paths

Validation:
- npm test -- src/commands/test.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npx prettier --check src/commands/test.ts src/commands/test.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI output so sensitive parts of video and failure-analysis links are no longer shown in text mode.
  * Preserved full link details in JSON output while making human-readable summaries cleaner and safer.
  * Updated test coverage to match the new link formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->