### PR TITLE
fix(test): validate list status before client setup

### DIFF
--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -475,6 +475,34 @@ describe('runList', () => {
     ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', details: { field: 'page-size' } });
   });
 
+  it('rejects invalid --status before requiring credentials', async () => {
+    const credentialsPath = join(mkdtempSync(join(tmpdir(), 'cli-list-status-')), 'credentials');
+    const fetchImpl = vi.fn();
+
+    await expect(
+      runList(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          projectId: 'project_alice',
+          status: 'notastatus',
+        },
+        {
+          credentialsPath,
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          stdout: () => undefined,
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+      details: { field: 'status' },
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it('forwards a server-side VALIDATION_ERROR envelope as ApiError exit 5', async () => {
     const { credentialsPath } = makeCreds();
     const fetchImpl = makeFetch(() => ({

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -452,6 +452,12 @@ export async function runList(opts: ListOptions, deps: TestDeps = {}): Promise<P
     maxItems: opts.maxItems,
   });
 
+  // M2.1 piece 2: validate `--status` tokens client-side before
+  // sending. Friendlier error than waiting for the server's 400 with
+  // a list of accepted tokens — and lets the user fix typos without
+  // a round trip.
+  validateStatusFilter(opts.status);
+
   const out = makeOutput(opts.output, deps);
   const client = makeClient(opts, deps);
 
@@ -459,12 +465,6 @@ export async function runList(opts: ListOptions, deps: TestDeps = {}): Promise<P
   // operator can grab one slice + cursor without auto-paging through a
   // huge project.
   const useSinglePage = opts.pageSize !== undefined && opts.maxItems === undefined;
-
-  // M2.1 piece 2: validate `--status` tokens client-side before
-  // sending. Friendlier error than waiting for the server's 400 with
-  // a list of accepted tokens — and lets the user fix typos without
-  // a round trip.
-  validateStatusFilter(opts.status);
 
   const baseQuery: Record<string, string | number | boolean | undefined> = {
     projectId: opts.projectId,


### PR DESCRIPTION
Fixes #151.

## Summary
- validate `test list --status` before creating the HTTP client
- preserve the existing local `VALIDATION_ERROR` behavior when the status filter is invalid
- add a regression test covering missing credentials so bad input wins over auth setup

## Verification
- `npm test -- src/commands/test.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build` plus a fresh-HOME CLI repro for invalid `--status` returning exit 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid `--status` values are now rejected immediately with a clear validation error before any network request is made.
  * The error response now includes the invalid field name, and the command exits consistently with the expected error code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->