### PR TITLE
fix(flaky): propagate auth trigger errors

### DIFF
--- a/src/commands/test.flaky.spec.ts
+++ b/src/commands/test.flaky.spec.ts
@@ -18,6 +18,7 @@ import { runFlaky } from './test.js';
 
 type FetchInput = Parameters<typeof globalThis.fetch>[0];
 type RunStatus = 'passed' | 'failed' | 'blocked' | 'cancelled';
+type TriggerAuthErrorCode = 'AUTH_REQUIRED' | 'AUTH_INVALID' | 'AUTH_FORBIDDEN';
 
 function urlOf(input: FetchInput): string {
   return typeof input === 'string'
@@ -46,6 +47,7 @@ function makeFlakyFetch(opts: {
   statuses: RunStatus[];
   testType?: 'frontend' | 'backend';
   notFoundOnTrigger?: boolean;
+  triggerAuthError?: TriggerAuthErrorCode;
 }): { fetchImpl: FetchImpl; triggerCount: () => number } {
   let triggers = 0;
   const testType = opts.testType ?? 'frontend';
@@ -67,6 +69,17 @@ function makeFlakyFetch(opts: {
     }
 
     if (method === 'POST' && url.includes('/runs/rerun')) {
+      if (opts.triggerAuthError) {
+        return jsonResponse(opts.triggerAuthError === 'AUTH_FORBIDDEN' ? 403 : 401, {
+          error: {
+            code: opts.triggerAuthError,
+            message: 'auth failed',
+            nextAction: 'run setup',
+            requestId: 'req_auth',
+            details: {},
+          },
+        });
+      }
       if (opts.notFoundOnTrigger) {
         return jsonResponse(404, {
           error: {
@@ -344,6 +357,35 @@ describe('runFlaky', () => {
     expect(err).toBeInstanceOf(ApiError);
     expect((err as ApiError).code).toBe('NOT_FOUND');
   });
+
+  it.each(['AUTH_REQUIRED', 'AUTH_INVALID', 'AUTH_FORBIDDEN'] as const)(
+    'propagates %s during trigger instead of scoring an error attempt',
+    async code => {
+      const { fetchImpl, triggerCount } = makeFlakyFetch({
+        statuses: [],
+        triggerAuthError: code,
+      });
+      const { deps, stdout } = makeDeps(fetchImpl);
+      const err = await runFlaky(
+        {
+          profile: 'default',
+          output: 'json',
+          dryRun: false,
+          debug: false,
+          verbose: false,
+          testId: 'test_x',
+          runs: 3,
+          untilFail: false,
+          timeoutSeconds: 600,
+        },
+        deps,
+      ).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(ApiError);
+      expect(err).toMatchObject({ code, exitCode: 3 });
+      expect(stdout).toEqual([]);
+      expect(triggerCount()).toBe(0);
+    },
+  );
 
   it('rejects --runs below the range (0) with a validation error (exit 5)', async () => {
     const { fetchImpl } = makeFlakyFetch({ statuses: [] });

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -8369,6 +8369,18 @@ const MAX_FLAKY_RUNS = 10;
 /** Default replay count when `--runs` is omitted. */
 const DEFAULT_FLAKY_RUNS = 5;
 
+function isFlakyFatalTriggerError(err: unknown): boolean {
+  if (!(err instanceof ApiError)) return false;
+  switch (err.code) {
+    case 'AUTH_REQUIRED':
+    case 'AUTH_INVALID':
+    case 'AUTH_FORBIDDEN':
+      return true;
+    default:
+      return false;
+  }
+}
+
 interface RunTestFlakyOptions extends CommonOptions {
   testId: string;
   /** Number of replays to run (1..MAX_FLAKY_RUNS). */
@@ -8466,6 +8478,9 @@ export async function runFlaky(
             details: { testId: opts.testId, reason: 'no_replayable_run' },
           },
         });
+      }
+      if (isFlakyFatalTriggerError(err)) {
+        throw err;
       }
       // Any other trigger error is recorded as an errored attempt so a single
       // transient blip doesn't abort a long stability probe.


### PR DESCRIPTION
## What does this PR do?

Replaces accidentally closed PR #200.

Updates `test flaky` so auth failures while triggering reruns are treated as fatal API errors instead of being recorded as ordinary flaky attempts.

Specifically, this propagates these trigger-time auth errors:

- `AUTH_REQUIRED`
- `AUTH_INVALID`
- `AUTH_FORBIDDEN`

That keeps the CLI from reporting an auth/environment failure as a flaky test signal.

## Related issue

Fixes #199

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

Previously validated on the original PR branch with:

- [x] `npm test -- src/commands/test.flaky.spec.ts`
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `NO_COLOR= npm test`

## Notes for reviewers

Focused change in `runFlaky`: auth-related rerun trigger errors are rethrown, while normal per-attempt flaky recording remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authentication failures when rerunning flaky tests.
  * Error responses now surface correctly for missing, invalid, or forbidden auth, with a clear exit code and no extra output.
  * Failed rerun attempts are no longer counted as successful trigger retries in these auth error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->