### PR TITLE
fix(rerun): reject explicit IDs with --all and --status/--skip-terminal without --all

### DIFF
--- a/src/commands/test.rerun.spec.ts
+++ b/src/commands/test.rerun.spec.ts
@@ -280,6 +280,126 @@ describe('runTestRerun — validation', () => {
     ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
   });
 
+  it('exit 5 (VALIDATION_ERROR) when explicit test IDs are combined with --all', async () => {
+    // The --all branch resolves the FULL project test set and overwrites the
+    // listed ids, so 'rerun test_abc --all' would silently rerun the ENTIRE
+    // project instead of test_abc — burning rerun/auto-heal credits. The
+    // guard throws BEFORE any network/dispatch. (Mirrors `test run`'s
+    // positional+--all guard and delete-batch's ids+--all guard.)
+    const creds = makeCreds();
+    await expect(
+      runTestRerun(
+        {
+          testIds: ['test_abc'],
+          all: true,
+          projectId: 'proj_1',
+          wait: false,
+          timeoutSeconds: 600,
+          autoHeal: false,
+          autoHealExplicit: false,
+          skipDependencies: false,
+          maxConcurrency: 10,
+          output: 'json',
+          profile: 'default',
+          dryRun: false,
+          debug: false,
+          verbose: false,
+        },
+        { ...creds, sleep: instantSleep },
+      ),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      details: expect.objectContaining({ field: 'test-ids' }),
+    });
+  });
+
+  it('exit 5 (VALIDATION_ERROR) when --status is passed WITHOUT --all', async () => {
+    // --status is an --all-only narrowing filter. With explicit ids it was
+    // silently ignored (both tests dispatched, filter dropped) — same
+    // failure mode as the --filter guard above.
+    const creds = makeCreds();
+    await expect(
+      runTestRerun(
+        {
+          testIds: ['test_a', 'test_b'],
+          all: false,
+          statusFilter: 'failed',
+          wait: false,
+          timeoutSeconds: 600,
+          autoHeal: false,
+          autoHealExplicit: false,
+          skipDependencies: false,
+          maxConcurrency: 10,
+          output: 'json',
+          profile: 'default',
+          dryRun: false,
+          debug: false,
+          verbose: false,
+        },
+        { ...creds, sleep: instantSleep },
+      ),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      details: expect.objectContaining({ field: 'status' }),
+    });
+  });
+
+  it('exit 5 (VALIDATION_ERROR) for an INVALID --status value without --all (was silently accepted)', async () => {
+    // Before the guard, an invalid --status token without --all was never
+    // even validated: 'rerun test_a --status notastatus' exited 0 while the
+    // same flag on delete-batch exits 5.
+    const creds = makeCreds();
+    await expect(
+      runTestRerun(
+        {
+          testIds: ['test_a'],
+          all: false,
+          statusFilter: 'notastatus',
+          wait: false,
+          timeoutSeconds: 600,
+          autoHeal: false,
+          autoHealExplicit: false,
+          skipDependencies: false,
+          maxConcurrency: 10,
+          output: 'json',
+          profile: 'default',
+          dryRun: false,
+          debug: false,
+          verbose: false,
+        },
+        { ...creds, sleep: instantSleep },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+  });
+
+  it('exit 5 (VALIDATION_ERROR) when --skip-terminal is passed WITHOUT --all', async () => {
+    const creds = makeCreds();
+    await expect(
+      runTestRerun(
+        {
+          testIds: ['test_a'],
+          all: false,
+          skipTerminal: true,
+          wait: false,
+          timeoutSeconds: 600,
+          autoHeal: false,
+          autoHealExplicit: false,
+          skipDependencies: false,
+          maxConcurrency: 10,
+          output: 'json',
+          profile: 'default',
+          dryRun: false,
+          debug: false,
+          verbose: false,
+        },
+        { ...creds, sleep: instantSleep },
+      ),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      details: expect.objectContaining({ field: 'skip-terminal' }),
+    });
+  });
+
   it('exit 5 when --all without --project', async () => {
     const creds = makeCreds();
     try {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -5653,6 +5653,18 @@ export async function runTestRerun(
       'provide at least one <test-id>, or use --all to rerun all tests in the project',
     );
   }
+  // Explicit ids + --all is ambiguous: the --all branch resolves the FULL
+  // project test set and overwrites the listed ids, so the user's narrowing
+  // intent would be silently replaced by a whole-project batch rerun —
+  // burning rerun/auto-heal credits. Reject early. (Mirrors `test run`'s
+  // positional+--all guard and delete-batch's ids+--all data-loss guard.)
+  if (opts.all && opts.testIds.length > 0) {
+    throw localValidationError(
+      'test-ids',
+      'pass either explicit test IDs or --all, not both — --all reruns every test in the ' +
+        'project and would ignore the listed IDs. Drop the IDs, or drop --all.',
+    );
+  }
   if (opts.all && !opts.projectId) {
     throw localValidationError(
       'project',
@@ -5669,6 +5681,24 @@ export async function runTestRerun(
       'filter',
       '--filter only applies with --all (it narrows which project tests get reran). ' +
         'Remove --filter, or add --all --project <id>.',
+    );
+  }
+  // --status and --skip-terminal are --all-only narrowing filters with the
+  // same silent-ignore failure mode as --filter above: without --all the
+  // explicit ids get reran unfiltered (and an invalid --status value is
+  // never even validated). Reject both, mirroring the --filter guard.
+  if (opts.statusFilter !== undefined && !opts.all) {
+    throw localValidationError(
+      'status',
+      '--status only applies with --all (it narrows which project tests get reran). ' +
+        'Remove --status, or add --all --project <id>.',
+    );
+  }
+  if (opts.skipTerminal && !opts.all) {
+    throw localValidationError(
+      'skip-terminal',
+      '--skip-terminal only applies with --all (it narrows which project tests get reran). ' +
+        'Remove --skip-terminal, or add --all --project <id>.',
     );
   }
   if (


### PR DESCRIPTION
## What does this PR do?

Closes two silent-footgun gaps in `test rerun`'s flag validation — the same guard class the codebase already applies to `test run`, `test delete-batch`, and rerun's own `--filter`:

**1. Explicit test IDs + `--all` silently rerun the ENTIRE project.**

The `--all` branch resolves the full project test set and overwrites the user's list (`testIds = allTests.map(t => t.id)`), so `testsprite test rerun test_abc --all --project proj_1` dispatched a batch rerun of **every test in the project** and never ran `test_abc`-only — burning rerun/auto-heal credits with no error. Both siblings already guard this exact ambiguity: `test run` rejects positional+`--all`, and `test delete-batch` rejects ids+`--all` with an explicit "data-loss footgun" comment.

**2. `--status <list>` / `--skip-terminal` without `--all` were silently ignored — including invalid `--status` values.**

`validateStatusFilter` only ran inside the `--all` branch, so `rerun test_a test_b --status failed` dispatched **both** tests (filter dropped, intent defeated), and even `rerun test_a --status notastatus` exited 0 — while the identical misuse of rerun's own `--filter` (and `delete-batch --status`) exits 5. All three `--all`-only narrowing filters now share the same guard.

Both cases now reject with a typed `VALIDATION_ERROR` (exit 5) **before any network dispatch**, with error text following the existing `--filter` guard's wording pattern.

## Related issue

Fixes #160

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [x] PR targets the `main` branch.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org).
- [x] `npm run lint` and `npm run format:check` pass.
- [x] `npm run typecheck` passes.
- [x] `npm test` passes and coverage stays at or above the 80% gate (1619 tests).
- [x] New behavior is covered by unit tests (mock-based; no network or credentials required).
- [x] No secrets, API keys, internal endpoints, or personal data are included.
- [x] User-facing changes are reflected in `README.md` / `DOCUMENTATION.md` where relevant (help text already documents all three flags as "with --all: …"; the guards make behavior match it).

## Notes for reviewers

- Four new specs in `test.rerun.spec.ts`: ids+`--all` rejected (field `test-ids`); `--status` without `--all` rejected (field `status`); an *invalid* `--status` value without `--all` rejected (previously exit 0); `--skip-terminal` without `--all` rejected (field `skip-terminal`).
- All existing `all: true` specs use empty `testIds`, and `--status`/`--skip-terminal` specs all pass `--all` — no behavior change for valid invocations.
- Strictly additive validation in the existing pre-network validation block; no flag, output-shape, or exit-code changes on valid paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
