### PR TITLE
feat(cli): honor HTTPS_PROXY/HTTP_PROXY/NO_PROXY behind corporate and CI proxies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.1.0",
-        "undici": "^8.5.0",
+        "undici": "^7.16.0",
         "valibot": "^1.4.1"
       },
       "bin": {
@@ -3818,12 +3818,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.6.0.tgz",
-      "integrity": "sha512-l2FlC6I510GawyEd1qgcE/okihKrzy+BRTEBlu6T0fdbM9m5yxtIH5Oa3ysRsH0zC4EhmWUEaSDsy2QngBeRlw==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@testsprite/testsprite-cli",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@testsprite/testsprite-cli",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.1.0",
+        "undici": "^8.5.0",
         "valibot": "^1.4.1"
       },
       "bin": {
@@ -1024,9 +1025,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1041,9 +1039,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1058,9 +1053,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1075,9 +1067,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,9 +1081,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,9 +1095,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,9 +1109,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,9 +1123,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1160,9 +1137,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1177,9 +1151,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1194,9 +1165,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,9 +1179,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1228,9 +1193,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3853,6 +3815,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.6.0.tgz",
+      "integrity": "sha512-l2FlC6I510GawyEd1qgcE/okihKrzy+BRTEBlu6T0fdbM9m5yxtIH5Oa3ysRsH0zC4EhmWUEaSDsy2QngBeRlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "commander": "^12.1.0",
-    "undici": "^8.5.0",
+    "undici": "^7.16.0",
     "valibot": "^1.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "commander": "^12.1.0",
+    "undici": "^8.5.0",
     "valibot": "^1.4.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { createTestCommand } from './commands/test.js';
 import { createUsageCommand } from './commands/usage.js';
 import { ApiError, CLIError, RequestTimeoutError } from './lib/errors.js';
 import { Output, isOutputMode } from './lib/output.js';
+import { maybeInstallProxyAgent } from './lib/proxy.js';
 import { renderCommanderError, rephraseUnknownOption } from './lib/render-error.js';
 import { maybeEmitSkillNudge } from './lib/skill-nudge.js';
 import { VERSION } from './version.js';
@@ -137,6 +138,10 @@ program.hook('preAction', (_thisCommand, actionCommand) => {
     env: process.env,
   });
 });
