### PR TITLE
fix(project): validate list flags before client setup

### DIFF
--- a/src/commands/project.test.ts
+++ b/src/commands/project.test.ts
@@ -199,6 +199,47 @@ describe('runList', () => {
     });
   });
 
+  it('rejects invalid pagination before requiring credentials', async () => {
+    const credentialsPath = join(mkdtempSync(join(tmpdir(), 'cli-p2-no-creds-')), 'credentials');
+    const fetchImpl = vi.fn();
+
+    await expect(
+      runList(
+        { profile: 'default', output: 'json', debug: false, pageSize: 1.5 },
+        { credentialsPath, fetchImpl: fetchImpl as unknown as typeof globalThis.fetch },
+      ),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+      details: { field: 'page-size' },
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid dry-run pagination before emitting the dry-run banner', async () => {
+    const stderr: string[] = [];
+    const fetchImpl = vi.fn();
+
+    await expect(
+      runList(
+        { profile: 'default', output: 'json', debug: false, dryRun: true, pageSize: 1.5 },
+        {
+          credentialsPath: join(mkdtempSync(join(tmpdir(), 'cli-p2-dryrun-')), 'credentials'),
+          fetchImpl: fetchImpl as unknown as typeof globalThis.fetch,
+          stderr: line => stderr.push(line),
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+      details: { field: 'page-size' },
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(stderr.join('\n')).not.toContain(DRY_RUN_BANNER);
+  });
+
   it('rejects pageSize=101 with VALIDATION_ERROR exit 5 (Fix 7 — upper-bound enforced client-side)', async () => {
     // Previously silently clamped to 100; now rejected so callers get fast feedback.
     const { credentialsPath } = makeCreds();

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -51,13 +51,13 @@ export async function runList(
   deps: ProjectDeps = {},
 ): Promise<Page<CliProject>> {
   const out = makeOutput(opts.output, deps);
-  const client = makeClient(opts, deps);
 
   const paginationFlags: PaginationFlags = validatePaginationFlags({
     pageSize: opts.pageSize,
     startingToken: opts.startingToken,
     maxItems: opts.maxItems,
   });
+  const client = makeClient(opts, deps);
 
   // When the user explicitly passed a page-size flag and did NOT ask
   // for --max-items, treat that as a "give me one page and the cursor"


### PR DESCRIPTION
## Summary

Fixes #148.

`project list` now validates pagination flags before constructing the HTTP client.

## Why

Before this change, invalid local flags could be hidden by client setup:

- fresh/no-credentials environments returned `AUTH_REQUIRED` before rejecting invalid pagination
- `--dry-run` emitted its sample-response banner before rejecting the invalid flag

The sibling `test list` path already validates pagination before client setup, so this aligns `project list` with the same local-validation behavior.

## Changes

- Move `validatePaginationFlags(...)` before `makeClient(...)` in `runList`.
- Add regression tests for no-credentials ordering and dry-run banner ordering.

## Verification

- `npm test -- src/commands/project.test.ts`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid pagination values are now rejected immediately, before any connection setup or dry-run output.
  * Non-integer page sizes return a client-side validation error with the correct field highlighted.
  * The command now fails earlier in these cases, avoiding unnecessary requests or side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->