### PR TITLE
fix(http): map non-JSON 200 responses to a typed error envelope

### DIFF
--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -140,6 +140,53 @@ describe('HttpClient happy path', () => {
   });
 });
 
+describe('HttpClient — 200 response with a non-JSON body', () => {
+  function htmlResponse(status = 200): Response {
+    return new Response('<!DOCTYPE html><html><body>Login</body></html>', {
+      status,
+      headers: { 'content-type': 'text/html' },
+    });
+  }
+
+  it('throws a typed INTERNAL ApiError (not a raw SyntaxError) with the requestId and details', async () => {
+    const fetchImpl = vi.fn(async () => htmlResponse());
+    const client = makeClient(fetchImpl as unknown as typeof fetch);
+    let caught: unknown;
+    try {
+      await client.get('/me');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ApiError);
+    const apiErr = caught as ApiError;
+    expect(apiErr.code).toBe('INTERNAL');
+    expect(apiErr.exitCode).toBe(1);
+    expect(apiErr.requestId).toMatch(/^cli_/);
+    expect(apiErr.message).toContain('non-JSON response');
+    expect(apiErr.nextAction).toContain('TESTSPRITE_API_URL');
+    expect(apiErr.details).toMatchObject({ httpStatus: 200, contentType: 'text/html' });
+    expect(String(apiErr.details.parseError)).toContain('JSON');
+  });
+
+  it('does not retry a malformed 200 body (single fetch call)', async () => {
+    const fetchImpl = vi.fn(async () => htmlResponse());
+    const client = makeClient(fetchImpl as unknown as typeof fetch);
+    await expect(client.get('/me')).rejects.toBeInstanceOf(ApiError);
+    // A non-JSON success body is a hard config error, not a transient transport
+    // failure — it must not burn the retry budget.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles an empty 200 body the same way', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('', { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    const client = makeClient(fetchImpl as unknown as typeof fetch);
+    await expect(client.get('/me')).rejects.toMatchObject({ code: 'INTERNAL', exitCode: 1 });
+  });
+});
+
 describe('HttpClient error mapping', () => {
   it('does not retry AUTH_INVALID and exits 3', async () => {
     const fetchImpl = vi.fn(async () => errorEnvelopeResponse(401, 'AUTH_INVALID'));

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -498,7 +498,13 @@ export class HttpClient {
         } catch (err) {
           // A timeout/abort can fire mid-body-read (headers received, stream stalls).
           this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId);
-          throw err;
+          // Otherwise the successful response body was not valid JSON — a
+          // misconfigured endpoint, a proxy / captive-portal / login page that
+          // returns HTML with a 200 status, or an empty body. Surface a typed
+          // error carrying the requestId instead of letting the raw SyntaxError
+          // escape to index.ts, where it would print a bare `{"error":"..."}`
+          // and break the --output json envelope contract.
+          throw malformedResponseError(response, requestId, err);
         }
       }
 
@@ -690,6 +696,53 @@ async function safeReadJson(response: Response): Promise<unknown> {
     if (isAbortError(err) || isTimeoutError(err)) throw err;
     return null;
   }
+}
+
+/**
+ * Build a typed error for a successful response whose body could not be parsed
+ * as JSON.
+ *
+ * The CLI expects every API response to be a JSON envelope. When a `200 OK`
+ * carries a non-JSON body — a misconfigured endpoint, a proxy / captive-portal
+ * / SSO login page returning HTML with a success status, or an empty body —
+ * `response.json()` throws a raw `SyntaxError`. Left unhandled it escapes to
+ * the top-level handler in `index.ts`, which prints a bare
+ * `{"error":"<parse message>"}` under `--output json` (breaking the
+ * typed-envelope contract every other error honors) and gives the operator no
+ * actionable context.
+ *
+ * This wraps it in a typed `INTERNAL` `ApiError` (exit 1, unchanged) that
+ * carries the `requestId`, names the likely cause, and points the operator at
+ * their endpoint configuration. `details` includes the HTTP status, the
+ * response `content-type` (when present), and the underlying parse message.
+ */
+export function malformedResponseError(
+  response: Response,
+  requestId: string,
+  cause: unknown,
+): ApiError {
+  const contentType = response.headers.get('content-type') ?? undefined;
+  const parseError = cause instanceof Error ? cause.message : String(cause);
+  const contentTypeNote = contentType ? ` (content-type: ${contentType})` : '';
+  return new ApiError(
+    {
+      code: 'INTERNAL',
+      message:
+        `The server returned a non-JSON response${contentTypeNote} for an HTTP ${response.status}. ` +
+        `This usually means the endpoint is not the TestSprite API — a proxy, captive portal, or ` +
+        `login page can return HTML with a success status.`,
+      nextAction:
+        'Check that --endpoint-url / TESTSPRITE_API_URL points at the TestSprite API ' +
+        '(default https://api.testsprite.com), then retry.',
+      requestId,
+      details: {
+        httpStatus: response.status,
+        ...(contentType ? { contentType } : {}),
+        parseError,
+      },
+    },
+    response.status,
+  );
 }
 
 export function parseRetryAfter(headerValue: string | null): number | undefined {


### PR DESCRIPTION
## What does this PR do?

Fixes an opaque crash when a **successful (`200 OK`) response carries a non-JSON body** — a misconfigured `TESTSPRITE_API_URL`, a proxy / captive-portal / SSO login page that returns HTML with a success status, or an empty body.

Today the OK path calls raw `response.json()`, whose `SyntaxError` escapes to the top-level handler. That produces an opaque **exit 1** and, under `--output json`, a bare `{"error":"<parse message>"}` that **breaks the typed-envelope contract** every other CLI error honors (agents reading `error.code` get `undefined`). The non-OK path already reads defensively via `safeReadJson()`; the OK path was the gap.

This wraps the OK-path parse failure in a typed `INTERNAL` `ApiError` (exit 1 unchanged) that carries the `requestId`, names the likely cause, and points the operator at their endpoint config. `details` includes the HTTP status, `content-type`, and the underlying parse message. Abort/timeout errors mid-read keep their existing classification (`rethrowIfAbort` preserved), and a non-JSON body is **not** retried (it's a hard config error, not a transient transport failure).

### Before / after

Against an endpoint returning `200 text/html`:

```console
# BEFORE — opaque SyntaxError, non-standard error shape
$ testsprite project list --output json
{ "error": "Unexpected token '<', \"<!DOCTYPE \"... is not valid JSON" }   # exit 1

# AFTER — typed envelope with code / nextAction / requestId / details
$ testsprite project list --output json
{
  "error": {
    "code": "INTERNAL",
    "message": "The server returned a non-JSON response (content-type: text/html) for an HTTP 200. This usually means the endpoint is not the TestSprite API — a proxy, captive portal, or login page can return HTML with a success status.",
    "nextAction": "Check that --endpoint-url / TESTSPRITE_API_URL points at the TestSprite API (default https://api.testsprite.com), then retry.",
    "requestId": "cli_9f45b314-a0ac-40a8-bb2d-cd266636d979",
    "details": { "httpStatus": 200, "contentType": "text/html", "parseError": "Unexpected token '<', \"<!DOCTYPE \"... is not valid JSON" }
  }
}
```

## Related issue

Fixes #94 (I am the assigned owner of #94).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [x] PR targets the `main` branch.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org).
- [x] `npm run lint` and `npm run format:check` pass.
- [x] `npm run typecheck` passes.
- [x] `npm test` passes and coverage stays at or above the 80% gate.
- [x] New behavior is covered by unit tests (mock-based; no network or credentials required).
- [x] No secrets, API keys, internal endpoints, or personal data are included.
- [ ] User-facing changes are reflected in `README.md` / `DOCUMENTATION.md` where relevant. — N/A (error-handling internals; no documented behavior changes).

## Notes for reviewers

- Scope is deliberately narrow: only the OK-path `response.json()` in `src/lib/http.ts`. The non-OK path (`safeReadJson`) and abort/timeout handling are unchanged.
- Exit code stays **1** (`INTERNAL`) — no exit-code regression; the improvement is the typed envelope + actionable message + `requestId`.
- Empty `200` bodies are handled the same way (also a malformed response).
- I'm the assigned owner of #94. I see #142 also addresses this issue — happy to coordinate with the maintainers on which approach to take.

### AI usage disclosure

Yes, I used AI assistance for this change — for investigation, drafting the fix, and writing tests. I reviewed and verified all changes myself (reproduced the bug before/after, and ran the full gate suite: typecheck, lint, format:check, 1618 unit tests, and the e2e suite — all green).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of successful HTTP responses that return non-JSON content, such as HTML or empty bodies with a JSON content type.
  * These responses now produce a clear, typed error with useful request and response details, instead of an unhelpful parsing failure.
  * Malformed success responses no longer affect retry behavior, so only the original request is counted.

* **Tests**
  * Added coverage for non-JSON and empty success responses to confirm the new error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->