### PR TITLE
fix(init): debug log whoami fallback

### DIFF
--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -231,6 +231,45 @@ describe('runInit — happy path (interactive)', () => {
     expect(agent.skills).toContain('testsprite-verify');
     expect(agent.skills).toContain('testsprite-onboard');
   });
+
+  it('debug mode reports a display-only whoami lookup failure without corrupting JSON stdout', async () => {
+    const { captured, deps } = makeCapture();
+    let callCount = 0;
+    const fetchMock = vi.fn(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(JSON.stringify(ME), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: 'AUTH_INVALID',
+            message: 'Invalid API key',
+            nextAction: 'Provide a valid key.',
+            requestId: 'r-whoami',
+          },
+        }),
+        { status: 401, headers: { 'content-type': 'application/json' } },
+      );
+    }) as unknown as InitDeps['fetchImpl'];
+
+    await runInit(
+      makeBaseOpts({ apiKey: 'sk-json-test', debug: true, noAgent: true, output: 'json' }),
+      {
+        ...deps,
+        fetchImpl: fetchMock,
+        credentialsPath,
+        isTTY: false,
+      },
+    );
+
+    const parsed = JSON.parse(captured.stdout.join('\n')) as Record<string, unknown>;
+    expect(parsed.status).toBe('initialized');
+    expect(captured.stderr.some(line => line.includes('setup identity lookup failed'))).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -291,9 +291,13 @@ export async function runInit(opts: InitOptions, deps: InitDeps = {}): Promise<v
   let me: MeResponse;
   try {
     me = await runWhoami(opts, whoamiDeps);
-  } catch {
+  } catch (err) {
     // Whoami is display-only. If it fails after a successful configure,
     // continue with a minimal placeholder so the summary still prints.
+    if (opts.debug) {
+      const reason = err instanceof Error ? err.message : String(err);
+      stderrFn(`[debug] setup identity lookup failed after configure: ${reason}`);
+    }
     me = { userId: '', keyId: '', scopes: [], env: 'production' };
   }
 


### PR DESCRIPTION
## Summary

Resubmission of #209 after the release-process hiccup closed it without merge.

Covers one `src/commands/init.ts` catch path from #186.

After `setup` successfully configures credentials, it runs a display-only `whoami` lookup to fill the final summary. If that lookup fails, setup intentionally continues with a placeholder summary. That behavior is fine, but the failure was completely silent, so `--debug` users could not tell why the summary fell back to no email / production / empty scopes.

This PR keeps default output and exit behavior unchanged, but emits a debug-only stderr line when the display-only identity lookup fails.

## Changes

- Capture the swallowed `runWhoami` error in `runInit`.
- Emit `[debug] setup identity lookup failed after configure: ...` only when `--debug` is set.
- Add a regression test that JSON stdout remains parseable while the debug line goes to stderr.

## Verification

- `rtk vitest run src/commands/init.test.ts -t "debug log whoami fallback|whoami fallback|debug"`
- `rtk npx eslint src/commands/init.ts src/commands/init.test.ts --fix-dry-run --format stylish`
- `rtk npx eslint src/commands/init.ts src/commands/init.test.ts`
- `rtk npm run typecheck`

Refs #186


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved init handling when identity lookup fails during setup, so the process still completes and prints a valid summary.
  * Added debug logging for lookup failures, while keeping JSON output clean and parseable.
  * Added coverage to verify the initialized status is still returned and debug messages appear only on stderr.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->