### PR TITLE
test(test): guard status filter validation order

### DIFF
--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -464,6 +464,14 @@ describe('runList', () => {
     ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
   });
 
+  it('rejects --status=junk before reading credentials', async () => {
+    const test = createTestCommand();
+    disableExits(test);
+    await expect(
+      test.parseAsync(['list', '--project', 'project_alice', '--status', 'junk'], { from: 'user' }),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+  });
+
   it('rejects --page-size=0 locally with VALIDATION_ERROR (no network call)', async () => {
     const { credentialsPath } = makeCreds();
     const fetchImpl = makeFetch(() => {


### PR DESCRIPTION
## Summary
- Resubmission of #211 after the release-process hiccup closed it without merge.
- Add a focused `test list --status junk` regression test that runs without credentials.
- Pin the expected local `VALIDATION_ERROR` behavior so invalid status filters cannot regress into `AUTH_REQUIRED` if validation order changes.

## Changes
- Covers the `runList` command-parser path for `--status` validation before credentials/client setup.

## Verification
- `rtk vitest run src/commands/test.test.ts -t "rejects --status=junk before reading credentials"`
- `rtk npx eslint src/commands/test.test.ts --fix-dry-run --format stylish`
- `rtk npx eslint src/commands/test.test.ts`
- `rtk npm run typecheck`

Fixes #210


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation so invalid `--status` values are rejected immediately when listing tests, with a clear validation error.
  * Prevents unnecessary follow-up actions after an invalid command is entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->