### PR TITLE
fix(browser): catch malformed URL TypeError and map to exit 5 VALIDATION_ERROR

### DIFF
--- a/src/lib/browser.test.ts
+++ b/src/lib/browser.test.ts
@@ -54,9 +54,16 @@ describe('openInBrowser', () => {
     expect(exec).not.toHaveBeenCalled();
   });
 
-  it('throws on a malformed URL', () => {
+  it('refuses a malformed URL with exit 5 before spawning', () => {
     const exec = vi.fn();
-    expect(() => openInBrowser('not a url', { exec })).toThrow();
+    let error: unknown;
+    try {
+      openInBrowser('not a url', { exec });
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).exitCode).toBe(5);
     expect(exec).not.toHaveBeenCalled();
   });
 

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -23,7 +23,12 @@ export interface OpenInBrowserDeps {
 }
 
 export function openInBrowser(url: string, deps: OpenInBrowserDeps = {}): void {
-  const parsed = new URL(url);
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw localValidationError('url', 'must be a valid http(s) URL', undefined, 'field');
+  }
   if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
     // User-input error, not an internal failure: classify as VALIDATION_ERROR
     // so it maps to exit 5 (like every other bad-argument path), not exit 1.


### PR DESCRIPTION
Closes #276

## Summary

Fixes un-guarded `new URL(url)` call in `openInBrowser` ([src/lib/browser.ts](file:///e:/project/testsprite%20cli/src/lib/browser.ts)) so malformed URLs return a clean CLI `VALIDATION_ERROR` (exit code 5) instead of crashing with an unhandled Node.js `TypeError`.

### Problem
When `openInBrowser(url)` receives a malformed or unparseable URL string (e.g. `"not a url"`), `new URL(url)` throws a raw Node.js `TypeError: Invalid URL`.
Because this call was not wrapped in a `try/catch` block:
- The process crashed with an unhandled exception (**exit code 1**) and printed a raw V8 stack trace.
- Non-HTTP schemes like `file://` already threw `VALIDATION_ERROR` (exit 5), creating an inconsistent error contract for bad inputs.

### Solution
Wrap `new URL(url)` in a `try/catch` block in `openInBrowser`:
```typescript
try {
  parsed = new URL(url);
} catch {
  throw localValidationError('url', 'must be a valid http(s) URL', undefined, 'field');
}
```

### Test Coverage
Updated [src/lib/browser.test.ts](file:///e:/project/testsprite%20cli/src/lib/browser.test.ts) to assert that malformed URL inputs throw `ApiError` with `exitCode = 5`. All unit tests pass.