### PR TITLE
docs(usage): add --debug example + exit codes to help text

### DIFF
--- a/src/commands/usage.ts
+++ b/src/commands/usage.ts
@@ -200,7 +200,12 @@ export function createUsageCommand(deps: UsageDeps = {}): Command {
       '\nExamples:\n' +
         '  testsprite usage                 # show balance + plan\n' +
         '  testsprite usage --output json   # machine-readable balance\n' +
+        '  testsprite usage --debug         # trace HTTP method/path, request id, latency\n' +
         '  testsprite credits               # alias for usage\n' +
+        '\nExit codes:\n' +
+        '  0   success (or --dry-run)\n' +
+        '  3   auth error — run `testsprite setup` to configure credentials\n' +
+        '  10  transport/network failure (UNAVAILABLE) — retry the command\n' +
         '\nNote: credit balance requires a backend update to /me. Until shipped,\n' +
         "  check your portal's Billing page (/dashboard/settings/billing) for your balance.",
     )


### PR DESCRIPTION
## What

This PR improves the `testsprite usage` command help text by adding:

1. A `--debug` example showing what it traces (HTTP method/path, request id, latency) — useful when debugging `auth error` or `transport failure` messages.
2. An explicit **Exit codes** section (0 success, 3 auth error, 10 network failure) so users scripting against the CLI in CI/CD know what to expect.

## Why

The current help text lists three examples but omits the `--debug` flag (a global option). It also doesn't document exit codes, which matters for CI/CD scripts that gate on the return value — for example, our own hackathon CI/CD workflow that runs `testsprite test run --wait` and gates the build on exit code.

## Context

Submitted as part of the **TestSprite Hackathon Season 3 — CLI Improvement Bonus**. Built by MOAAMN SAYED while integrating the CLI into the NEXUS IDE project.

## Checklist

- [x] Pure documentation improvement — no behavioral change
- [x] No new dependencies
- [x] Existing unit tests pass (`npm test`)
- [x] Follows the existing help-text formatting convention

## Testing

```bash
npm test
# → all unit tests pass
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `usage`/`credits` command help text with an additional example showing `--debug` for HTTP tracing.
  * No command behavior changed; this is a help text improvement only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->