+
+// Corporate/CI proxies: honor HTTPS_PROXY/HTTP_PROXY/NO_PROXY (Node's fetch
+// ignores them by default). No-op when no proxy variable is set.
+maybeInstallProxyAgent();
 
 try {
   await program.parseAsync(process.argv);

--- a/src/lib/proxy.test.ts
+++ b/src/lib/proxy.test.ts
@@ -31,4 +31,29 @@ describe('maybeInstallProxyAgent', () => {
     expect(maybeInstallProxyAgent({ env: { HTTPS_PROXY: '' }, install })).toBe(false);
     expect(install).not.toHaveBeenCalled();
   });
+
+  it('falls back (returns false, warns, never throws) when installing the agent fails', () => {
+    // A malformed/unsupported proxy value makes the agent throw at startup; the
+    // CLI must degrade to a proxy-less dispatcher, not crash every command.
+    const errs: string[] = [];
+    const installed = maybeInstallProxyAgent({
+      env: { HTTPS_PROXY: 'http://proxy.corp.example.com:8080' },
+      install: () => {
+        throw new Error('unsupported proxy scheme');
+      },
+      stderr: line => errs.push(line),
+    });
+    expect(installed).toBe(false);
+    expect(errs.join('\n')).toContain('ignoring proxy environment');
+  });
+
+  it('still installs when NO_PROXY is set (exemptions are applied per request by undici)', () => {
+    const install = vi.fn();
+    const installed = maybeInstallProxyAgent({
+      env: { HTTPS_PROXY: 'http://proxy.corp.example.com:8080', NO_PROXY: 'localhost,127.0.0.1' },
+      install,
+    });
+    expect(installed).toBe(true);
+    expect(install).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/lib/proxy.test.ts
+++ b/src/lib/proxy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { maybeInstallProxyAgent } from './proxy.js';
+
+describe('maybeInstallProxyAgent', () => {
+  it('installs an agent when HTTPS_PROXY is set', () => {
+    const install = vi.fn();
+    const installed = maybeInstallProxyAgent({
+      env: { HTTPS_PROXY: 'http://proxy.corp.example.com:8080' },
+      install,
+    });
+    expect(installed).toBe(true);
+    expect(install).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['https_proxy', 'HTTP_PROXY', 'http_proxy'] as const)(
+    'also honors the %s spelling',
+    name => {
+      const install = vi.fn();
+      const installed = maybeInstallProxyAgent({
+        env: { [name]: 'http://proxy.corp.example.com:8080' },
+        install,
+      });
+      expect(installed).toBe(true);
+      expect(install).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('does nothing when no proxy variable is set (default path unchanged)', () => {
+    const install = vi.fn();
+    expect(maybeInstallProxyAgent({ env: {}, install })).toBe(false);
+    expect(maybeInstallProxyAgent({ env: { HTTPS_PROXY: '' }, install })).toBe(false);
+    expect(install).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -20,6 +20,8 @@ export interface ProxyDeps {
   env?: NodeJS.ProcessEnv;
   /** Dispatcher installer. Defaults to undici's setGlobalDispatcher. */
   install?: (agent: Dispatcher) => void;
+  /** Warning sink. Defaults to `process.stderr`. */
+  stderr?: (line: string) => void;
 }
 
 /**
@@ -36,6 +38,21 @@ export function maybeInstallProxyAgent(deps: ProxyDeps = {}): boolean {
   const install = deps.install ?? setGlobalDispatcher;
   // EnvHttpProxyAgent reads HTTPS_PROXY/HTTP_PROXY/NO_PROXY itself, per
   // request, so NO_PROXY exemptions apply without extra plumbing here.
-  install(new EnvHttpProxyAgent());
-  return true;
+  //
+  // A malformed or unsupported proxy value (e.g. `socks5://...`) makes the
+  // agent throw. Because this runs at startup, an unguarded throw would abort
+  // every command before the CLI's own error handling — so fall back to the
+  // default (proxy-less) dispatcher and warn instead of crashing.
+  try {
+    install(new EnvHttpProxyAgent());
+    return true;
+  } catch (error) {
+    const stderr = deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
+    stderr(
+      `warning: ignoring proxy environment (could not initialize proxy agent): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return false;
+  }
 }

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -1,0 +1,41 @@
+/**
+ * Proxy support (issue #119): honor HTTPS_PROXY / HTTP_PROXY / NO_PROXY.
+ *
+ * Node's built-in fetch (undici) deliberately ignores the proxy environment
+ * variables, so behind a corporate or CI proxy every request dies with
+ * `fetch failed` after a full retry cycle. Installing undici's
+ * `EnvHttpProxyAgent` as the global dispatcher restores the conventional
+ * behavior (including NO_PROXY exemptions) for every fetch the CLI makes.
+ *
+ * Only active when a proxy env var is actually present, so the default path
+ * stays byte-identical and pays zero startup cost. Dependency note for
+ * reviewers: this adds `undici` as an explicit runtime dependency (the same
+ * engine Node already bundles); the alternative, a hand-rolled CONNECT
+ * tunnel, would re-implement what undici ships and maintains.
+ */
+import type { Dispatcher } from 'undici';
+import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
+
+export interface ProxyDeps {
+  env?: NodeJS.ProcessEnv;
+  /** Dispatcher installer. Defaults to undici's setGlobalDispatcher. */
+  install?: (agent: Dispatcher) => void;
+}
+
+/**
+ * Install the env-driven proxy dispatcher when any proxy variable is set
+ * (both canonical upper-case and conventional lower-case spellings).
+ * Returns whether an agent was installed (observable for tests/debugging).
+ */
+export function maybeInstallProxyAgent(deps: ProxyDeps = {}): boolean {
+  const env = deps.env ?? process.env;
+  const hasProxy = [env.HTTPS_PROXY, env.https_proxy, env.HTTP_PROXY, env.http_proxy].some(
+    value => typeof value === 'string' && value.length > 0,
+  );
+  if (!hasProxy) return false;
+  const install = deps.install ?? setGlobalDispatcher;
+  // EnvHttpProxyAgent reads HTTPS_PROXY/HTTP_PROXY/NO_PROXY itself, per
+  // request, so NO_PROXY exemptions apply without extra plumbing here.
+  install(new EnvHttpProxyAgent());
+  return true;
+}


### PR DESCRIPTION
## What does this PR do?
Node's built-in fetch (undici) ignores the proxy environment variables, so
behind a corporate or CI proxy every TestSprite request dies with `fetch failed`
after a full retry cycle. This installs undici's `EnvHttpProxyAgent` as the
global dispatcher at startup **only when** a proxy variable is present, honoring
`HTTPS_PROXY`/`HTTP_PROXY` (upper and lower case) and `NO_PROXY` exemptions. No
proxy var set → no-op, default path byte-identical, zero startup cost.

## Related issue
Fixes #119

## Type of change
- [x] New feature (non-breaking change that adds functionality)

## Checklist
- [x] PR targets the `main` branch.
- [x] Commits follow Conventional Commits.
- [x] `npm run lint` and `npm run format:check` pass.
- [x] `npm run typecheck` passes.
- [x] `npm test` passes and coverage stays at or above the 80% gate.
- [x] New behavior is covered by unit tests (mock-based; no network).
- [x] No secrets, API keys, internal endpoints, or personal data are included.

## Notes for reviewers
Adds `undici` as an explicit runtime dependency (the same engine Node already
bundles for fetch) — per the triage note on #119 approving this. The installer
is dependency-injected (`ProxyDeps.install`) so the unit tests never touch the
global dispatcher. `EnvHttpProxyAgent` reads `NO_PROXY` itself per request, so
exemptions work with no extra plumbing. I'm the assignee of #119.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic proxy support for Node network requests by honoring `HTTP_PROXY`/`HTTPS_PROXY` (including uppercase and lowercase variants).
  * Proxy handling is enabled only when a non-empty proxy value is provided; otherwise it does nothing.
  * If proxy configuration is invalid, the app now warns and continues running.
* **Tests**
  * Expanded coverage for proxy env handling, empty/missing values, `NO_PROXY` behavior, and installer failure/warning behavior.
* **Chores**
  * Added the `undici` runtime dependency to support proxy-aware fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->