### PR TITLE
Recovered: fix(doctor): validate --output through the shared output-mode validator (#213 by @Yazan-O)

### DIFF
--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -9,8 +9,9 @@
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Command } from 'commander';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { CLIError } from '../lib/errors.js';
+import { ApiError, CLIError } from '../lib/errors.js';
 import { writeProfile } from '../lib/credentials.js';
 import type { DoctorDeps, DoctorReport } from './doctor.js';
 import { createDoctorCommand, runDoctor } from './doctor.js';
@@ -54,6 +55,14 @@ function healthyDeps(credentialsPath: string, extra: Partial<DoctorDeps> = {}): 
     fetchImpl: makeFetch(OK_ME),
     ...extra,
   };
+}
+
+function makeDoctorProgram(deps: DoctorDeps = {}): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.option('--output <mode>', 'output', 'text');
+  program.addCommand(createDoctorCommand(deps));
+  return program;
 }
 
 let credentialsPath: string;
@@ -225,5 +234,37 @@ describe('createDoctorCommand wiring', () => {
 
   it('--help describes the diagnostic', () => {
     expect(createDoctorCommand().helpInformation()).toContain('Diagnose');
+  });
+
+  it('rejects invalid --output with the shared VALIDATION_ERROR', async () => {
+    const rejection = await makeDoctorProgram()
+      .parseAsync(['node', 'ts', '--output', 'yaml', 'doctor'])
+      .catch((error: unknown) => error);
+    expect(rejection).toBeInstanceOf(ApiError);
+    expect(rejection).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      exitCode: 5,
+      nextAction: 'Flag `--output` is invalid: must be one of: json, text.',
+    });
+  });
+
+  it('accepts valid --output modes through command wiring', async () => {
+    writeProfile('default', { apiKey: 'sk-abc' }, { path: credentialsPath });
+    for (const mode of ['text', 'json'] as const) {
+      const { capture, deps } = makeCapture();
+      await makeDoctorProgram({ ...healthyDeps(credentialsPath), ...deps }).parseAsync([
+        'node',
+        'ts',
+        '--output',
+        mode,
+        'doctor',
+      ]);
+      const raw = capture.stdout.join('');
+      if (mode === 'json') {
+        expect((JSON.parse(raw) as DoctorReport).failures).toBe(0);
+      } else {
+        expect(raw).toContain('All checks passed.');
+      }
+    }
   });
 });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -24,7 +24,7 @@ import {
 import { loadConfig } from '../lib/config.js';
 import { ApiError, CLIError, localValidationError } from '../lib/errors.js';
 import type { FetchImpl } from '../lib/http.js';
-import { GLOBAL_OPTS_HINT, Output, type OutputMode } from '../lib/output.js';
+import { GLOBAL_OPTS_HINT, Output, resolveOutputMode, type OutputMode } from '../lib/output.js';
 import { isVerifySkillInstalled } from '../lib/skill-nudge.js';
 import { VERSION } from '../version.js';
 import { MIN_SUPPORTED_NODE_MAJOR, shouldRejectNodeVersion } from '../version-guard.js';
@@ -257,7 +257,7 @@ function resolveCommonOptions(command: Command): CommonOptions {
   };
   return {
     profile: globals.profile ?? 'default',
-    output: globals.output ?? 'text',
+    output: resolveOutputMode(globals.output),
     endpointUrl: globals.endpointUrl,
     debug: globals.debug ?? false,
     verbose: globals.verbose ?? false,


### PR DESCRIPTION
## Summary

`doctor` resolved the global `--output` flag directly (`globals.output ?? 'text'`), bypassing the shared validator every other command uses — so an invalid mode (e.g. `--output yaml`) silently fell through instead of producing the standard typed `VALIDATION_ERROR`.

This routes doctor's option resolution through `resolveOutputMode` and adds command-wiring coverage: invalid `--output` now yields the standard `VALIDATION_ERROR`; `text` and `json` still work.

4 lines of src change + tests.

## Tests

- `vitest run src/commands/doctor.test.ts` — 14/14 pass
- `npm run lint:fix`, `npm run typecheck`, `npm run build` — pass
- Full `npm test` on this Windows host is blocked by the POSIX path/mode assumptions fixed in #207 — the two PRs compose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the doctor command’s output format so invalid values are rejected with a clear validation error.
  * Ensured valid output modes continue to work correctly, including both text and JSON results.

* **Tests**
  * Added coverage for command parsing and output-mode validation.
  * Verified successful report output in both text and JSON formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->