### PR TITLE
feat(agent): add GitHub Copilot as an install target

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -115,14 +115,15 @@ testsprite agent install cline      # .clinerules/testsprite-verify.md
 testsprite agent install windsurf   # .windsurf/rules/testsprite-verify.md
 testsprite agent install antigravity  # .agents/skills/testsprite-verify/SKILL.md
 testsprite agent install kiro       # .kiro/skills/testsprite-verify/SKILL.md
-testsprite agent list               # list all 7 targets with status + mode + path
+testsprite agent install copilot    # .github/instructions/testsprite-verify.instructions.md
+testsprite agent list               # list all 8 targets with status + mode + path
 ```
 
-Supported targets: `claude` (GA), `codex` (experimental), `cursor` (experimental), `cline` (experimental), `antigravity` (experimental), `kiro` (experimental), `windsurf` (experimental).
+Supported targets: `claude` (GA), `codex` (experimental), `cursor` (experimental), `cline` (experimental), `antigravity` (experimental), `kiro` (experimental), `windsurf` (experimental), `copilot` (experimental).
 
 The `codex` target uses **managed-section mode** — it writes only a sentinel-delimited section inside your existing `AGENTS.md`, so your project instructions are never clobbered. Re-running without `--force` replaces the section in-place; user content outside the sentinels is always preserved.
 
-Re-running with `--force` on **own-file targets** (claude, cursor, cline, antigravity, kiro, windsurf) backs up the existing file to `<path>.bak` first.
+Re-running with `--force` on **own-file targets** (claude, cursor, cline, antigravity, kiro, windsurf, copilot) backs up the existing file to `<path>.bak` first.
 
 ## Command reference
 

--- a/README.md
+++ b/README.md
@@ -89,28 +89,28 @@ Prefer to configure each step by hand (or learn the surface offline with `--dry-
 
 ## Commands
 
