### PR TITLE
fix(test): guard default artifact run id path

### DIFF
--- a/src/commands/test.artifact.spec.ts
+++ b/src/commands/test.artifact.spec.ts
@@ -355,17 +355,14 @@ describe('runArtifactGet', () => {
     'nested/run',
     'nested\\run',
     'bad\0id',
-  ])(
-    'rejects unsafe default artifact runId segment %j',
-    runId => {
-      expect(() => resolveDefaultArtifactDir(runId, '/repo')).toThrowError(
-        expect.objectContaining({
-          code: 'VALIDATION_ERROR',
-          details: expect.objectContaining({ field: 'run-id' }),
-        }),
-      );
-    },
-  );
+  ])('rejects unsafe default artifact runId segment %j', runId => {
+    expect(() => resolveDefaultArtifactDir(runId, '/repo')).toThrowError(
+      expect.objectContaining({
+        code: 'VALIDATION_ERROR',
+        details: expect.objectContaining({ field: 'run-id' }),
+      }),
+    );
+  });
 
   it('keeps the documented default directory for path-safe runIds', () => {
     expect(resolveDefaultArtifactDir(SAMPLE_RUN_ID, '/repo')).toBe(

--- a/src/commands/test.artifact.spec.ts
+++ b/src/commands/test.artifact.spec.ts
@@ -21,6 +21,7 @@ import {
   assertOutDirParentExists,
   createTestArtifactCommand,
   createTestCommand,
+  resolveDefaultArtifactDir,
   runArtifactGet,
   runFailureGet,
 } from './test.js';
@@ -320,6 +321,31 @@ describe('runArtifactGet', () => {
     } finally {
       cwdSpy.mockRestore();
     }
+  });
+
+  it('rejects path-like runId before auth or fetch when default --out is used', async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>();
+
+    await expect(
+      runArtifactGet(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          runId: '../../outside',
+          failedOnly: false,
+        },
+        { fetchImpl, stdout: () => {} },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('keeps the documented default directory for path-safe runIds', () => {
+    expect(resolveDefaultArtifactDir(SAMPLE_RUN_ID, '/repo')).toBe(
+      join('/repo', '.testsprite', 'runs', SAMPLE_RUN_ID),
+    );
   });
 
   // ---- --failed-only passed through to writeBundle ----

--- a/src/commands/test.artifact.spec.ts
+++ b/src/commands/test.artifact.spec.ts
@@ -342,7 +342,20 @@ describe('runArtifactGet', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it.each(['.', '..', '. ', '.. ', '../outside', '..\\outside', 'nested/run', 'nested\\run', 'bad\0id'])(
+  it.each([
+    '.',
+    '..',
+    '. ',
+    '.. ',
+    '...',
+    '.. .',
+    '. .',
+    '../outside',
+    '..\\outside',
+    'nested/run',
+    'nested\\run',
+    'bad\0id',
+  ])(
     'rejects unsafe default artifact runId segment %j',
     runId => {
       expect(() => resolveDefaultArtifactDir(runId, '/repo')).toThrowError(

--- a/src/commands/test.artifact.spec.ts
+++ b/src/commands/test.artifact.spec.ts
@@ -342,6 +342,18 @@ describe('runArtifactGet', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it.each(['.', '..', '. ', '.. ', '../outside', '..\\outside', 'nested/run', 'nested\\run', 'bad\0id'])(
+    'rejects unsafe default artifact runId segment %j',
+    runId => {
+      expect(() => resolveDefaultArtifactDir(runId, '/repo')).toThrowError(
+        expect.objectContaining({
+          code: 'VALIDATION_ERROR',
+          details: expect.objectContaining({ field: 'run-id' }),
+        }),
+      );
+    },
+  );
+
   it('keeps the documented default directory for path-safe runIds', () => {
     expect(resolveDefaultArtifactDir(SAMPLE_RUN_ID, '/repo')).toBe(
       join('/repo', '.testsprite', 'runs', SAMPLE_RUN_ID),

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -6842,9 +6842,7 @@ export async function runArtifactGet(
 
   // Resolve output dir: explicit --out or the default .testsprite/runs/<runId>/
   const resolvedDir =
-    opts.out !== undefined
-      ? resolveBundleDir(opts.out)
-      : resolveDefaultArtifactDir(runId);
+    opts.out !== undefined ? resolveBundleDir(opts.out) : resolveDefaultArtifactDir(runId);
 
   // --dry-run: no network, no disk write.
   // The client (makeClient) is already wired with createDryRunFetch() when

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -6772,8 +6772,9 @@ export interface ArtifactGetResult {
 
 export function resolveDefaultArtifactDir(runId: string, cwd: string = process.cwd()): string {
   requireNonEmpty('run-id', runId);
-  const windowsNormalizedSegment = runId.trimEnd();
+  const windowsNormalizedSegment = runId.replace(/[ .]+$/u, '');
   if (
+    windowsNormalizedSegment === '' ||
     windowsNormalizedSegment === '.' ||
     windowsNormalizedSegment === '..' ||
     runId.includes('/') ||

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -6770,6 +6770,20 @@ export interface ArtifactGetResult {
   bundle?: WriteBundleResult;
 }
 
+export function resolveDefaultArtifactDir(runId: string, cwd: string = process.cwd()): string {
+  requireNonEmpty('run-id', runId);
+  if (runId === '.' || runId === '..' || runId.includes('/') || runId.includes('\\')) {
+    throw localValidationError(
+      'run-id',
+      'must be a single path-safe segment for the default output directory; pass --out <dir> to choose a custom path',
+    );
+  }
+  if (runId.includes('\0')) {
+    throw localValidationError('run-id', 'must not contain NUL bytes');
+  }
+  return join(cwd, '.testsprite', 'runs', runId);
+}
+
 /**
  * Validate that the parent directory of `resolvedDir` exists and is a
  * directory. Surfaces `VALIDATION_ERROR` (exit 5) — matches the convention
@@ -6819,14 +6833,13 @@ export async function runArtifactGet(
   deps: TestDeps = {},
 ): Promise<ArtifactGetResult> {
   const out = makeOutput(opts.output, deps);
-  const client = makeClient(opts, deps);
   const { runId } = opts;
 
   // Resolve output dir: explicit --out or the default .testsprite/runs/<runId>/
   const resolvedDir =
     opts.out !== undefined
       ? resolveBundleDir(opts.out)
-      : join(process.cwd(), '.testsprite', 'runs', runId);
+      : resolveDefaultArtifactDir(runId);
 
   // --dry-run: no network, no disk write.
   // The client (makeClient) is already wired with createDryRunFetch() when
@@ -6871,6 +6884,8 @@ export async function runArtifactGet(
   if (opts.out !== undefined) {
     await assertOutDirParentExists(resolvedDir);
   }
+
+  const client = makeClient(opts, deps);
 
   // Fetch the run-scoped failure bundle.
   const { body: context, requestId: fetchRequestId } = await client.getWithMeta<CliFailureContext>(

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -6772,14 +6772,18 @@ export interface ArtifactGetResult {
 
 export function resolveDefaultArtifactDir(runId: string, cwd: string = process.cwd()): string {
   requireNonEmpty('run-id', runId);
-  if (runId === '.' || runId === '..' || runId.includes('/') || runId.includes('\\')) {
+  const windowsNormalizedSegment = runId.trimEnd();
+  if (
+    windowsNormalizedSegment === '.' ||
+    windowsNormalizedSegment === '..' ||
+    runId.includes('/') ||
+    runId.includes('\\') ||
+    runId.includes('\0')
+  ) {
     throw localValidationError(
       'run-id',
       'must be a single path-safe segment for the default output directory; pass --out <dir> to choose a custom path',
     );
-  }
-  if (runId.includes('\0')) {
-    throw localValidationError('run-id', 'must not contain NUL bytes');
   }
   return join(cwd, '.testsprite', 'runs', runId);
 }


### PR DESCRIPTION
## Summary

Fixes #45.

This reopens the artifact default-path guard from #47 on a clean branch based on the latest `main`, and includes the Windows normalization coverage that made #71 the preferred consolidation target.

`test artifact get <run-id>` now treats the positional `runId` as an opaque identifier when computing the implicit default output directory:

```text
./.testsprite/runs/<run-id>/
```

Unsafe path-like values fail before auth, network, or filesystem work when `--out` is omitted. Explicit `--out <dir>` remains the supported way to choose a custom filesystem destination.

## Changes

- Add `resolveDefaultArtifactDir(runId, cwd)` for default artifact output paths.
- Reject unsafe default-path run IDs:
  - `.` / `..`
  - Windows trailing-space dot segments like `. ` / `.. `
  - Windows trailing-period/dot-suffix segments like `...`, `. .`, and `.. .`
  - `/` and `\`
  - NUL bytes
- Keep normal run IDs under `./.testsprite/runs/<run-id>/`.
- Validate the implicit path before client/auth/fetch work.
- Add regression coverage for unsafe segments and the documented default path.

## Verification

- `npx vitest run src/commands/test.artifact.spec.ts`
- `npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `test artifact get` now automatically saves to the default `.testsprite/runs/<run-id>/` directory when `--out` is not provided.

* **Bug Fixes**
  * Improved `run-id` validation: unsafe values (including `.`/`..`, traversal attempts, slashes/backslashes, and null bytes) are rejected consistently with a validation error on `run-id` and exit code `5`, before any fetch work begins.
  * Explicit `--out` validation continues to occur prior to any fetch.

* **Tests**
  * Added unit coverage for default output directory resolution and unsafe `run-id` rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->