### PR TITLE
fix(dry-run): include failed run-scoped step sample

### DIFF
--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -3025,6 +3025,40 @@ describe('runSteps', () => {
     expect(block.match(/error: /g)).toHaveLength(1);
   });
 
+  it('--run-id dry-run sample maps the failed step error and failure contributor flag', async () => {
+    const out: string[] = [];
+    const page = await runSteps(
+      {
+        profile: 'default',
+        output: 'json',
+        debug: false,
+        dryRun: true,
+        testId: 'test_fe',
+        runId: 'run_dry',
+      },
+      {
+        env: {} as NodeJS.ProcessEnv,
+        credentialsPath: join(tmpdir(), 'testsprite-no-creds'),
+        stdout: line => out.push(line),
+        stderr: () => undefined,
+      },
+    );
+
+    const failing = page.items.find(step => step.stepIndex === 3);
+    expect(failing).toMatchObject({
+      status: 'failed',
+      error: expect.any(String),
+      stepType: 'assertion',
+      outcomeContributesToFailure: true,
+    });
+    expect(page.items.find(step => step.stepIndex === 1)?.outcomeContributesToFailure).toBe(false);
+
+    const printed = JSON.parse(out[0]!) as { items: Array<{ stepIndex: number; error?: string }> };
+    expect(printed.items.some(step => step.stepIndex === 3 && typeof step.error === 'string')).toBe(
+      true,
+    );
+  });
+
   it('--run-id: rejects a runId that belongs to a different test (exit 4)', async () => {
     const { credentialsPath } = makeCreds();
     // The run-scoped endpoint returns a run whose testId differs from the

--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -3025,7 +3025,7 @@ describe('runSteps', () => {
     expect(block.match(/error: /g)).toHaveLength(1);
   });
 
-  it('--run-id dry-run sample maps the failed step error and failure contributor flag', async () => {
+  it('--run-id run_failed_sample dry-run sample maps the failed step error and contributor flag', async () => {
     const out: string[] = [];
     const page = await runSteps(
       {
@@ -3034,7 +3034,7 @@ describe('runSteps', () => {
         debug: false,
         dryRun: true,
         testId: 'test_fe',
-        runId: 'run_dry',
+        runId: 'run_failed_sample',
       },
       {
         env: {} as NodeJS.ProcessEnv,

--- a/src/lib/dry-run/samples.test.ts
+++ b/src/lib/dry-run/samples.test.ts
@@ -424,8 +424,24 @@ describe('findSample', () => {
     expect(e).toBeUndefined();
   });
 
-  it('GET /runs/{runId} sample includes a failed run-scoped step', () => {
+  // defect-2 fix: getRun sample must return the passed shape (first-match-wins
+  // in findSample). Prior to fix, a duplicate failed-shape entry appeared
+  // before the passed-shape entry; `test wait --dry-run` always resolved to
+  // status: "failed", giving agents the wrong happy-path canned response.
+  it('GET /runs/{runId} resolves to the passed-shape getRun (not the failed shape)', () => {
     const e = findSample('GET', 'https://api.testsprite.com/api/cli/v1/runs/run_xyz');
+    expect(e?.operationId).toBe('getRun');
+    const body = e?.body() as {
+      status: string;
+      runId: string;
+      stepSummary: { failedCount: number };
+    };
+    expect(body.status).toBe('passed');
+    expect(body.stepSummary.failedCount).toBe(0);
+  });
+
+  it('GET /runs/run_failed_sample resolves to the sentinel failed run-scoped step sample', () => {
+    const e = findSample('GET', 'https://api.testsprite.com/api/cli/v1/runs/run_failed_sample');
     expect(e?.operationId).toBe('getRun');
     const body = e?.body() as {
       status: string;
@@ -441,6 +457,7 @@ describe('findSample', () => {
         error: string | null;
       }>;
     };
+    expect(body.runId).toBe('run_failed_sample');
     expect(body.status).toBe('failed');
     expect(body.failedStepIndex).toBe(3);
     expect(body.failureKind).toBe('assertion');

--- a/src/lib/dry-run/samples.test.ts
+++ b/src/lib/dry-run/samples.test.ts
@@ -595,13 +595,18 @@ describe('findSample', () => {
     expect(body.summary.total).toBeGreaterThanOrEqual(1);
   });
 
-  it('only one getRun entry exists in the registry (no duplicate)', () => {
-    // Guards against re-introducing the duplicate by ensuring exactly one
-    // sample is registered for GET /runs/{runId}.
-    const matches = DRY_RUN_SAMPLE_ENTRIES.filter(
-      e => e.method === 'GET' && e.operationId === 'getRun',
+  it('keeps the failed run sentinel before the generic getRun sample', () => {
+    // findSample is first-match-wins; exact run fixtures must precede
+    // `/runs/{runId}` so `test wait --dry-run` still gets the passed sample.
+    const failedRunIndex = DRY_RUN_SAMPLE_ENTRIES.findIndex(
+      e => e.method === 'GET' && e.pathTemplate === '/runs/run_failed_sample',
     );
-    expect(matches).toHaveLength(1);
+    const genericRunIndex = DRY_RUN_SAMPLE_ENTRIES.findIndex(
+      e => e.method === 'GET' && e.pathTemplate === '/runs/{runId}',
+    );
+    expect(failedRunIndex).toBeGreaterThanOrEqual(0);
+    expect(genericRunIndex).toBeGreaterThanOrEqual(0);
+    expect(failedRunIndex).toBeLessThan(genericRunIndex);
   });
 
   // Input-derived sample tests (Fix #1 — dogfood 2026-05-15)

--- a/src/lib/dry-run/samples.test.ts
+++ b/src/lib/dry-run/samples.test.ts
@@ -424,20 +424,41 @@ describe('findSample', () => {
     expect(e).toBeUndefined();
   });
 
-  // defect-2 fix: getRun sample must return the passed shape (first-match-wins
-  // in findSample). Prior to fix, a duplicate failed-shape entry appeared
-  // before the passed-shape entry; `test wait --dry-run` always resolved to
-  // status: "failed", giving agents the wrong happy-path canned response.
-  it('GET /runs/{runId} resolves to the passed-shape getRun (not the failed shape)', () => {
+  it('GET /runs/{runId} sample includes a failed run-scoped step', () => {
     const e = findSample('GET', 'https://api.testsprite.com/api/cli/v1/runs/run_xyz');
     expect(e?.operationId).toBe('getRun');
     const body = e?.body() as {
       status: string;
       runId: string;
-      stepSummary: { failedCount: number };
+      failedStepIndex: number | null;
+      failureKind: string | null;
+      error: string | null;
+      stepSummary: { total: number; completed: number; passedCount: number; failedCount: number };
+      steps: Array<{
+        stepIndex: string;
+        type: string;
+        status: string | null;
+        error: string | null;
+      }>;
     };
-    expect(body.status).toBe('passed');
-    expect(body.stepSummary.failedCount).toBe(0);
+    expect(body.status).toBe('failed');
+    expect(body.failedStepIndex).toBe(3);
+    expect(body.failureKind).toBe('assertion');
+    expect(body.error).toEqual(expect.any(String));
+    expect(body.stepSummary).toMatchObject({
+      total: 3,
+      completed: 3,
+      passedCount: 2,
+      failedCount: 1,
+    });
+
+    const failingStep = body.steps.find(step => step.stepIndex === '0003');
+    expect(failingStep).toMatchObject({
+      type: 'assertion',
+      status: 'failed',
+      error: expect.any(String),
+    });
+    expect(failingStep?.error).not.toBe('');
   });
 
   // DEV-331 piece 3: POST /runs/{runId}/cancel must resolve to `cancelRun`,

--- a/src/lib/dry-run/samples.test.ts
+++ b/src/lib/dry-run/samples.test.ts
@@ -595,17 +595,22 @@ describe('findSample', () => {
     expect(body.summary.total).toBeGreaterThanOrEqual(1);
   });
 
-  it('keeps the failed run sentinel before the generic getRun sample', () => {
+  it('keeps the failed run sentinel before generic getRun while retaining cancelRun', () => {
     // findSample is first-match-wins; exact run fixtures must precede
     // `/runs/{runId}` so `test wait --dry-run` still gets the passed sample.
+    // The adjacent POST cancel fixture was added on main after this branch forked.
     const failedRunIndex = DRY_RUN_SAMPLE_ENTRIES.findIndex(
       e => e.method === 'GET' && e.pathTemplate === '/runs/run_failed_sample',
     );
     const genericRunIndex = DRY_RUN_SAMPLE_ENTRIES.findIndex(
       e => e.method === 'GET' && e.pathTemplate === '/runs/{runId}',
     );
+    const cancelRunIndex = DRY_RUN_SAMPLE_ENTRIES.findIndex(
+      e => e.method === 'POST' && e.pathTemplate === '/runs/{runId}/cancel',
+    );
     expect(failedRunIndex).toBeGreaterThanOrEqual(0);
     expect(genericRunIndex).toBeGreaterThanOrEqual(0);
+    expect(cancelRunIndex).toBeGreaterThanOrEqual(0);
     expect(failedRunIndex).toBeLessThan(genericRunIndex);
   });
 

--- a/src/lib/dry-run/samples.ts
+++ b/src/lib/dry-run/samples.ts
@@ -369,9 +369,9 @@ const passedRunSample: RunResponse = {
   error: null,
   videoUrl: null,
   stepSummary: {
-    total: 8,
-    completed: 8,
-    passedCount: 8,
+    total: 2,
+    completed: 2,
+    passedCount: 2,
     failedCount: 0,
   },
   // Representative per-run steps so `test steps --run-id <id> --dry-run`
@@ -823,6 +823,7 @@ const ENTRIES: DryRunSampleEntry[] = [
   // fix(2026-05-21): a duplicate failed-shape entry that appeared before
   // this entry was removed; findSample first-match-wins was always
   // returning status: "failed" for `test wait --dry-run`.
+  entry('getRun', 'GET', `/runs/${SAMPLE_FAILED_RUN_ID}`, failedRunSample),
   entry('getRun', 'GET', '/runs/{runId}', passedRunSample),
   // DEV-331 piece 3 — POST /runs/{runId}/cancel. Method-guarded in
   // `findSample` (POST vs `getRun`'s GET), so this can't be shadowed by the
@@ -905,10 +906,7 @@ export function findSample(
   const pathOnly = extractPath(url);
   for (const e of ENTRIES) {
     if (e.method === upper && e.pattern.test(pathOnly)) {
-      const body =
-        e.operationId === 'getRun' && pathOnly === `/runs/${SAMPLE_FAILED_RUN_ID}`
-          ? failedRunSample
-          : e.body(requestBody);
+      const body = e.body(requestBody);
       // Rebind body so callers get the resolved value, not the factory.
       // We return a new object with `body` already applied so downstream
       // code can keep calling `e.body` as-before (no API break for tests

--- a/src/lib/dry-run/samples.ts
+++ b/src/lib/dry-run/samples.ts
@@ -702,17 +702,15 @@ const ENTRIES: DryRunSampleEntry[] = [
     },
   } satisfies BatchRerunResponse),
   // M3.3 piece-3 — GET /runs/{runId} (live status / long-poll).
-  // A terminal `passed` row is the most useful dry-run shape: agents see
-  // what a completed run looks like, and `--wait` terminates immediately.
-  // fix(2026-05-21): a duplicate failed-shape entry that appeared before
-  // this entry was removed; findSample first-match-wins was always
-  // returning status: "failed" for `test wait --dry-run`.
+  // Use a terminal failed row with a concrete failed step so
+  // `test steps --run-id <id> --dry-run` demonstrates the run-scoped
+  // error + failedStepIndex mapping without needing live credentials.
   entry('getRun', 'GET', '/runs/{runId}', {
     runId: SAMPLE_RUN_ID,
-    testId: SAMPLE_TEST_ID_PASSED,
+    testId: SAMPLE_TEST_ID_FAILED,
     projectId: SAMPLE_PROJECT_ID,
     userId: SAMPLE_USER_ID,
-    status: 'passed',
+    status: 'failed',
     source: 'cli',
     createdAt: '2026-05-15T19:32:00.000Z',
     startedAt: '2026-05-15T19:32:05.000Z',
@@ -720,19 +718,19 @@ const ENTRIES: DryRunSampleEntry[] = [
     codeVersion: 'v1',
     targetUrl: SAMPLE_TARGET_URL,
     createdFrom: null,
-    failedStepIndex: null,
-    failureKind: null,
-    error: null,
+    failedStepIndex: 3,
+    failureKind: 'assertion',
+    error: 'Expected billing status badge to be visible, but it was not found.',
     videoUrl: null,
     stepSummary: {
-      total: 8,
-      completed: 8,
-      passedCount: 8,
-      failedCount: 0,
+      total: 3,
+      completed: 3,
+      passedCount: 2,
+      failedCount: 1,
     },
     // Representative per-run steps so `test steps --run-id <id> --dry-run`
     // demonstrates real output instead of an empty list (the generic
-    // `/runs/{runId}` sample is also used by `test wait`, which ignores steps).
+    // `/runs/{runId}` sample is also safe for wait flows, which ignore steps).
     steps: [
       {
         stepIndex: '0001',
@@ -755,6 +753,17 @@ const ENTRIES: DryRunSampleEntry[] = [
         screenshotUrl: null,
         htmlSnapshotUrl: null,
         createdAt: '2026-05-15T19:32:20.000Z',
+      },
+      {
+        stepIndex: '0003',
+        type: 'assertion',
+        action: 'assert_visible',
+        status: 'failed',
+        description: 'Billing status badge is visible',
+        error: 'Expected billing status badge to be visible, but it was not found.',
+        screenshotUrl: null,
+        htmlSnapshotUrl: null,
+        createdAt: '2026-05-15T19:32:30.000Z',
       },
     ],
   } satisfies RunResponse),

--- a/src/lib/dry-run/samples.ts
+++ b/src/lib/dry-run/samples.ts
@@ -52,6 +52,10 @@ const SAMPLE_TEST_ID_FAILED = 'test_8f2a4d10';
 const SAMPLE_TEST_ID_PASSED = 'test_3a91bb02';
 const SAMPLE_TEST_ID_BLOCKED = 'test_blocked_4f7a';
 export const SAMPLE_RUN_ID = 'run_abc';
+// Documented sentinel for `test steps --run-id run_failed_sample --dry-run`:
+// keeps wait flows on the default passed sample while still demonstrating a
+// run-scoped failed step offline.
+const SAMPLE_FAILED_RUN_ID = 'run_failed_sample';
 // M3.4 rerun dry-run sample IDs
 const SAMPLE_RERUN_ID_BE_NAMED = 'run_rerun_be_named';
 const SAMPLE_RERUN_ID_BE_PRODUCER = 'run_rerun_be_producer';
@@ -345,6 +349,118 @@ const failureSummary: CliFailureSummary = {
   snapshotId: SAMPLE_SNAPSHOT_ID,
   rootCauseHypothesis: failureContext.failure.rootCauseHypothesis,
   recommendedFixTarget: failureContext.failure.recommendedFixTarget,
+};
+
+const passedRunSample: RunResponse = {
+  runId: SAMPLE_RUN_ID,
+  testId: SAMPLE_TEST_ID_PASSED,
+  projectId: SAMPLE_PROJECT_ID,
+  userId: SAMPLE_USER_ID,
+  status: 'passed',
+  source: 'cli',
+  createdAt: '2026-05-15T19:32:00.000Z',
+  startedAt: '2026-05-15T19:32:05.000Z',
+  finishedAt: '2026-05-15T19:34:00.000Z',
+  codeVersion: 'v1',
+  targetUrl: SAMPLE_TARGET_URL,
+  createdFrom: null,
+  failedStepIndex: null,
+  failureKind: null,
+  error: null,
+  videoUrl: null,
+  stepSummary: {
+    total: 8,
+    completed: 8,
+    passedCount: 8,
+    failedCount: 0,
+  },
+  // Representative per-run steps so `test steps --run-id <id> --dry-run`
+  // demonstrates real output instead of an empty list (the generic
+  // `/runs/{runId}` sample is also used by `test wait`, which ignores steps).
+  steps: [
+    {
+      stepIndex: '0001',
+      type: 'action',
+      action: 'navigate',
+      status: 'passed',
+      description: 'Open the target URL',
+      error: null,
+      screenshotUrl: null,
+      htmlSnapshotUrl: null,
+      createdAt: '2026-05-15T19:32:10.000Z',
+    },
+    {
+      stepIndex: '0002',
+      type: 'assertion',
+      action: 'assert_visible',
+      status: 'passed',
+      description: 'Dashboard heading is visible',
+      error: null,
+      screenshotUrl: null,
+      htmlSnapshotUrl: null,
+      createdAt: '2026-05-15T19:32:20.000Z',
+    },
+  ],
+};
+
+const failedRunSample: RunResponse = {
+  runId: SAMPLE_FAILED_RUN_ID,
+  testId: SAMPLE_TEST_ID_FAILED,
+  projectId: SAMPLE_PROJECT_ID,
+  userId: SAMPLE_USER_ID,
+  status: 'failed',
+  source: 'cli',
+  createdAt: '2026-05-15T19:32:00.000Z',
+  startedAt: '2026-05-15T19:32:05.000Z',
+  finishedAt: '2026-05-15T19:34:00.000Z',
+  codeVersion: 'v1',
+  targetUrl: SAMPLE_TARGET_URL,
+  createdFrom: null,
+  failedStepIndex: 3,
+  failureKind: 'assertion',
+  error: 'Expected billing status badge to be visible, but it was not found.',
+  videoUrl: null,
+  stepSummary: {
+    total: 3,
+    completed: 3,
+    passedCount: 2,
+    failedCount: 1,
+  },
+  steps: [
+    {
+      stepIndex: '0001',
+      type: 'action',
+      action: 'navigate',
+      status: 'passed',
+      description: 'Open the target URL',
+      error: null,
+      screenshotUrl: null,
+      htmlSnapshotUrl: null,
+      createdAt: '2026-05-15T19:32:10.000Z',
+    },
+    {
+      stepIndex: '0002',
+      type: 'assertion',
+      action: 'assert_visible',
+      status: 'passed',
+      description: 'Dashboard heading is visible',
+      error: null,
+      screenshotUrl: null,
+      htmlSnapshotUrl: null,
+      createdAt: '2026-05-15T19:32:20.000Z',
+    },
+    {
+      stepIndex: '0003',
+      type: 'assertion',
+      action: 'assert_visible',
+      status: 'failed',
+      description: 'Billing status badge is visible',
+      error: 'Expected billing status badge to be visible, but it was not found.',
+      screenshotUrl: null,
+      htmlSnapshotUrl: null,
+      createdAt: '2026-05-15T19:32:30.000Z',
+    },
+  ],
 };
 
 /**
@@ -702,71 +818,12 @@ const ENTRIES: DryRunSampleEntry[] = [
     },
   } satisfies BatchRerunResponse),
   // M3.3 piece-3 — GET /runs/{runId} (live status / long-poll).
-  // Use a terminal failed row with a concrete failed step so
-  // `test steps --run-id <id> --dry-run` demonstrates the run-scoped
-  // error + failedStepIndex mapping without needing live credentials.
-  entry('getRun', 'GET', '/runs/{runId}', {
-    runId: SAMPLE_RUN_ID,
-    testId: SAMPLE_TEST_ID_FAILED,
-    projectId: SAMPLE_PROJECT_ID,
-    userId: SAMPLE_USER_ID,
-    status: 'failed',
-    source: 'cli',
-    createdAt: '2026-05-15T19:32:00.000Z',
-    startedAt: '2026-05-15T19:32:05.000Z',
-    finishedAt: '2026-05-15T19:34:00.000Z',
-    codeVersion: 'v1',
-    targetUrl: SAMPLE_TARGET_URL,
-    createdFrom: null,
-    failedStepIndex: 3,
-    failureKind: 'assertion',
-    error: 'Expected billing status badge to be visible, but it was not found.',
-    videoUrl: null,
-    stepSummary: {
-      total: 3,
-      completed: 3,
-      passedCount: 2,
-      failedCount: 1,
-    },
-    // Representative per-run steps so `test steps --run-id <id> --dry-run`
-    // demonstrates real output instead of an empty list (the generic
-    // `/runs/{runId}` sample is also safe for wait flows, which ignore steps).
-    steps: [
-      {
-        stepIndex: '0001',
-        type: 'action',
-        action: 'navigate',
-        status: 'passed',
-        description: 'Open the target URL',
-        error: null,
-        screenshotUrl: null,
-        htmlSnapshotUrl: null,
-        createdAt: '2026-05-15T19:32:10.000Z',
-      },
-      {
-        stepIndex: '0002',
-        type: 'assertion',
-        action: 'assert_visible',
-        status: 'passed',
-        description: 'Dashboard heading is visible',
-        error: null,
-        screenshotUrl: null,
-        htmlSnapshotUrl: null,
-        createdAt: '2026-05-15T19:32:20.000Z',
-      },
-      {
-        stepIndex: '0003',
-        type: 'assertion',
-        action: 'assert_visible',
-        status: 'failed',
-        description: 'Billing status badge is visible',
-        error: 'Expected billing status badge to be visible, but it was not found.',
-        screenshotUrl: null,
-        htmlSnapshotUrl: null,
-        createdAt: '2026-05-15T19:32:30.000Z',
-      },
-    ],
-  } satisfies RunResponse),
+  // A terminal `passed` row is the most useful dry-run shape: agents see
+  // what a completed run looks like, and `--wait` terminates immediately.
+  // fix(2026-05-21): a duplicate failed-shape entry that appeared before
+  // this entry was removed; findSample first-match-wins was always
+  // returning status: "failed" for `test wait --dry-run`.
+  entry('getRun', 'GET', '/runs/{runId}', passedRunSample),
   // DEV-331 piece 3 — POST /runs/{runId}/cancel. Method-guarded in
   // `findSample` (POST vs `getRun`'s GET), so this can't be shadowed by the
   // broader `/runs/{runId}` pattern above despite sharing its path prefix.
@@ -848,11 +905,15 @@ export function findSample(
   const pathOnly = extractPath(url);
   for (const e of ENTRIES) {
     if (e.method === upper && e.pattern.test(pathOnly)) {
+      const body =
+        e.operationId === 'getRun' && pathOnly === `/runs/${SAMPLE_FAILED_RUN_ID}`
+          ? failedRunSample
+          : e.body(requestBody);
       // Rebind body so callers get the resolved value, not the factory.
       // We return a new object with `body` already applied so downstream
       // code can keep calling `e.body` as-before (no API break for tests
       // that call `findSample` directly).
-      return { ...e, body: () => e.body(requestBody) };
+      return { ...e, body: () => body };
     }
   }
   return undefined;

--- a/src/lib/dry-run/samples.ts
+++ b/src/lib/dry-run/samples.ts
@@ -906,12 +906,9 @@ export function findSample(
   const pathOnly = extractPath(url);
   for (const e of ENTRIES) {
     if (e.method === upper && e.pattern.test(pathOnly)) {
-      const body = e.body(requestBody);
-      // Rebind body so callers get the resolved value, not the factory.
-      // We return a new object with `body` already applied so downstream
-      // code can keep calling `e.body` as-before (no API break for tests
-      // that call `findSample` directly).
-      return { ...e, body: () => body };
+      // Rebind body so downstream code can call `e.body` as before while
+      // still preserving the original lazy factory semantics.
+      return { ...e, body: () => e.body(requestBody) };
     }
   }
   return undefined;


### PR DESCRIPTION
## What does this PR do?

Replaces accidentally closed PR #198.

Adds a dry-run path that demonstrates failed run-scoped step output without breaking the default `test wait --dry-run` happy path.

After reviewer feedback on the original PR, this uses a sentinel run id approach:

- default `GET /runs/{runId}` dry-run sample stays terminal `passed`
- `GET /runs/run_failed_sample` returns the failed run-scoped sample
- `test steps --run-id run_failed_sample --dry-run` demonstrates the failed step mapping offline

## Related issue

Fixes #197

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

Previously validated on the original PR branch with:

- [x] `npm test -- src/lib/dry-run/samples.test.ts src/commands/test.test.ts`
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `NO_COLOR= npm test`

## Notes for reviewers

This keeps wait flows on the default passed sample while still giving agents a documented failed run-scoped step sample for dry-run exploration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dry-run sample support for a failed run, including step-level failure details in the output.
* **Bug Fixes**
  * Improved dry-run run lookup to return the correct payload for the failed-run matching ID.
  * Ensured failed steps are consistently labeled (failed status, assertion type, and error text) and that sample selection follows first-match precedence.
* **Tests**
  * Added regression coverage for failed-run dry-runs and for dry-run sample resolution/selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->