### PR TITLE
fix(bundle): preserve root output path

### DIFF
--- a/src/lib/bundle.test.ts
+++ b/src/lib/bundle.test.ts
@@ -601,6 +601,10 @@ describe('resolveBundleDir', () => {
     const out = resolveBundleDir('/tmp/x/');
     expect(out).toBe('/tmp/x');
   });
+
+  it('preserves the filesystem root path', () => {
+    expect(resolveBundleDir('/')).toBe('/');
+  });
 });
 
 describe('streamUrlToFile retry', () => {

--- a/src/lib/bundle.ts
+++ b/src/lib/bundle.ts
@@ -325,7 +325,7 @@ export function resolveBundleDir(rawPath: string): string {
       },
     });
   }
-  const trimmed = rawPath.endsWith('/') ? rawPath.slice(0, -1) : rawPath;
+  const trimmed = rawPath.endsWith('/') && rawPath.length > 1 ? rawPath.slice(0, -1) : rawPath;
   return isAbsolute(trimmed) ? trimmed : resolve(process.cwd(), trimmed);
 }
 


### PR DESCRIPTION
## Summary

Resubmission of #205 after the release-process hiccup closed it without merge.

`resolveBundleDir('/')` currently strips the trailing slash before checking whether the path is absolute. For the filesystem root path, that turns `/` into an empty string, so the helper resolves it against `process.cwd()` instead of preserving `/`.

This PR keeps the root path intact while preserving the existing behavior for ordinary trailing slashes like `/tmp/bundle/`.

## Changes

- Only strip a trailing slash when the raw path has more than one character.
- Add regression coverage that `resolveBundleDir('/')` returns `/`.

## Verification

- `rtk vitest run src/lib/bundle.test.ts -t "root|resolveBundleDir"`
- `rtk npx eslint src/lib/bundle.ts src/lib/bundle.test.ts --fix-dry-run --format stylish`
- `rtk npx eslint src/lib/bundle.ts src/lib/bundle.test.ts`
- `rtk npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the filesystem root path when cleaning up output directories, so `/` is no longer reduced to an empty value.
  * Improved handling of paths with trailing slashes, keeping valid root paths intact while still normalizing other paths.
  * Added coverage for the root-path case to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->