### PR TITLE
fix(completion): cross-platform shell auto-detection for Windows paths and .exe extensions

### DIFF
--- a/src/commands/completion.test.ts
+++ b/src/commands/completion.test.ts
@@ -23,8 +23,16 @@ describe('isShell / detectShell', () => {
     expect(detectShell({ SHELL: '/usr/local/bin/fish' })).toBe('fish');
   });
 
+  it('detects shells with Windows backslashes, .exe suffixes, and uppercase paths', () => {
+    expect(detectShell({ SHELL: 'C:\\Program Files\\Git\\bin\\bash.exe' })).toBe('bash');
+    expect(detectShell({ SHELL: 'C:\\tools\\zsh.exe' })).toBe('zsh');
+    expect(detectShell({ SHELL: '/usr/bin/FISH.EXE' })).toBe('fish');
+    expect(detectShell({ SHELL: 'C:/Program Files\\Git\\bin/bash.exe' })).toBe('bash');
+  });
+
   it('returns undefined for an unknown or missing shell', () => {
     expect(detectShell({ SHELL: '/bin/sh' })).toBeUndefined();
+    expect(detectShell({ SHELL: 'C:\\Windows\\System32\\cmd.exe' })).toBeUndefined();
     expect(detectShell({})).toBeUndefined();
   });
 });

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -42,7 +42,8 @@ export function isShell(value: string): value is Shell {
 /** Best-effort shell detection from `$SHELL` (e.g. "/bin/zsh" -> "zsh"). */
 export function detectShell(env: NodeJS.ProcessEnv): Shell | undefined {
   const shellPath = env.SHELL ?? '';
-  const base = shellPath.slice(shellPath.lastIndexOf('/') + 1);
+  const rawBase = shellPath.split(/[/\\]/).pop() ?? '';
+  const base = rawBase.toLowerCase().replace(/\.exe$/, '');
   return isShell(base) ? base : undefined;
 }
 


### PR DESCRIPTION
Closes #275

## Summary

Fixes shell auto-detection in `testsprite completion` when invoked without an explicit shell argument.

### Problem
Currently, `detectShell(env)` in `src/commands/completion.ts` uses `shellPath.slice(shellPath.lastIndexOf('/') + 1)`.
On Windows or cross-platform environments using Git Bash / MSYS2 / WSL:
1. `$SHELL` uses backslashes (e.g. `C:\Program Files\Git\bin\bash.exe`). `lastIndexOf('/')` returns `-1`, resulting in the full path string `C:\Program Files\Git\bin\bash.exe` which fails `isShell()`.
2. `$SHELL` filenames end in `.exe` (e.g. `bash.exe`, `zsh.exe`, `fish.exe`), causing `isShell("bash.exe")` to return `false`.

### Solution
Enhances `detectShell(env)` to:
- Split on both forward `/` and backward `\` slashes (`/[/\\]/`).
- Lowercase and strip trailing `.exe` extensions (`.toLowerCase().replace(/\.exe$/, '')`).
- Match against `isShell()` (`bash`, `zsh`, `fish`).

### Test Coverage
Updated `src/commands/completion.test.ts` with unit tests for Windows paths, `.exe` suffixes, mixed slashes, and uppercase names. All 2,002 tests pass.