### PR TITLE
fix(ci): migrate github-script to v8 — repair the broken gate check

### DIFF
--- a/.github/workflows/ci-nudge.yml
+++ b/.github/workflows/ci-nudge.yml
@@ -55,7 +55,7 @@ jobs:
           # back to github-actions[bot], defeating this bot's own purpose.
           permission-issues: write
 
-      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
@@ -65,7 +65,7 @@ jobs:
             const marker = process.env.MARKER;
 
             const appClient = process.env.APP_TOKEN
-              ? require('@actions/github').getOctokit(process.env.APP_TOKEN)
+              ? new (github.constructor)({ auth: process.env.APP_TOKEN })
               : null;
             async function write(fn) {
               if (appClient) {

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -57,7 +57,7 @@ jobs:
           # of inheriting the App's full installation permissions.
           permission-issues: write
 
-      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           # App token when available (→ testsprite-hob[bot]); else the default
           # GITHUB_TOKEN (→ github-actions[bot]). Either way the logic is identical.

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -71,7 +71,7 @@ jobs:
           # fallback path (unused by this specific App-token mint).
           permission-issues: write
 
-      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
@@ -86,7 +86,7 @@ jobs:
             const author = pr.user.login;
 
             const appClient = process.env.APP_TOKEN
-              ? require('@actions/github').getOctokit(process.env.APP_TOKEN)
+              ? new (github.constructor)({ auth: process.env.APP_TOKEN })
               : null;
             // Prefer the App identity; fall back to github-actions[bot] when the
             // App is absent or lacks the Pull-requests permission (403/404).

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,7 +26,7 @@ jobs:
       issues: write # comment + (un)label + close stale issues
       pull-requests: write # comment + (un)label + close stale PRs
     steps:
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           # ── issues ──────────────────────────────────────────────────────
           days-before-issue-stale: 60


### PR DESCRIPTION
## Why

The `gate` check (and the ci-nudge/issue-triage bots) is mechanically red on every recent PR: GitHub's runner infra now force-runs `actions/github-script@v7` on Node 24, where the script-side `require('@actions/github')` can't resolve — the failure has nothing to do with whether a PR links an issue. Sorry for the confusing red ✗ everyone has been seeing.

## What

- Pin `actions/github-script` to `ed597411… # v8.0.0` in pr-triage / ci-nudge / issue-triage.
- Replace `require('@actions/github').getOctokit(APP_TOKEN)` with `new (github.constructor)({ auth: APP_TOKEN })`. v8.0.0 injects no `getOctokit` script parameter (verified against `src/async-function.ts` at the pinned SHA), so a require-free construction from the injected client's own class is the safe route.
- Bump `actions/stale` to `1e223db… # v10.4.0`.

Diagnosis credit: @sandman-sh first surfaced the Node-24/v8 root cause in #257. 🙏

Note for contributors: existing PRs will show a green `gate` after their next push or re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub automation actions to newer versions for improved compatibility and maintenance.
  * Preserved existing CI failure notifications, issue and pull request triage, and stale-item handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->