### PR TITLE
feat(agent): stamp installed skills with a version/hash marker and add "agent status"

### DIFF
--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -9,13 +9,21 @@ import {
   MANAGED_SECTION_END,
   ONBOARD_CODEX_LINE,
   SKILLS,
+  buildSkillMarker,
   pathFor,
   renderForTarget,
+  renderOwnFileWithMarker,
   TARGETS,
   type AgentTarget,
 } from '../lib/agent-targets.js';
-import type { AgentDeps, AgentFs, InstallResult, ListResult } from './agent.js';
-import { AGENTS_MD_CODEX_BUDGET_BYTES, createAgentCommand, runInstall, runList } from './agent.js';
+import type { AgentDeps, AgentFs, InstallResult, ListResult, StatusResult } from './agent.js';
+import {
+  AGENTS_MD_CODEX_BUDGET_BYTES,
+  createAgentCommand,
+  runInstall,
+  runList,
+  runStatus,
+} from './agent.js';
 
 // ---------------------------------------------------------------------------
 // In-memory AgentFs backed by a Map
@@ -2425,5 +2433,122 @@ describe('runInstall — SKILLS registry / DEFAULT_SKILLS contract', () => {
   it('ONBOARD_CODEX_LINE is the one-liner used in the codex section', () => {
     expect(typeof ONBOARD_CODEX_LINE).toBe('string');
     expect(ONBOARD_CODEX_LINE).toContain('**First-time setup:**');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runStatus — `agent status` (issue #123)
+// ---------------------------------------------------------------------------
+
+describe('runStatus — agent status (issue #123)', () => {
+  const statusOpts = {
+    profile: 'default' as const,
+    output: 'json' as const,
+    debug: false,
+    dryRun: false,
+  };
+
+  /** Run status against the given fs and return the printed rows. */
+  async function statusRows(agentFs: AgentFs): Promise<{ rows: StatusResult[]; thrown: unknown }> {
+    const { capture, deps } = makeCapture();
+    let thrown: unknown;
+    try {
+      await runStatus(statusOpts, { cwd: CWD, fs: agentFs, ...deps });
+    } catch (err) {
+      thrown = err;
+    }
+    return { rows: JSON.parse(capture.stdout.join('')) as StatusResult[], thrown };
+  }
+
+  it('nothing installed: every row is absent and the command exits 0', async () => {
+    const { fs: agentFs } = makeMemFs();
+    const { rows, thrown } = await statusRows(agentFs);
+    expect(thrown).toBeUndefined();
+    expect(rows).toHaveLength(Object.keys(TARGETS).length * DEFAULT_SKILLS.length);
+    expect(rows.every(row => row.state === 'absent')).toBe(true);
+  });
+
+  it('fresh installs read ok (own-file and codex managed section), exit 0', async () => {
+    const { fs: agentFs } = makeMemFs();
+    const { deps } = makeCapture();
+    await runInstall(
+      {
+        profile: 'default',
+        output: 'text',
+        debug: false,
+        dryRun: false,
+        target: ['claude', 'codex'],
+        skills: [...DEFAULT_SKILLS],
+        force: false,
+      },
+      { cwd: CWD, fs: agentFs, ...deps },
+    );
+
+    const { rows, thrown } = await statusRows(agentFs);
+    expect(thrown).toBeUndefined();
+    for (const skill of DEFAULT_SKILLS) {
+      expect(rows.find(r => r.target === 'claude' && r.skill === skill)?.state).toBe('ok');
+      expect(rows.find(r => r.target === 'codex' && r.skill === skill)?.state).toBe('ok');
+      expect(rows.find(r => r.target === 'cursor' && r.skill === skill)?.state).toBe('absent');
+    }
+  });
+
+  it('stale: a marker whose hash matches an OLDER body reads stale and exits 1', async () => {
+    const { fs: agentFs, seedFile } = makeMemFs();
+    const oldBody = '# TestSprite Verification Loop\n\nold body from a previous CLI release\n';
+    seedFile(
+      path.resolve(CWD, pathFor('claude', 'testsprite-verify')),
+      renderOwnFileWithMarker(
+        'claude',
+        'testsprite-verify',
+        buildSkillMarker('testsprite-verify', oldBody),
+        oldBody,
+      ),
+    );
+
+    const { rows, thrown } = await statusRows(agentFs);
+    expect(rows.find(r => r.target === 'claude' && r.skill === 'testsprite-verify')?.state).toBe(
+      'stale',
+    );
+    expect(thrown).toBeInstanceOf(CLIError);
+    expect((thrown as CLIError).exitCode).toBe(1);
+    expect((thrown as CLIError).message).toContain('need attention');
+  });
+
+  it('modified: current hash but edited bytes reads modified and exits 1', async () => {
+    const { fs: agentFs, seedFile } = makeMemFs();
+    const canonical = renderForTarget('claude', 'testsprite-verify').content;
+    seedFile(
+      path.resolve(CWD, pathFor('claude', 'testsprite-verify')),
+      `${canonical}\n<!-- my local tweak -->\n`,
+    );
+
+    const { rows, thrown } = await statusRows(agentFs);
+    expect(rows.find(r => r.target === 'claude' && r.skill === 'testsprite-verify')?.state).toBe(
+      'modified',
+    );
+    expect((thrown as CLIError).exitCode).toBe(1);
+  });
+
+  it('unmarked: an artifact without a marker line reads unmarked and exits 1', async () => {
+    const { fs: agentFs, seedFile } = makeMemFs();
+    seedFile(
+      path.resolve(CWD, pathFor('claude', 'testsprite-verify')),
+      '# hand-rolled skill file with no marker\n',
+    );
+
+    const { rows, thrown } = await statusRows(agentFs);
+    expect(rows.find(r => r.target === 'claude' && r.skill === 'testsprite-verify')?.state).toBe(
+      'unmarked',
+    );
+    expect((thrown as CLIError).exitCode).toBe(1);
+  });
+
+  it('rejects an explicit empty --dir (exit 5), matching the resolve-to-cwd hazard', async () => {
+    const { fs: agentFs } = makeMemFs();
+    const { deps } = makeCapture();
+    await expect(
+      runStatus({ ...statusOpts, dir: '   ' }, { cwd: CWD, fs: agentFs, ...deps }),
+    ).rejects.toMatchObject({ exitCode: 5 });
   });
 });

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -11,10 +11,15 @@ import {
   TARGETS,
   SKILLS,
   DEFAULT_SKILLS,
+  MARKER_SKILL_SEPARATOR,
   pathFor,
   loadSkillBodyFor,
+  bodyHash12,
   buildCodexAggregate,
+  buildSkillMarker,
+  parseSkillMarker,
   renderForTarget,
+  renderOwnFileWithMarker,
   MANAGED_SECTION_BEGIN,
   MANAGED_SECTION_END,
 } from '../lib/agent-targets.js';
@@ -150,11 +155,15 @@ async function writeBackup(agentFs: AgentFs, abs: string, existing: string): Pro
 // ---------------------------------------------------------------------------
 
 /**
- * Build the section block to inject (sentinels + body + trailing newline).
+ * Build the section block to inject (sentinels + marker + body + trailing
+ * newline). The provenance marker line sits just inside the BEGIN sentinel so
+ * `agent status` can fingerprint the section. The same skill set + CLI version
+ * + body always produce byte-identical output, so the classifySection
+ * 'unchanged' fast-path keeps working across re-installs.
  * Uses \n throughout; the caller handles CRLF normalisation.
  */
-function buildSection(body: string): string {
-  return `${MANAGED_SECTION_BEGIN}\n${body.trimEnd()}\n${MANAGED_SECTION_END}\n`;
+function buildSection(body: string, markerLine: string): string {
+  return `${MANAGED_SECTION_BEGIN}\n${markerLine}\n${body.trimEnd()}\n${MANAGED_SECTION_END}\n`;
 }
 
 /**
@@ -437,7 +446,14 @@ export async function runInstall(opts: InstallOptions, deps: AgentDeps = {}): Pr
   let codexSectionCache: string | undefined;
   const getCodexSection = (): string => {
     if (codexSectionCache === undefined) {
-      codexSectionCache = buildSection(buildCodexAggregate(skills));
+      const aggregate = buildCodexAggregate(skills);
+      // ONE marker for the whole managed section: it names every aggregated
+      // skill ('+'-joined) and hashes the canonical aggregate body, so
+      // `agent status` can attribute and fingerprint the section per skill.
+      codexSectionCache = buildSection(
+        aggregate,
+        buildSkillMarker(skills.join(MARKER_SKILL_SEPARATOR), aggregate),
+      );
     }
     return codexSectionCache;
   };
@@ -790,6 +806,236 @@ export async function runList(opts: CommonOptions, deps: AgentDeps = {}): Promis
 }
 
 // ---------------------------------------------------------------------------
+// runStatus (issue #123: detect silently stale installed skill files)
+// ---------------------------------------------------------------------------
+
+/**
+ * Health of one installed skill artifact, as reported by `agent status`.
+ *
+ * Decision order (first match wins):
+ *  - 'absent'   : nothing at the landing path (codex: no managed section,
+ *                 including an AGENTS.md that exists without our sentinels).
+ *  - 'corrupt'  : codex only. Dangling or duplicated sentinels, the same
+ *                 classification `agent install` refuses on; status REPORTS it
+ *                 instead of refusing.
+ *  - 'unmarked' : artifact present but carries no testsprite-skill marker
+ *                 (installed before markers existed), or the landing path is
+ *                 occupied by a non-regular file (never followed).
+ *  - 'stale'    : marker present, but its hash differs from the current
+ *                 canonical body: a re-install would change the content. Edits
+ *                 on top of an OLD install also read stale (older renders
+ *                 cannot be reproduced); the remedy is the same re-install.
+ *  - 'modified' : marker hash matches the current body, but the artifact bytes
+ *                 differ from the canonical render carrying that same marker
+ *                 line: the user edited the artifact after install.
+ *  - 'ok'       : marker hash matches and the bytes equal the canonical render
+ *                 with the file's own marker line (a version-string-only lag
+ *                 with an unchanged body still reads ok).
+ *
+ * For the codex managed section, ONE marker names every aggregated skill
+ * ('+'-joined); skills not named by the marker report 'absent'.
+ */
+export type SkillArtifactState = 'ok' | 'stale' | 'modified' | 'unmarked' | 'absent' | 'corrupt';
+
+export interface StatusResult {
+  target: AgentTarget;
+  skill: string;
+  path: string;
+  state: SkillArtifactState;
+}
+
+interface StatusOptions extends CommonOptions {
+  dir?: string;
+}
+
+/**
+ * Classify one own-file artifact per the {@link SkillArtifactState} contract.
+ * Comparisons are byte-exact, matching the installer's own skipped/blocked
+ * comparison for own-file targets.
+ */
+async function classifyOwnFileState(
+  agentFs: AgentFs,
+  abs: string,
+  target: AgentTarget,
+  skill: string,
+  bodyForSkill: (skill: string) => string,
+): Promise<SkillArtifactState> {
+  const stat = await agentFs.lstat(abs);
+  if (stat === null) return 'absent';
+  // Occupied by a directory or symlink: not something our installer wrote, and
+  // never followed (mirrors the installer's fail-closed stance on symlinks).
+  if (!stat.isFile) return 'unmarked';
+
+  const existing = await agentFs.readFile(abs);
+  const marker = parseSkillMarker(existing);
+  if (marker === null) return 'unmarked';
+
+  const canonicalBody = bodyForSkill(skill);
+  if (marker.hash12 !== bodyHash12(canonicalBody)) return 'stale';
+
+  // Hash matches the current body: pristine iff the file equals the canonical
+  // render carrying its own marker line, so a marker whose version string lags
+  // behind an unchanged body still reads ok.
+  const reRender = renderOwnFileWithMarker(target, skill, marker.line, canonicalBody);
+  return existing === reRender ? 'ok' : 'modified';
+}
+
+/**
+ * Classify the codex managed section per skill. The section is ONE artifact
+ * carrying ONE marker that names every aggregated skill, so a single
+ * inspection answers all skill rows; the returned function maps a skill name
+ * to its state. Comparisons are CRLF-insensitive on the section bytes.
+ */
+async function classifyManagedSectionStates(
+  agentFs: AgentFs,
+  abs: string,
+): Promise<(skill: string) => SkillArtifactState> {
+  const constantState =
+    (state: SkillArtifactState): ((skill: string) => SkillArtifactState) =>
+    () =>
+      state;
+
+  const stat = await agentFs.lstat(abs);
+  if (stat === null) return constantState('absent');
+  // Occupied by a directory or symlink: never followed (fail-closed).
+  if (!stat.isFile) return constantState('unmarked');
+
+  const existing = await agentFs.readFile(abs);
+
+  // Current canonical section for the default skill set. classifySection's
+  // 'unchanged' answers the common all-defaults-fresh case; its
+  // corrupt/append classification is reused verbatim for status verdicts.
+  const defaultAggregate = buildCodexAggregate(DEFAULT_SKILLS);
+  const defaultSection = buildSection(
+    defaultAggregate,
+    buildSkillMarker(DEFAULT_SKILLS.join(MARKER_SKILL_SEPARATOR), defaultAggregate),
+  );
+  const sectionState = classifySection(existing, defaultSection);
+
+  if (sectionState.kind === 'corrupt') return constantState('corrupt');
+  // No standalone sentinels anywhere: the managed section is not installed.
+  if (sectionState.kind === 'append') return constantState('absent');
+  if (sectionState.kind === 'unchanged') {
+    // Byte-identical to today's default install.
+    return skill => ((DEFAULT_SKILLS as readonly string[]).includes(skill) ? 'ok' : 'absent');
+  }
+  if (sectionState.kind !== 'replace') {
+    // 'create' is unreachable when the file exists; treat defensively as absent.
+    return constantState('absent');
+  }
+
+  // Sentinels are present but the section differs from today's default
+  // canonical: slice the live section bytes out of the file and inspect its
+  // own marker (before/after are exact byte prefix/suffix around the section).
+  const sectionContent = existing.slice(
+    sectionState.before.length,
+    existing.length - sectionState.after.length,
+  );
+  const marker = parseSkillMarker(sectionContent);
+  if (marker === null) return constantState('unmarked');
+
+  const installedSkills = marker.skill.split(MARKER_SKILL_SEPARATOR);
+  const coversSkill = (skill: string): boolean => installedSkills.includes(skill);
+
+  // A marker naming a skill this CLI does not ship cannot be re-rendered;
+  // report the named skills stale (a re-install refreshes the section).
+  if (installedSkills.some(name => SKILLS[name] === undefined)) {
+    return skill => (coversSkill(skill) ? 'stale' : 'absent');
+  }
+
+  const canonicalAggregate = buildCodexAggregate(installedSkills);
+  if (marker.hash12 !== bodyHash12(canonicalAggregate)) {
+    return skill => (coversSkill(skill) ? 'stale' : 'absent');
+  }
+
+  // Hash matches the current aggregate: the section is pristine iff its bytes
+  // equal a re-render carrying its own marker line (version-string-only lag
+  // with an unchanged body still reads ok).
+  const pristine =
+    sectionContent.replace(/\r\n/g, '\n') === buildSection(canonicalAggregate, marker.line);
+  return skill => (coversSkill(skill) ? (pristine ? 'ok' : 'modified') : 'absent');
+}
+
+/**
+ * `agent status`: one row per (target × default skill), each classified per
+ * the {@link SkillArtifactState} contract. Exit contract: returns normally
+ * (exit 0) when every row is 'ok' or 'absent'; throws CLIError exit 1 when any
+ * row is stale/modified/unmarked/corrupt, so the command can gate CI.
+ */
+export async function runStatus(opts: StatusOptions, deps: AgentDeps = {}): Promise<void> {
+  const agentFs = deps.fs ?? defaultAgentFs;
+  const out = makeOutput(opts.output, deps);
+
+  // An explicit but empty --dir must not silently resolve to cwd
+  // (path.resolve('') === cwd).
+  if (opts.dir !== undefined && opts.dir.trim() === '') {
+    throw localValidationError('dir', 'must not be empty');
+  }
+  const dir = opts.dir !== undefined ? opts.dir.trim() : (deps.cwd ?? process.cwd());
+  const root = path.resolve(dir);
+
+  // Canonical own-file bodies, read once per skill (same lazy caching pattern
+  // as runInstall's bodyForSkill).
+  const skillBodyCache = new Map<string, string>();
+  const bodyForSkill = (skill: string): string => {
+    let cachedBody = skillBodyCache.get(skill);
+    if (cachedBody === undefined) {
+      cachedBody = loadSkillBodyFor(skill);
+      skillBodyCache.set(skill, cachedBody);
+    }
+    return cachedBody;
+  };
+
+  const results: StatusResult[] = [];
+  for (const [target, spec] of Object.entries(TARGETS) as [
+    AgentTarget,
+    { mode: string; path: string },
+  ][]) {
+    if (spec.mode === 'managed-section') {
+      const stateFor = await classifyManagedSectionStates(agentFs, path.resolve(root, spec.path));
+      for (const skill of DEFAULT_SKILLS) {
+        results.push({ target, skill, path: spec.path, state: stateFor(skill) });
+      }
+      continue;
+    }
+    for (const skill of DEFAULT_SKILLS) {
+      const relPath = pathFor(target, skill);
+      results.push({
+        target,
+        skill,
+        path: relPath,
+        state: await classifyOwnFileState(
+          agentFs,
+          path.resolve(root, relPath),
+          target,
+          skill,
+          bodyForSkill,
+        ),
+      });
+    }
+  }
+
+  out.print(results, data => {
+    const items = data as StatusResult[];
+    const header = `${'TARGET'.padEnd(14)} ${'SKILL'.padEnd(20)} ${'STATE'.padEnd(10)} PATH`;
+    const rows = items.map(
+      row => `${row.target.padEnd(14)} ${row.skill.padEnd(20)} ${row.state.padEnd(10)} ${row.path}`,
+    );
+    return [header, ...rows].join('\n');
+  });
+
+  const needingAttention = results.filter(
+    result => result.state !== 'ok' && result.state !== 'absent',
+  );
+  if (needingAttention.length > 0) {
+    throw new CLIError(
+      `${needingAttention.length} skill artifact(s) need attention (stale/modified/unmarked/corrupt); re-run \`testsprite agent install\` (add --force for own-file targets) to refresh them.`,
+      1,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Command factory
 // ---------------------------------------------------------------------------
 
@@ -850,6 +1096,17 @@ export function createAgentCommand(deps: AgentDeps = {}): Command {
     .addHelpText('after', GLOBAL_OPTS_HINT)
     .action(async (_o, command: Command) => {
       await runList(resolveCommonOptions(command), deps);
+    });
+
+  agent
+    .command('status')
+    .description(
+      'Check installed TestSprite skill files against this CLI version: ok, stale, modified, unmarked, absent, or corrupt (exits 1 when anything needs attention, so it can gate CI)',
+    )
+    .option('--dir <path>', 'Project root to inspect (default: cwd)')
+    .addHelpText('after', GLOBAL_OPTS_HINT)
+    .action(async (cmdOpts: { dir?: string }, command: Command) => {
+      await runStatus({ ...resolveCommonOptions(command), dir: cmdOpts.dir }, deps);
     });
 
   return agent;

--- a/src/lib/agent-targets.test.ts
+++ b/src/lib/agent-targets.test.ts
@@ -1,5 +1,7 @@
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { VERSION } from '../version.js';
 import {
   DEFAULT_SKILLS,
   MANAGED_SECTION_BEGIN,
@@ -9,13 +11,17 @@ import {
   SKILL_NAME,
   SKILLS,
   TARGETS,
+  bodyHash12,
   buildCodexAggregate,
+  buildSkillMarker,
   codexContentFor,
   loadCodexSkillBody,
   loadSkillBody,
   loadSkillBodyFor,
+  parseSkillMarker,
   pathFor,
   renderForTarget,
+  renderOwnFileWithMarker,
 } from './agent-targets.js';
 
 // ---------------------------------------------------------------------------
@@ -678,5 +684,112 @@ describe('renderForTarget for testsprite-onboard', () => {
 
   it('unknown skill throws for renderForTarget', () => {
     expect(() => renderForTarget('claude', 'testsprite-unknown')).toThrow('unknown skill');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Install marker (issue #123): format, parsing, and render placement
+// ---------------------------------------------------------------------------
+
+describe('buildSkillMarker / parseSkillMarker / bodyHash12', () => {
+  it('marker line is an HTML comment carrying name, vVERSION, and a 12-hex hash', () => {
+    const marker = buildSkillMarker('testsprite-verify', STUB_BODY);
+    expect(marker).toBe(
+      `<!-- testsprite-skill: testsprite-verify v${VERSION} sha256:${bodyHash12(STUB_BODY)} -->`,
+    );
+    expect(marker).toMatch(
+      /^<!-- testsprite-skill: testsprite-verify v\S+ sha256:[0-9a-f]{12} -->$/,
+    );
+  });
+
+  it('bodyHash12 equals the first 12 hex chars of the body SHA-256', () => {
+    const fullHex = createHash('sha256').update(STUB_BODY, 'utf8').digest('hex');
+    expect(bodyHash12(STUB_BODY)).toBe(fullHex.slice(0, 12));
+  });
+
+  it('parseSkillMarker round-trips a built marker embedded in surrounding content', () => {
+    const marker = buildSkillMarker('testsprite-verify', STUB_BODY);
+    const parsed = parseSkillMarker(`# heading\n${marker}\nbody text\n`);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.skill).toBe('testsprite-verify');
+    expect(parsed?.version).toBe(VERSION);
+    expect(parsed?.hash12).toBe(bodyHash12(STUB_BODY));
+    expect(parsed?.line).toBe(marker);
+  });
+
+  it('parseSkillMarker strips a trailing CR so CRLF checkouts parse identically', () => {
+    const marker = buildSkillMarker('testsprite-verify', STUB_BODY);
+    const parsed = parseSkillMarker(`${marker}\r\nrest\r\n`);
+    expect(parsed?.line).toBe(marker);
+  });
+
+  it('parseSkillMarker returns null when no marker line is present', () => {
+    expect(parseSkillMarker('# Just a heading\n\nProse without any marker.\n')).toBeNull();
+  });
+
+  it('parseSkillMarker ignores the managed-section sentinels (also HTML comments)', () => {
+    expect(parseSkillMarker(`${MANAGED_SECTION_BEGIN}\nbody\n${MANAGED_SECTION_END}\n`)).toBeNull();
+  });
+});
+
+describe('render marker placement (own-file targets)', () => {
+  it('claude render carries the marker on the line right after the closing frontmatter fence', () => {
+    const { content } = renderForTarget('claude', 'testsprite-verify', STUB_BODY);
+    const closingFence = '\n---\n';
+    const fenceEnd = content.indexOf(closingFence) + closingFence.length;
+    expect(content.slice(fenceEnd).startsWith('<!-- testsprite-skill: testsprite-verify ')).toBe(
+      true,
+    );
+  });
+
+  it('cline render appends the marker as the LAST line so the body H1 stays first', () => {
+    const { content } = renderForTarget('cline', 'testsprite-verify', STUB_BODY);
+    expect(content.trimStart().startsWith('# TestSprite Verification Loop')).toBe(true);
+    const lines = content.trimEnd().split('\n');
+    expect(lines[lines.length - 1]).toBe(buildSkillMarker('testsprite-verify', STUB_BODY));
+  });
+
+  it('marker hash covers the canonical body only: same body renders the same hash on every target', () => {
+    const claudeMarker = parseSkillMarker(
+      renderForTarget('claude', 'testsprite-verify', STUB_BODY).content,
+    );
+    const cursorMarker = parseSkillMarker(
+      renderForTarget('cursor', 'testsprite-verify', STUB_BODY).content,
+    );
+    expect(claudeMarker?.hash12).toBe(bodyHash12(STUB_BODY));
+    expect(cursorMarker?.hash12).toBe(bodyHash12(STUB_BODY));
+  });
+
+  it('renderForTarget("codex") stays marker-free (the install writes the section marker)', () => {
+    const result = renderForTarget('codex', 'testsprite-verify', '# codex stub\n');
+    expect(result.content).toBe('# codex stub\n');
+    expect(parseSkillMarker(result.content)).toBeNull();
+  });
+
+  it('renderOwnFileWithMarker splices an arbitrary marker line into the canonical render', () => {
+    const foreignMarker = '<!-- testsprite-skill: testsprite-verify v0.0.1 sha256:0123456789ab -->';
+    const withForeign = renderOwnFileWithMarker(
+      'claude',
+      'testsprite-verify',
+      foreignMarker,
+      STUB_BODY,
+    );
+    expect(withForeign).toContain(foreignMarker);
+    // Marker line aside, the bytes match the canonical render exactly.
+    const canonical = renderForTarget('claude', 'testsprite-verify', STUB_BODY).content;
+    const currentMarker = buildSkillMarker('testsprite-verify', STUB_BODY);
+    expect(withForeign.replace(foreignMarker, currentMarker)).toBe(canonical);
+  });
+
+  it('renderOwnFileWithMarker rejects the managed-section target', () => {
+    expect(() => renderOwnFileWithMarker('codex', 'testsprite-verify', 'marker', 'body')).toThrow(
+      'own-file',
+    );
+  });
+
+  it('renderOwnFileWithMarker throws on an unknown skill', () => {
+    expect(() => renderOwnFileWithMarker('claude', 'testsprite-unknown', 'marker')).toThrow(
+      'unknown skill',
+    );
   });
 });

--- a/src/lib/agent-targets.ts
+++ b/src/lib/agent-targets.ts
@@ -1,4 +1,6 @@
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
+import { VERSION } from '../version.js';
 
 export type AgentTarget = 'claude' | 'cursor' | 'cline' | 'antigravity' | 'codex';
 
@@ -201,6 +203,85 @@ export const MANAGED_SECTION_BEGIN =
   '<!-- BEGIN TESTSPRITE AGENT SECTION (testsprite agent install codex) -->';
 export const MANAGED_SECTION_END = '<!-- END TESTSPRITE AGENT SECTION -->';
 
+// ---------------------------------------------------------------------------
+// Install marker (stale-skill detection, issue #123)
+// ---------------------------------------------------------------------------
+
+/**
+ * Hex characters of the canonical body's SHA-256 kept in the install marker.
+ * 12 hex chars (48 bits) is ample for drift DETECTION (equality against bodies
+ * this CLI ships); the marker is provenance metadata, not a security boundary.
+ */
+const MARKER_HASH_HEX_LENGTH = 12;
+
+/**
+ * When one marker covers several skills (the codex managed section aggregates
+ * every installed skill), their names are joined with this separator in the
+ * marker's skill field. Skill names never contain '+' (see {@link SKILLS} keys).
+ */
+export const MARKER_SKILL_SEPARATOR = '+';
+
+/**
+ * Marker line shape: `<!-- testsprite-skill: <name> v<version> sha256:<hash> -->`.
+ * An HTML comment is inert in every target format (SKILL.md, .mdc, .clinerules
+ * markdown, AGENTS.md). Built via `new RegExp` so the hash length stays bound
+ * to {@link MARKER_HASH_HEX_LENGTH}.
+ */
+const SKILL_MARKER_LINE_RE = new RegExp(
+  `^<!-- testsprite-skill: (\\S+) v(\\S+) sha256:([0-9a-f]{${MARKER_HASH_HEX_LENGTH}}) -->$`,
+);
+
+/**
+ * First {@link MARKER_HASH_HEX_LENGTH} hex chars of the SHA-256 of a canonical
+ * skill body. The hash covers the CANONICAL BODY ONLY (pre-wrap, pre-marker),
+ * so writing the marker into the rendered artifact never changes the hash the
+ * marker itself carries.
+ */
+export function bodyHash12(canonicalBody: string): string {
+  return createHash('sha256')
+    .update(canonicalBody, 'utf8')
+    .digest('hex')
+    .slice(0, MARKER_HASH_HEX_LENGTH);
+}
+
+/**
+ * Build the provenance marker line for a skill (or a
+ * {@link MARKER_SKILL_SEPARATOR}-joined skill set) and its canonical body.
+ * `agent status` compares this fingerprint against the bodies the running CLI
+ * ships to detect silently stale installs.
+ */
+export function buildSkillMarker(skillName: string, canonicalBody: string): string {
+  return `<!-- testsprite-skill: ${skillName} v${VERSION} sha256:${bodyHash12(canonicalBody)} -->`;
+}
+
+/** A marker line parsed back into its fields. */
+export interface ParsedSkillMarker {
+  /** Skill name, or several names joined with {@link MARKER_SKILL_SEPARATOR}. */
+  skill: string;
+  /** CLI version that wrote the artifact. */
+  version: string;
+  /** First 12 hex chars of the canonical body's SHA-256 at install time. */
+  hash12: string;
+  /** The exact marker line (trailing CR/whitespace stripped) as found. */
+  line: string;
+}
+
+/**
+ * Find the first testsprite-skill marker line in `content`, or null when the
+ * content carries none (a pre-marker install). Lines are matched whole with
+ * trailing CR/whitespace stripped, so CRLF checkouts parse identically.
+ */
+export function parseSkillMarker(content: string): ParsedSkillMarker | null {
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trimEnd();
+    const matched = SKILL_MARKER_LINE_RE.exec(line);
+    if (matched) {
+      return { skill: matched[1]!, version: matched[2]!, hash12: matched[3]!, line };
+    }
+  }
+  return null;
+}
+
 type ReadFn = (url: URL) => string;
 
 const defaultRead: ReadFn = (url: URL) => readFileSync(url, 'utf8');
@@ -276,14 +357,66 @@ export function loadCodexSkillBody(read: ReadFn = defaultRead): string {
 // ---------------------------------------------------------------------------
 
 /**
+ * Place the marker line inside a wrapped own-file render.
+ *
+ * - Wraps that emit YAML frontmatter (claude/antigravity/cursor): the marker
+ *   lands on the line right after the closing `---` fence, before the body.
+ * - Wrapless targets (cline, body verbatim): the marker is appended as the
+ *   LAST line instead. Cline surfaces the file's first heading as the rule
+ *   title, so a leading comment would displace the body's H1.
+ */
+function injectMarkerLine(wrapped: string, markerLine: string): string {
+  if (wrapped.startsWith('---\n')) {
+    // The name/description frontmatter values are single-line, so the first
+    // `\n---\n` after the opening fence is always the closing fence.
+    const closingFence = '\n---\n';
+    const fenceIdx = wrapped.indexOf(closingFence);
+    if (fenceIdx !== -1) {
+      const insertAt = fenceIdx + closingFence.length;
+      return `${wrapped.slice(0, insertAt)}${markerLine}\n${wrapped.slice(insertAt)}`;
+    }
+  }
+  const separator = wrapped.endsWith('\n') ? '' : '\n';
+  return `${wrapped}${separator}${markerLine}\n`;
+}
+
+/**
+ * Exact own-file bytes for a skill on a target, carrying the GIVEN marker line.
+ * `agent status` uses this to re-render the current canonical body with a
+ * file's own (possibly older-versioned) marker: when only the marker's version
+ * string lags but the body is unchanged, the artifact still compares pristine.
+ */
+export function renderOwnFileWithMarker(
+  target: AgentTarget,
+  skill: string,
+  markerLine: string,
+  body?: string,
+): string {
+  const spec = TARGETS[target];
+  if (spec.mode !== 'own-file') {
+    throw new Error(`renderOwnFileWithMarker: ${target} is not an own-file target`);
+  }
+  const skillSpec = SKILLS[skill];
+  if (!skillSpec) throw new Error(`unknown skill: ${skill}`);
+  const resolvedBody = body !== undefined ? body : loadSkillBodyFor(skill);
+  return injectMarkerLine(
+    spec.wrap(skillSpec.name, skillSpec.description, resolvedBody),
+    markerLine,
+  );
+}
+
+/**
  * The exact bytes to write for one skill on one target.
  *
  * - own-file targets: `body` defaults to the skill's own-file asset, wrapped in
- *   the target's frontmatter/header.
+ *   the target's frontmatter/header, and carrying a provenance marker line so
+ *   `agent status` can tell fresh, stale, and hand-edited installs apart.
  * - codex (managed-section): returns the skill's codex contribution unwrapped
- *   (plain Markdown, no frontmatter). The real install does NOT call this for
- *   codex — it aggregates all skills via {@link buildCodexAggregate} — but it is
- *   kept single-skill here for tests and parity. Pass an explicit `body` to override.
+ *   and marker-free (plain Markdown, no frontmatter). The real install does NOT
+ *   call this for codex: it aggregates all skills via
+ *   {@link buildCodexAggregate} and writes ONE marker just inside the BEGIN
+ *   sentinel. It is kept single-skill here for tests and parity. Pass an
+ *   explicit `body` to override.
  */
 export function renderForTarget(
   t: AgentTarget,
@@ -299,5 +432,8 @@ export function renderForTarget(
     return { path, content: spec.wrap(skillSpec.name, skillSpec.description, resolvedBody) };
   }
   const resolvedBody = body !== undefined ? body : loadSkillBodyFor(skill);
-  return { path, content: spec.wrap(skillSpec.name, skillSpec.description, resolvedBody) };
+  return {
+    path,
+    content: renderOwnFileWithMarker(t, skill, buildSkillMarker(skill, resolvedBody), resolvedBody),
+  };
 }

--- a/test/__snapshots__/help.snapshot.test.ts.snap
+++ b/test/__snapshots__/help.snapshot.test.ts.snap
@@ -14,6 +14,9 @@ Commands:
                      first-run onboarding) into a project for a coding agent
   list               List supported agent targets and skills, their status, and
                      landing paths
+  status [options]   Check installed TestSprite skill files against this CLI
+                     version: ok, stale, modified, unmarked, absent, or corrupt
+                     (exits 1 when anything needs attention, so it can gate CI)
   help [command]     display help for command
 "
 `;


### PR DESCRIPTION
## What does this PR do?
Installed skill files go stale silently: nothing records which CLI version
wrote them, so drift (e.g. a shipped skill referencing a deprecated command)
is invisible. This stamps every install with an inert HTML-comment marker
(`<!-- testsprite-skill: <name> v<version> sha256:<hash12> -->`) — placed
after the frontmatter fence for own-file targets, appended last for cline so
its H1-derived title survives, and ONE marker just inside the codex managed
section's BEGIN sentinel. A new `agent status` command classifies every
(target x skill) artifact as ok / stale / modified / unmarked / absent /
corrupt and exits 1 when anything needs attention, so it can gate CI.

## Related issue
Fixes #123

## Type of change
- [x] New feature (non-breaking change that adds functionality)

## Checklist
- [x] PR targets the `main` branch.
- [x] Commits follow Conventional Commits.
- [x] `npm run lint` and `npm run format:check` pass.
- [x] `npm run typecheck` passes.
- [x] `npm test` passes and coverage stays at or above the 80% gate.
- [x] New behavior is covered by unit tests (mock-based; no network).
- [x] No secrets, API keys, internal endpoints, or personal data are included.

## Notes for reviewers
The hash covers the CANONICAL body only (pre-wrap, pre-marker), so writing the
marker never changes the hash it carries, and a version-string-only lag with an
unchanged body still reads ok. The codex byte-identity path is kept intact:
same skill set + version + body always renders byte-identical, so the
classifySection 'unchanged' fast-path still short-circuits re-installs.
Comparisons follow the installer's own semantics (byte-exact for own-file,
CRLF-insensitive on the codex section slice).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `agent status` command to check installed skill artifacts and report their current state.
  * Skill files now include a visible provenance marker so the app can track whether they are current, changed, or missing.

* **Bug Fixes**
  * Improved detection of outdated, modified, unmarked, and missing skill installations.
  * Added clearer exit codes and status reporting for invalid directory input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->