### PR TITLE
fix(agent): update verify skill auth commands

### DIFF
--- a/docs/cli-v1-agent-install/skill-template.md
+++ b/docs/cli-v1-agent-install/skill-template.md
@@ -61,13 +61,13 @@ because <X>. Treat this as unverified until that's resolved." Don't claim done.
 
 ```bash
 testsprite --version              # CLI installed?
-testsprite auth whoami            # credentials configured?
+testsprite auth status            # credentials configured?
 ```
 
 - `--version` fails → the CLI isn't installed. Tell the user to install the
   TestSprite CLI (see the TestSprite docs) and stop; don't install it for them.
-- `auth whoami` fails → no credentials. Tell the user they can run
-  `testsprite auth configure`, then stop.
+- `auth status` fails → no credentials. Tell the user they can run
+  `testsprite setup`, then stop.
 
 ## 2. Find the project
 

--- a/skills/testsprite-verify.codex.md
+++ b/skills/testsprite-verify.codex.md
@@ -16,11 +16,11 @@ build/config changes, or when the repo has no TestSprite project linked.
 
 ```bash
 testsprite --version          # CLI installed?
-testsprite auth whoami        # credentials valid?
+testsprite auth status        # credentials valid?
 ```
 
 If `--version` fails, tell the user to install the CLI and stop.
-If `auth whoami` fails, tell the user to run `testsprite auth configure` and stop.
+If `auth status` fails, tell the user to run `testsprite setup` and stop.
 
 ### 2. Find the project
 

--- a/skills/testsprite-verify.skill.md
+++ b/skills/testsprite-verify.skill.md
@@ -56,13 +56,13 @@ because <X>. Treat this as unverified until that's resolved." Don't claim done.
 
 ```bash
 testsprite --version              # CLI installed?
-testsprite auth whoami            # credentials configured?
+testsprite auth status            # credentials configured?
 ```
 
 - `--version` fails → the CLI isn't installed. Tell the user to install the
   TestSprite CLI (see the TestSprite docs) and stop; don't install it for them.
-- `auth whoami` fails → no credentials. Tell the user they can run
-  `testsprite auth configure`, then stop.
+- `auth status` fails → no credentials. Tell the user they can run
+  `testsprite setup`, then stop.
 
 ## 2. Find the project
 

--- a/src/lib/agent-targets.test.ts
+++ b/src/lib/agent-targets.test.ts
@@ -448,6 +448,27 @@ describe('loadCodexSkillBody', () => {
 });
 
 // ---------------------------------------------------------------------------
+// content integrity — current auth command names
+// ---------------------------------------------------------------------------
+
+describe('content integrity — testsprite-verify auth commands', () => {
+  it('uses current auth/setup commands in every canonical verify skill asset', () => {
+    const assets = [
+      ['docs template', templateRaw],
+      ['own-file skill body', loadSkillBodyFor('testsprite-verify')],
+      ['codex skill body', codexContentFor('testsprite-verify')],
+    ] as const;
+
+    for (const [name, content] of assets) {
+      expect(content, name).toContain('testsprite auth status');
+      expect(content, name).toContain('testsprite setup');
+      expect(content, name).not.toContain('auth whoami');
+      expect(content, name).not.toContain('auth configure');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // MANAGED_SECTION sentinels
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Replaces accidentally closed PR #202.

Updates the canonical TestSprite verify skill assets to use the current auth/setup command names:

- `testsprite auth status` for preflight credential checks
- `testsprite setup` for missing-credential guidance

This avoids newly installed coding-agent skills teaching deprecated aliases (`auth whoami` / `auth configure`) and keeps the docs template, packaged generic skill, and Codex skill aligned.

## Related issue

Fixes #201

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

Previously validated on the original PR branch with:

- [x] `npm test -- src/lib/agent-targets.test.ts`
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `NO_COLOR= npm test`

## Notes for reviewers

Added content-integrity coverage across the docs template, own-file skill body, and Codex skill body to prevent deprecated auth aliases from returning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the verification steps to use the current credential check command and matching recovery guidance.
  * Clarified what to do when credentials are not set up so users can get back on track quickly.

* **Tests**
  * Added coverage to ensure the published guidance stays consistent across the main documentation sources.
  * Verified the updated command wording appears everywhere and the older wording no longer does.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->