-| Group     | Command                                             | What it does                                                                                                           |
-| --------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **Setup** | `setup`                                             | **Start here** — one command: configure your API key, verify it, and install the agent verification skill              |
-| **Auth**  | `auth status`                                       | Resolve the active profile to its user, key, env, and scopes                                                           |
-|           | `auth remove`                                       | Remove the active profile from the credentials file                                                                    |
-| **Read**  | `project list` / `project get`                      | List projects / fetch one by id                                                                                        |
-|           | `test list` / `test get`                            | List tests under a project / fetch one by id                                                                           |
-|           | `test code get`                                     | Print (or write) the generated test source                                                                             |
-|           | `test steps`                                        | List the latest run's steps with screenshot / DOM pointers                                                             |
-|           | `test result`                                       | Latest result; `--history` lists a test's prior runs                                                                   |
-|           | `test failure get`                                  | The agent entry point: one self-contained latest-failure bundle                                                        |
-|           | `test failure summary`                              | One-screen triage card (no media download)                                                                             |
-| **Write** | `test create` / `test create-batch`                 | Create a test (or bulk-create from a plan file); `--produces` / `--needs` / `--category` wire BE dependency metadata   |
-|           | `test update` / `test delete` / `test delete-batch` | Edit metadata / soft-delete                                                                                            |
-|           | `test code put`                                     | Replace generated code (etag-guarded)                                                                                  |
-|           | `test plan put`                                     | Replace a frontend test's plan-steps                                                                                   |
-|           | `project create` / `project update`                 | Manage projects                                                                                                        |
-| **Run**   | `test run`                                          | Trigger a fresh run; `--wait` blocks until terminal; `--all --project <id>` runs all tests in a project in wave order  |
-|           | `test rerun`                                        | Cheap replay of one/many tests (FE verbatim; BE with deps); `--all --project <id>` reruns all tests                    |
-|           | `test wait`                                         | Block on a `runId` until terminal                                                                                      |
-|           | `test artifact get`                                 | Download the failure bundle for a specific `runId`                                                                     |
-| **Agent** | `agent install` / `agent list`                      | Add or list coding-agent targets (pure-local): `claude`, `codex`, `cursor`, `cline`, `antigravity`, `kiro`, `windsurf` |
+| Group     | Command                                             | What it does                                                                                                                      |
+| --------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Setup** | `setup`                                             | **Start here** — one command: configure your API key, verify it, and install the agent verification skill                         |
+| **Auth**  | `auth status`                                       | Resolve the active profile to its user, key, env, and scopes                                                                      |
+|           | `auth remove`                                       | Remove the active profile from the credentials file                                                                               |
+| **Read**  | `project list` / `project get`                      | List projects / fetch one by id                                                                                                   |
+|           | `test list` / `test get`                            | List tests under a project / fetch one by id                                                                                      |
+|           | `test code get`                                     | Print (or write) the generated test source                                                                                        |
+|           | `test steps`                                        | List the latest run's steps with screenshot / DOM pointers                                                                        |
+|           | `test result`                                       | Latest result; `--history` lists a test's prior runs                                                                              |
+|           | `test failure get`                                  | The agent entry point: one self-contained latest-failure bundle                                                                   |
+|           | `test failure summary`                              | One-screen triage card (no media download)                                                                                        |
+| **Write** | `test create` / `test create-batch`                 | Create a test (or bulk-create from a plan file); `--produces` / `--needs` / `--category` wire BE dependency metadata              |
+|           | `test update` / `test delete` / `test delete-batch` | Edit metadata / soft-delete                                                                                                       |
+|           | `test code put`                                     | Replace generated code (etag-guarded)                                                                                             |
+|           | `test plan put`                                     | Replace a frontend test's plan-steps                                                                                              |
+|           | `project create` / `project update`                 | Manage projects                                                                                                                   |
+| **Run**   | `test run`                                          | Trigger a fresh run; `--wait` blocks until terminal; `--all --project <id>` runs all tests in a project in wave order             |
+|           | `test rerun`                                        | Cheap replay of one/many tests (FE verbatim; BE with deps); `--all --project <id>` reruns all tests                               |
+|           | `test wait`                                         | Block on a `runId` until terminal                                                                                                 |
+|           | `test artifact get`                                 | Download the failure bundle for a specific `runId`                                                                                |
+| **Agent** | `agent install` / `agent list`                      | Add or list coding-agent targets (pure-local): `claude`, `codex`, `cursor`, `cline`, `antigravity`, `kiro`, `windsurf`, `copilot` |
 
 > The earlier command names — `init`, `auth configure`, `auth whoami`, `auth logout` — still work as hidden, deprecated aliases (each prints a one-line notice pointing at the new name), so existing scripts keep running. `auth configure` now runs the full `setup` (it also installs the skill).
 

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -769,13 +769,14 @@ describe('runList', () => {
 
     const json = JSON.parse(capture.stdout.join('\n')) as ListResult[];
     expect(Array.isArray(json)).toBe(true);
-    // 7 targets × 2 default skills = 14 rows
-    expect(json).toHaveLength(14);
+    // 8 targets × 2 default skills = 16 rows
+    expect(json).toHaveLength(16);
     const targets = json.map(r => r.target);
     expect(targets).toContain('claude');
     expect(targets).toContain('cursor');
     expect(targets).toContain('cline');
     expect(targets).toContain('windsurf');
+    expect(targets).toContain('copilot');
     expect(targets).toContain('antigravity');
     expect(targets).toContain('kiro');
     expect(targets).toContain('codex');
@@ -949,11 +950,11 @@ describe('runInstall — all own-file targets', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Dry-run for all six own-file targets
+// Dry-run for all seven own-file targets
 // ---------------------------------------------------------------------------
 
 describe('runInstall — dry-run all own-file targets', () => {
-  it('writes nothing for any of the six own-file targets (default 2 skills = 12 would-write lines)', async () => {
+  it('writes nothing for any of the seven own-file targets (default 2 skills = 14 would-write lines)', async () => {
     const { store, fs: agentFs } = makeMemFs();
     const { capture, deps } = makeCapture();
 
@@ -963,7 +964,7 @@ describe('runInstall — dry-run all own-file targets', () => {
         output: 'text',
         debug: false,
         dryRun: true,
-        target: ['claude', 'cursor', 'cline', 'antigravity', 'kiro', 'windsurf'],
+        target: ['claude', 'cursor', 'cline', 'antigravity', 'kiro', 'windsurf', 'copilot'],
         force: false,
       },
       { cwd: CWD, fs: agentFs, ...deps },
@@ -973,9 +974,9 @@ describe('runInstall — dry-run all own-file targets', () => {
     const stderrOut = capture.stderr.join('\n');
     // Banner appears once
     expect(stderrOut).toContain('[dry-run] no files written');
-    // 6 targets × 2 default skills = 12 would-write lines
+    // 7 targets × 2 default skills = 14 would-write lines
     const wouldWriteLines = stderrOut.split('\n').filter(l => l.includes('would write'));
-    expect(wouldWriteLines.length).toBe(12);
+    expect(wouldWriteLines.length).toBe(14);
   });
 });
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1061,7 +1061,7 @@ function collect(v: string, prev: string[]): string[] {
 
 export function createAgentCommand(deps: AgentDeps = {}): Command {
   const agent = new Command('agent').description(
-    'Install TestSprite guidance into coding-agent config (Claude Code, Cursor, Cline, Windsurf, Antigravity, Codex)',
+    'Install TestSprite guidance into coding-agent config (Claude Code, Cursor, Cline, Windsurf, Copilot, Antigravity, Codex)',
   );
 
   agent
@@ -1071,7 +1071,7 @@ export function createAgentCommand(deps: AgentDeps = {}): Command {
     )
     .option(
       '--target <t>',
-      'Agent target(s): claude, cursor, cline, antigravity, kiro, windsurf, codex (comma-separated or repeated)',
+      'Agent target(s): claude, cursor, cline, antigravity, kiro, windsurf, copilot, codex (comma-separated or repeated)',
       collect,
       [],
     )

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1061,7 +1061,7 @@ function collect(v: string, prev: string[]): string[] {
 
 export function createAgentCommand(deps: AgentDeps = {}): Command {
   const agent = new Command('agent').description(
-    'Install TestSprite guidance into coding-agent config (Claude Code, Cursor, Cline, Windsurf, Copilot, Antigravity, Codex)',
+    'Install TestSprite guidance into coding-agent config (Claude Code, Cursor, Cline, Antigravity, Kiro, Windsurf, Copilot, Codex)',
   );
 
   agent

--- a/src/lib/agent-targets.test.ts
+++ b/src/lib/agent-targets.test.ts
@@ -80,19 +80,29 @@ testsprite test artifact get <run-id> --out ./out/
 // ---------------------------------------------------------------------------
 
 describe('TARGETS', () => {
-  it('has all seven required keys', () => {
+  it('has all eight required keys', () => {
     const keys = Object.keys(TARGETS).sort();
-    expect(keys).toEqual(['antigravity', 'claude', 'cline', 'codex', 'cursor', 'kiro', 'windsurf']);
+    expect(keys).toEqual([
+      'antigravity',
+      'claude',
+      'cline',
+      'codex',
+      'copilot',
+      'cursor',
+      'kiro',
+      'windsurf',
+    ]);
   });
 
   it('claude is GA', () => {
     expect(TARGETS.claude.status).toBe('ga');
   });
 
-  it('cursor, cline, windsurf, antigravity, kiro, and codex are experimental', () => {
+  it('cursor, cline, windsurf, copilot, antigravity, kiro, and codex are experimental', () => {
     expect(TARGETS.cursor.status).toBe('experimental');
     expect(TARGETS.cline.status).toBe('experimental');
     expect(TARGETS.windsurf.status).toBe('experimental');
+    expect(TARGETS.copilot.status).toBe('experimental');
     expect(TARGETS.antigravity.status).toBe('experimental');
     expect(TARGETS.kiro.status).toBe('experimental');
     expect(TARGETS.codex.status).toBe('experimental');
@@ -112,6 +122,7 @@ describe('TARGETS', () => {
     expect(TARGETS.cline.mode).toBe('own-file');
     expect(TARGETS.kiro.mode).toBe('own-file');
     expect(TARGETS.windsurf.mode).toBe('own-file');
+    expect(TARGETS.copilot.mode).toBe('own-file');
   });
 
   it('codex target has mode managed-section', () => {
@@ -341,11 +352,45 @@ describe('windsurf renders within the rules-file budget', () => {
   });
 });
 
+describe('renderForTarget("copilot")', () => {
+  const result = renderForTarget('copilot', 'testsprite-verify', STUB_BODY);
+
+  it('returns the .github/instructions path', () => {
+    expect(result.path).toBe('.github/instructions/testsprite-verify.instructions.md');
+  });
+
+  it('uses the Copilot frontmatter (applyTo + description)', () => {
+    expect(result.content.startsWith('---\n')).toBe(true);
+    expect(result.content).toContain(`description: ${SKILL_DESCRIPTION}`);
+    expect(result.content).toContain("applyTo: '**'");
+  });
+
+  it('does NOT carry the Claude/Cursor/Windsurf frontmatter keys', () => {
+    const match = /^---\n([\s\S]*?)\n---/.exec(result.content);
+    const fm = match?.[1] ?? '';
+    expect(fm).not.toContain('name:'); // claude key
+    expect(fm).not.toContain('alwaysApply:'); // cursor .mdc key
+    expect(fm).not.toContain('trigger:'); // windsurf Cascade key
+  });
+
+  it('renders the compact verify body (applyTo:** is always-on, so keep it small)', () => {
+    // Uses the REAL bodies (no stub): copilot always-injects, so like windsurf it
+    // ships the trimmed verify body while keeping the load-bearing command.
+    const copilot = renderForTarget('copilot', 'testsprite-verify');
+    const claude = renderForTarget('claude', 'testsprite-verify');
+    expect(copilot.content.length).toBeLessThan(claude.content.length);
+    expect(copilot.content).not.toContain('The verification loop that flies');
+    expect(copilot.content).toContain('testsprite test run');
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Content integrity — load-bearing command strings must survive any body trim
 // ---------------------------------------------------------------------------
 
 describe('content integrity — own-file targets', () => {
+  // Full-body own-file targets. Compact-body targets (windsurf, copilot) are
+  // excluded — they render the trimmed verify body; see their dedicated tests.
   const ownFileTargets: Array<'claude' | 'cursor' | 'cline' | 'antigravity' | 'kiro'> = [
     'claude',
     'cursor',

--- a/src/lib/agent-targets.ts
+++ b/src/lib/agent-targets.ts
@@ -9,7 +9,8 @@ export type AgentTarget =
   | 'antigravity'
   | 'codex'
   | 'kiro'
-  | 'windsurf';
+  | 'windsurf'
+  | 'copilot';
 
 export interface TargetSpec {
   status: 'ga' | 'experimental';
@@ -149,6 +150,19 @@ function wrapWindsurf(_name: string, description: string, body: string): string 
   return `---\ntrigger: model_decision\ndescription: ${description}\n---\n\n${body}\n`;
 }
 
+/**
+ * GitHub Copilot reads path-specific custom instructions from
+ * `.github/instructions/*.instructions.md` (VS Code / Visual Studio / GitHub
+ * Copilot Chat). Each file carries YAML frontmatter with `applyTo` — a glob that
+ * scopes when the instructions attach. `applyTo: '**'` attaches the guidance to
+ * every request in the repo, which is what a persistent verification skill wants
+ * (there is no on-demand "model decides" mode for Copilot instruction files, so
+ * always-apply is the correct idiom). `description` is surfaced in Copilot's UI.
+ */
+function wrapCopilot(_name: string, description: string, body: string): string {
+  return `---\ndescription: ${description}\napplyTo: '**'\n---\n\n${body}\n`;
+}
+
 // ---------------------------------------------------------------------------
 // Landing paths
 // ---------------------------------------------------------------------------
@@ -173,6 +187,8 @@ export function pathFor(target: AgentTarget, skill: string): string {
       return `.kiro/skills/${skill}/SKILL.md`;
     case 'windsurf':
       return `.windsurf/rules/${skill}.md`;
+    case 'copilot':
+      return `.github/instructions/${skill}.instructions.md`;
     case 'codex':
       return 'AGENTS.md';
   }
@@ -219,6 +235,18 @@ export const TARGETS: Record<AgentTarget, TargetSpec> = {
     // so render the compact body per skill (see compactBodyFor).
     compactBody: true,
     wrap: wrapWindsurf,
+  },
+  copilot: {
+    status: 'experimental',
+    path: pathFor('copilot', SKILL_NAME),
+    mode: 'own-file',
+    // GitHub Copilot path-specific instructions: frontmatter carries `applyTo`.
+    // `applyTo: '**'` means the file is ALWAYS injected into Copilot requests
+    // (there is no on-demand "model decides" mode like Cursor/Windsurf), so
+    // render the compact body to keep the always-on context cost small — the
+    // same reasoning that drives windsurf's compact render.
+    compactBody: true,
+    wrap: wrapCopilot,
   },
   /**
    * codex target — managed-section mode.

--- a/test/__snapshots__/help.snapshot.test.ts.snap
+++ b/test/__snapshots__/help.snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`--help snapshots > agent 1`] = `
 "Usage: testsprite agent [options] [command]
 
 Install TestSprite guidance into coding-agent config (Claude Code, Cursor,
-Cline, Windsurf, Antigravity, Codex)
+Cline, Windsurf, Copilot, Antigravity, Codex)
 
 Options:
   -h, --help         display help for command
@@ -29,7 +29,8 @@ into a project for a coding agent
 
 Options:
   --target <t>    Agent target(s): claude, cursor, cline, antigravity, kiro,
-                  windsurf, codex (comma-separated or repeated) (default: [])
+                  windsurf, copilot, codex (comma-separated or repeated)
+                  (default: [])
   --skill <name>  Skill(s) to install: testsprite-verify, testsprite-onboard
                   (comma-separated or repeated; default: all) (default: [])
   --dir <path>    Project root to write into (default: cwd)
@@ -115,8 +116,8 @@ Options:
   --from-env        Read TESTSPRITE_API_KEY from the environment instead of
                     prompting (default: false)
   --agent <target>  Coding-agent target to install: claude, antigravity,
-                    cursor, cline, kiro, windsurf, codex (default: claude)
-                    (default: "claude")
+                    cursor, cline, kiro, windsurf, copilot, codex (default:
+                    claude) (default: "claude")
   --no-agent        Skip the agent skill install (configure credentials only)
   --force           Overwrite an existing skill file (a .bak backup is kept)
   --dir <path>      Project root for the skill install (default: current
@@ -651,7 +652,7 @@ Commands:
   test                         Inspect TestSprite tests
   agent                        Install TestSprite guidance into coding-agent
                                config (Claude Code, Cursor, Cline, Windsurf,
-                               Antigravity, Codex)
+                               Copilot, Antigravity, Codex)
   usage|credits                Show credit balance and plan/entitlement info
                                (proactive pre-flight before a large test run)
   help [command]               display help for command

--- a/test/__snapshots__/help.snapshot.test.ts.snap
+++ b/test/__snapshots__/help.snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`--help snapshots > agent 1`] = `
 "Usage: testsprite agent [options] [command]
 
 Install TestSprite guidance into coding-agent config (Claude Code, Cursor,
-Cline, Windsurf, Copilot, Antigravity, Codex)
+Cline, Antigravity, Kiro, Windsurf, Copilot, Codex)
 
 Options:
   -h, --help         display help for command
@@ -651,8 +651,8 @@ Commands:
   project                      Manage TestSprite projects
   test                         Inspect TestSprite tests
   agent                        Install TestSprite guidance into coding-agent
-                               config (Claude Code, Cursor, Cline, Windsurf,
-                               Copilot, Antigravity, Codex)
+                               config (Claude Code, Cursor, Cline, Antigravity,
+                               Kiro, Windsurf, Copilot, Codex)
   usage|credits                Show credit balance and plan/entitlement info
                                (proactive pre-flight before a large test run)
   help [command]               display help for command

--- a/test/e2e/agent-install.e2e.test.ts
+++ b/test/e2e/agent-install.e2e.test.ts
@@ -174,6 +174,11 @@ describe('content integrity', () => {
         expect(content.startsWith('---'), `windsurf: should start with ---`).toBe(true);
         expect(content).toContain('trigger: model_decision');
         expect(content).toContain('description:');
+      } else if (target === 'copilot') {
+        // GitHub Copilot instructions frontmatter: applyTo glob + description
+        expect(content.startsWith('---'), `copilot: should start with ---`).toBe(true);
+        expect(content).toContain("applyTo: '**'");
+        expect(content).toContain('description:');
       }
 
       // (b) branding — the renamed H1 must be present in every body variant
@@ -211,6 +216,9 @@ describe('content integrity', () => {
         expect(content.startsWith('---'), `windsurf/onboard: should start with ---`).toBe(true);
         expect(content).toContain('trigger: model_decision');
         expect(content).toContain('description:');
+      } else if (target === 'copilot') {
+        expect(content.startsWith('---'), `copilot/onboard: should start with ---`).toBe(true);
+        expect(content).toContain("applyTo: '**'");
       }
 
       // Load-bearing onboard string: the skill body must reference setup
@@ -803,7 +811,7 @@ describe('agent list', () => {
     }>;
     expect(Array.isArray(parsed)).toBe(true);
 
-    // Expected: 7 targets × 2 skills = 14 rows
+    // Expected: 8 targets × 2 skills = 16 rows
     const expectedCount = Object.keys(TARGETS).length * DEFAULT_SKILLS.length;
     expect(parsed.length).toBe(expectedCount);
 
@@ -839,6 +847,7 @@ describe('matrix coverage guard', () => {
       'cline',
       'kiro',
       'windsurf',
+      'copilot',
       'codex',
     ]);
   });

--- a/test/e2e/setup.e2e.test.ts
+++ b/test/e2e/setup.e2e.test.ts
@@ -229,6 +229,7 @@ describe('matrix coverage guard', () => {
       'cline',
       'kiro',
       'windsurf',
+      'copilot',
       'codex',
     ]);
   });


### PR DESCRIPTION
## What does this PR do?

Adds **GitHub Copilot** as an `agent install` target — the most widely-used AI coding assistant, and the biggest remaining gap in the target set.

GitHub Copilot reads path-specific custom instructions from `.github/instructions/*.instructions.md` (VS Code, Visual Studio, Copilot Chat), with YAML frontmatter carrying an `applyTo` glob. This PR installs the verification-loop skill there the same way it's installed for Cursor/Cline/Windsurf:

- **Path:** `.github/instructions/testsprite-verify.instructions.md` (+ `testsprite-onboard.instructions.md`).
- **Frontmatter:** `applyTo: '**'` + `description`. Copilot instruction files have no on-demand "model decides" mode (unlike Cursor's `alwaysApply: false` or Windsurf's `trigger: model_decision`), so always-apply is the correct idiom.
- **Always-on ⇒ compact body:** since `applyTo: '**'` injects the file into every Copilot request, the target renders the **compact** body (~6 KB) instead of the full ~23 KB body — the same reasoning behind windsurf's compact render, keeping the always-injected context cost small.

It slots into the existing `TARGETS` machinery, so `agent list`, `setup --agent`, and skill-nudge install-detection pick it up automatically.

### Verified locally

```console
$ testsprite agent install --target copilot --dir /tmp/x
$ cat /tmp/x/.github/instructions/testsprite-verify.instructions.md
---
description: TestSprite verification loop — ...
applyTo: '**'
---
...
# 6009 bytes (compact), under always-on budget
```

## Related issue

Fixes #195

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [x] PR targets the `main` branch.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org).
- [x] `npm run lint` and `npm run format:check` pass.
- [x] `npm run typecheck` passes.
- [x] `npm test` passes and coverage stays at or above the 80% gate.
- [x] New behavior is covered by unit tests (mock-based; no network or credentials required).
- [x] No secrets, API keys, internal endpoints, or personal data are included.
- [x] User-facing changes are reflected in `README.md` / `DOCUMENTATION.md`.

## Notes for reviewers

- Follows the exact pattern established by the merged windsurf (#29) and kiro (#10) targets: `AgentTarget` union, `pathFor`, `TARGETS`, help strings, README/DOCUMENTATION, both e2e matrix guards, and the regenerated help snapshot.
- Renders through the content-integrity marker path (`renderOwnFileWithMarker`/`buildSkillMarker`), so `agent status` tracks copilot files like every other own-file target.
- All gates green locally: typecheck, lint, format:check, **1825 unit tests**, **55 e2e**.
- **Scope note:** I saw the "target policy settled this round" note from the windsurf/kiro/gemini triage. I'm proposing Copilot as the clear next-highest-value target (it's the single most-used assistant and unclaimed), but I'm happy to defer if the target set is closed for now — no hard feelings if this waits for a future round.

### AI usage disclosure

Yes, I used AI assistance for this change — investigation, implementation, and tests. I reviewed and verified everything myself (installed the target, inspected the rendered file and its frontmatter/size, and ran the full gate suite).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the new **Copilot** agent target across the CLI and installation flow.
  * Copilot target now renders instruction files with `description` and `applyTo: '**'`.

* **Bug Fixes**
  * Refreshed command help text, examples, and target listings so the supported target count and output matrix are accurate.
  * Updated backup/force behavior listings to include Copilot where applicable.

* **Documentation**
  * Updated README and agent onboarding docs to include Copilot in supported targets and commands.

* **Tests**
  * Updated unit and end-to-end tests to reflect the expanded target/skill matrix (including Copilot).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
