### PR TITLE
fix(config): normalize empty/whitespace TESTSPRITE_PROFILE to unset

### DIFF
--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -55,6 +55,23 @@ describe('loadConfig', () => {
     ).toBe('option-profile');
   });
 
+  it('treats empty TESTSPRITE_PROFILE as unset (falls back to default)', () => {
+    expect(loadConfig({ env: { TESTSPRITE_PROFILE: '' }, credentialsPath }).profile).toBe(
+      'default',
+    );
+  });
+
+  it('treats whitespace-only TESTSPRITE_PROFILE as unset (falls back to default)', () => {
+    const config = loadConfig({ env: { TESTSPRITE_PROFILE: '   ' }, credentialsPath });
+    expect(config.profile).toBe('default');
+  });
+
+  it('reads credentials from the default profile when TESTSPRITE_PROFILE is blank', () => {
+    writeProfile('default', { apiKey: 'sk-default' }, { path: credentialsPath });
+    const config = loadConfig({ env: { TESTSPRITE_PROFILE: '  ' }, credentialsPath });
+    expect(config.apiKey).toBe('sk-default');
+  });
+
   it('option.endpointUrl overrides everything', () => {
     writeProfile('default', { apiUrl: 'https://file' }, { path: credentialsPath });
     const config = loadConfig({

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -39,13 +39,17 @@ export function defaultConfigPath(): string {
  */
 export function loadConfig(options: LoadConfigOptions = {}): Config {
   const env = options.env ?? process.env;
-  const profile = options.profile ?? env.TESTSPRITE_PROFILE ?? DEFAULT_PROFILE;
+  const profile = options.profile ?? normalizeEnvVar(env.TESTSPRITE_PROFILE) ?? DEFAULT_PROFILE;
   const credentialsPath = options.credentialsPath ?? defaultCredentialsPath();
   const fileEntry = readProfile(profile, { path: credentialsPath });
 
   // Empty / whitespace-only env vars are treated as unset so they do not
-  // short-circuit the `??` chain (e.g. `export TESTSPRITE_API_URL=` in a shell
-  // profile). Matches the normalization in auth configure and init/setup.
+  // short-circuit the `??` chain (e.g. `export TESTSPRITE_API_URL=` or
+  // `export TESTSPRITE_PROFILE=` in a shell profile). For the profile this
+  // also avoids a confusing VALIDATION_ERROR: an empty name fails the INI
+  // section-name guard, so without normalization a blank env var would break
+  // every command instead of falling back to the default profile. Matches the
+  // normalization in auth configure and init/setup.
   const envApiUrl = normalizeEnvVar(env.TESTSPRITE_API_URL);
   const envApiKey = normalizeEnvVar(env.TESTSPRITE_API_KEY);
 


### PR DESCRIPTION
One-line fix: wraps env.TESTSPRITE_PROFILE with normalizeEnvVar() so an
empty/whitespace-only value is treated as unset and resolves to the "default"
profile — consistent with TESTSPRITE_API_URL and TESTSPRITE_API_KEY.

3 new unit tests added (empty, whitespace-only, blank-with-credentials).
eslint + prettier + tsc all clean locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading when the profile environment setting is empty or contains only whitespace.
  * Automatically falls back to the default profile in these cases, including its configured credentials.

* **Tests**
  * Added coverage for empty, whitespace-only, and default profile configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->