### PR TITLE
feat(output): add csv and ndjson output modes for list commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@testsprite/testsprite-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@testsprite/testsprite-cli",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.1.0",

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -289,7 +289,7 @@ describe('createDoctorCommand wiring', () => {
     expect(rejection).toMatchObject({
       code: 'VALIDATION_ERROR',
       exitCode: 5,
-      nextAction: 'Flag `--output` is invalid: must be one of: json, text.',
+      nextAction: 'Flag `--output` is invalid: must be one of: json, text, csv, ndjson.',
     });
   });
 

--- a/src/commands/project.test.ts
+++ b/src/commands/project.test.ts
@@ -1423,3 +1423,171 @@ describe('dogfood 2026-06-30 — whitespace-only --name is rejected (parity with
     ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
   });
 });
+
+// ---------------------------------------------------------------------------
+// issue #164 — `project list --output csv|ndjson`
+// ---------------------------------------------------------------------------
+
+describe('project list --output csv', () => {
+  it('renders an RFC 4180 header + one row per project, quoting fields with commas/quotes/newlines', async () => {
+    const { credentialsPath } = makeCreds();
+    const quirky: CliProject = {
+      ...PROJECT_FIXTURE,
+      id: 'project_quirky',
+      name: 'Say "hi", then\nnewline',
+    };
+    const fetchImpl = makeFetch(() => ({
+      body: { items: [PROJECT_FIXTURE, quirky], nextToken: null },
+    }));
+
+    const out: string[] = [];
+    const err: string[] = [];
+    await runList(
+      { profile: 'default', output: 'csv', debug: false },
+      { credentialsPath, fetchImpl, stdout: line => out.push(line), stderr: line => err.push(line) },
+    );
+
+    expect(out).toHaveLength(1);
+    const lines = out[0]!.split('\r\n');
+    expect(lines[0]).toBe('id,name,type,createdFrom,createdAt,updatedAt');
+    expect(lines[1]).toBe(
+      `${PROJECT_FIXTURE.id},${PROJECT_FIXTURE.name},${PROJECT_FIXTURE.type},${PROJECT_FIXTURE.createdFrom},${PROJECT_FIXTURE.createdAt},${PROJECT_FIXTURE.updatedAt}`,
+    );
+    // Embedded comma, double quote, and (raw) newline all force RFC 4180
+    // quoting; the embedded `"` is doubled per §2 rule 7. The record is one
+    // CSV row even though it contains a literal `\n` — only `\r\n` is a row
+    // separator, so `.split('\r\n')` does not break it apart.
+    expect(lines).toHaveLength(3);
+    expect(lines[2]).toBe(
+      'project_quirky,"Say ""hi"", then\nnewline",frontend,portal,2026-04-15T10:23:00.000Z,2026-05-05T08:12:00.000Z',
+    );
+    expect(err).toEqual([]);
+  });
+
+  it('emits the header row only (no data rows) for an empty page', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = makeFetch(() => ({ body: { items: [], nextToken: null } }));
+
+    const out: string[] = [];
+    await runList(
+      { profile: 'default', output: 'csv', debug: false },
+      { credentialsPath, fetchImpl, stdout: line => out.push(line) },
+    );
+
+    expect(out).toEqual(['id,name,type,createdFrom,createdAt,updatedAt']);
+  });
+
+  it('routes the pagination cursor to stderr, keeping stdout pure CSV', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = makeFetch(() => ({
+      body: { items: [PROJECT_FIXTURE], nextToken: 'opaque-cursor-1' },
+    }));
+
+    const out: string[] = [];
+    const err: string[] = [];
+    await runList(
+      { profile: 'default', output: 'csv', debug: false, pageSize: 1 },
+      { credentialsPath, fetchImpl, stdout: line => out.push(line), stderr: line => err.push(line) },
+    );
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).not.toContain('nextToken');
+    expect(err).toEqual(['nextToken: opaque-cursor-1']);
+  });
+});
+
+describe('project list --output ndjson', () => {
+  it('emits one compact JSON object per line, no wrapping array', async () => {
+    const { credentialsPath } = makeCreds();
+    const second = { ...PROJECT_FIXTURE, id: 'project_2' };
+    const fetchImpl = makeFetch(() => ({ body: { items: [PROJECT_FIXTURE, second], nextToken: null } }));
+
+    const out: string[] = [];
+    await runList(
+      { profile: 'default', output: 'ndjson', debug: false },
+      { credentialsPath, fetchImpl, stdout: line => out.push(line) },
+    );
+
+    expect(out).toHaveLength(1);
+    const lines = out[0]!.split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!)).toEqual(PROJECT_FIXTURE);
+    expect(JSON.parse(lines[1]!)).toEqual(second);
+    // Compact — no pretty-printed indentation.
+    expect(lines[0]).not.toContain('\n  ');
+  });
+
+  it('writes nothing to stdout for an empty page (no stray blank line)', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = makeFetch(() => ({ body: { items: [], nextToken: null } }));
+
+    const out: string[] = [];
+    await runList(
+      { profile: 'default', output: 'ndjson', debug: false },
+      { credentialsPath, fetchImpl, stdout: line => out.push(line) },
+    );
+
+    expect(out).toEqual([]);
+  });
+
+  it('routes the pagination cursor to stderr as JSON, keeping stdout pure NDJSON', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = makeFetch(() => ({
+      body: { items: [PROJECT_FIXTURE], nextToken: 'opaque-cursor-1' },
+    }));
+
+    const out: string[] = [];
+    const err: string[] = [];
+    await runList(
+      { profile: 'default', output: 'ndjson', debug: false, pageSize: 1 },
+      { credentialsPath, fetchImpl, stdout: line => out.push(line), stderr: line => err.push(line) },
+    );
+
+    expect(out).toHaveLength(1);
+    expect(err).toEqual([JSON.stringify({ nextToken: 'opaque-cursor-1' })]);
+  });
+});
+
+describe('issue #164 — single-object commands reject --output csv|ndjson', () => {
+  it('runGet exits 5 (VALIDATION_ERROR) for --output csv', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = makeFetch(() => ({ body: PROJECT_FIXTURE }));
+
+    await expect(
+      runGet(
+        { profile: 'default', output: 'csv', debug: false, projectId: 'p1' },
+        { credentialsPath, fetchImpl, stdout: () => {} },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
+  });
+
+  it('runGet exits 5 (VALIDATION_ERROR) for --output ndjson', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = makeFetch(() => ({ body: PROJECT_FIXTURE }));
+
+    await expect(
+      runGet(
+        { profile: 'default', output: 'ndjson', debug: false, projectId: 'p1' },
+        { credentialsPath, fetchImpl, stdout: () => {} },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
+  });
+
+  it('runCreate exits 5 (VALIDATION_ERROR) for --output csv', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = makeFetch(() => ({ body: PROJECT_FIXTURE }));
+
+    await expect(
+      runCreate(
+        {
+          profile: 'default',
+          output: 'csv',
+          debug: false,
+          type: 'backend',
+          name: 'Checkout',
+        },
+        { credentialsPath, fetchImpl, stdout: () => {}, stderr: () => {} },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
+  });
+});

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -10,7 +10,13 @@ import {
 import { ApiError } from '../lib/errors.js';
 import type { FetchImpl } from '../lib/http.js';
 import type { HttpClient } from '../lib/http.js';
-import { GLOBAL_OPTS_HINT, Output, resolveOutputMode, type OutputMode } from '../lib/output.js';
+import {
+  GLOBAL_OPTS_HINT,
+  Output,
+  resolveOutputMode,
+  type ListColumn,
+  type OutputMode,
+} from '../lib/output.js';
 import { assertNotLocal } from '../lib/target-url.js';
 import { renderTextTable, resolveTextColumns, type TextTableColumn } from '../lib/text-table.js';
 import { assertIdempotencyKey } from '../lib/validate.js';
@@ -86,6 +92,27 @@ export async function runList(
         }),
       paginationFlags,
     );
+  }
+
+  // csv/ndjson: routed here (before `out.print`, which rejects both modes
+  // for every non-list command) so the row data goes to stdout and the
+  // pagination cursor goes to stderr — keeping stdout a pure, parseable
+  // table/stream per M-hackathon-164.
+  if (opts.output === 'csv' || opts.output === 'ndjson') {
+    const stderr = deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
+    if (opts.output === 'csv') {
+      out.printCsv(page.items, PROJECT_CSV_COLUMNS);
+    } else {
+      out.printNdjson(page.items);
+    }
+    if (page.nextToken) {
+      stderr(
+        opts.output === 'csv'
+          ? `nextToken: ${page.nextToken}`
+          : JSON.stringify({ nextToken: page.nextToken }),
+      );
+    }
+    return page;
   }
 
   out.print(page, data => {
@@ -1027,6 +1054,20 @@ const PROJECT_LIST_COLUMNS: ReadonlyArray<TextTableColumn<CliProject>> = [
   { header: 'TYPE', width: 8, render: project => project.type },
   { header: 'FROM', width: 6, render: project => project.createdFrom },
   { header: 'CREATED', width: 0, render: project => project.createdAt },
+];
+
+/**
+ * `--output csv`/`--output ndjson` columns for `project list`, derived
+ * straight from the `CliProject` source-of-truth shape (not the
+ * possibly-reordered/subset `PROJECT_LIST_COLUMNS` used for `--output text`).
+ */
+const PROJECT_CSV_COLUMNS: ReadonlyArray<ListColumn<CliProject>> = [
+  { header: 'id', value: p => p.id },
+  { header: 'name', value: p => p.name },
+  { header: 'type', value: p => p.type },
+  { header: 'createdFrom', value: p => p.createdFrom },
+  { header: 'createdAt', value: p => p.createdAt },
+  { header: 'updatedAt', value: p => p.updatedAt },
 ];
 
 function renderProjectListText(

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -54,7 +54,13 @@ import {
 import { REQUEST_TIMEOUT_DEFAULT_MS, REQUEST_TIMEOUT_MAX_MS } from '../lib/http.js';
 import type { FetchImpl } from '../lib/http.js';
 import type { HttpClient } from '../lib/http.js';
-import { GLOBAL_OPTS_HINT, Output, resolveOutputMode, type OutputMode } from '../lib/output.js';
+import {
+  GLOBAL_OPTS_HINT,
+  Output,
+  resolveOutputMode,
+  type ListColumn,
+  type OutputMode,
+} from '../lib/output.js';
 import {
   fetchSinglePage,
   paginate,
@@ -602,6 +608,26 @@ export async function runList(opts: ListOptions, deps: TestDeps = {}): Promise<P
         }),
       paginationFlags,
     );
+  }
+
+  // csv/ndjson: handled before `out.print` (which rejects both modes for
+  // every non-list command) — row data to stdout, pagination cursor to
+  // stderr so stdout stays a pure, parseable table/stream (M-hackathon-164).
+  if (opts.output === 'csv' || opts.output === 'ndjson') {
+    const stderr = deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
+    if (opts.output === 'csv') {
+      out.printCsv(page.items, TEST_CSV_COLUMNS);
+    } else {
+      out.printNdjson(page.items);
+    }
+    if (page.nextToken) {
+      stderr(
+        opts.output === 'csv'
+          ? `nextToken: ${page.nextToken}`
+          : JSON.stringify({ nextToken: page.nextToken }),
+      );
+    }
+    return page;
   }
 
   out.print(page, data =>
@@ -4620,8 +4646,31 @@ export async function runResultHistory(
     since: sinceIso,
   });
 
-  if (opts.output !== 'text') {
+  if (opts.output === 'json') {
     out.print({ runs: resp.runs, nextCursor: resp.nextCursor }, data => JSON.stringify(data));
+    return resp;
+  }
+
+  // csv/ndjson: handled before `out.print` (which rejects both modes for
+  // every non-list command) — run rows go to stdout, `nextCursor` and the
+  // `meta` block go to stderr so stdout stays a pure, parseable table/stream
+  // (M-hackathon-164).
+  if (opts.output === 'csv' || opts.output === 'ndjson') {
+    const stderr = deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
+    if (opts.output === 'csv') {
+      out.printCsv(resp.runs, RUN_HISTORY_CSV_COLUMNS);
+    } else {
+      out.printNdjson(resp.runs);
+    }
+    if (resp.nextCursor !== null) {
+      stderr(
+        opts.output === 'csv'
+          ? `nextCursor: ${resp.nextCursor}`
+          : JSON.stringify({ nextCursor: resp.nextCursor }),
+      );
+    }
+    if (resp.meta.note) stderr(`note: ${resp.meta.note}`);
+    if (resp.meta.portalUrl) stderr(`portal: ${resp.meta.portalUrl}`);
     return resp;
   }
 
@@ -4695,6 +4744,27 @@ const RUN_HISTORY_TABLE_COLUMNS: ReadonlyArray<TextTableColumn<RunHistoryItem>> 
     width: 0,
     render: run => formatDurationMs(run.startedAt ?? run.createdAt, run.finishedAt),
   },
+];
+
+/**
+ * `--output csv`/`--output ndjson` columns for `test result --history`,
+ * derived straight from the `RunHistoryItem` source-of-truth shape (not the
+ * text-table-only `RUN_HISTORY_TABLE_COLUMNS`, which drops several fields
+ * and derives `RERUN?`/`DURATION` for display).
+ */
+const RUN_HISTORY_CSV_COLUMNS: ReadonlyArray<ListColumn<RunHistoryItem>> = [
+  { header: 'runId', value: run => run.runId },
+  { header: 'status', value: run => run.status },
+  { header: 'source', value: run => run.source },
+  { header: 'isRerun', value: run => run.isRerun },
+  { header: 'createdFrom', value: run => run.createdFrom },
+  { header: 'createdAt', value: run => run.createdAt },
+  { header: 'startedAt', value: run => run.startedAt },
+  { header: 'finishedAt', value: run => run.finishedAt },
+  { header: 'codeVersion', value: run => run.codeVersion },
+  { header: 'failureKind', value: run => run.failureKind },
+  { header: 'targetUrl', value: run => run.targetUrl },
+  { header: 'targetUrlSource', value: run => run.targetUrlSource },
 ];
 
 /**
@@ -10168,6 +10238,30 @@ const TEST_LIST_COLUMNS: ReadonlyArray<TextTableColumn<CliTest>> = [
   { header: 'FROM', width: 6, render: test => test.createdFrom },
   { header: 'STATUS', width: 9, render: test => test.status },
   { header: 'UPDATED', width: 0, render: test => test.updatedAt },
+];
+
+/**
+ * `--output csv`/`--output ndjson` columns for `test list`, derived straight
+ * from the `CliTest` source-of-truth shape (not the possibly-reordered/subset
+ * `TEST_LIST_COLUMNS` used for `--output text`). `produces`/`consumes` are
+ * comma-joined; `renderCsv`'s escaping quotes the cell automatically since a
+ * joined list contains commas.
+ */
+const TEST_CSV_COLUMNS: ReadonlyArray<ListColumn<CliTest>> = [
+  { header: 'id', value: t => t.id },
+  { header: 'projectId', value: t => t.projectId },
+  { header: 'projectName', value: t => t.projectName },
+  { header: 'name', value: t => t.name },
+  { header: 'type', value: t => t.type },
+  { header: 'createdFrom', value: t => t.createdFrom },
+  { header: 'status', value: t => t.status },
+  { header: 'createdAt', value: t => t.createdAt },
+  { header: 'updatedAt', value: t => t.updatedAt },
+  { header: 'planStepCount', value: t => t.planStepCount },
+  { header: 'priority', value: t => t.priority },
+  { header: 'produces', value: t => t.produces?.join(',') },
+  { header: 'consumes', value: t => t.consumes?.join(',') },
+  { header: 'category', value: t => t.category },
 ];
 
 function renderTestListText(

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,12 @@ program
   .name('testsprite')
   .description('Official TestSprite command-line interface')
   .version(VERSION)
-  .option('--output <mode>', 'Output format (json|text)', 'text')
+  .option(
+    '--output <mode>',
+    'Output format (json|text|csv|ndjson). csv/ndjson are only supported by list commands ' +
+      '(project list, test list, test result --history).',
+    'text',
+  )
   .option('--profile <name>', 'Configuration profile to use')
   .option('--endpoint-url <url>', 'Override the API endpoint host')
   .option(

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,6 +1,14 @@
 import { localValidationError } from './errors.js';
 
-export type OutputMode = 'json' | 'text';
+export type OutputMode = 'json' | 'text' | 'csv' | 'ndjson';
+
+/**
+ * Output modes accepted by the `--output` flag. `csv` and `ndjson` are only
+ * meaningful for list-style commands (`project list`, `test list`,
+ * `test result --history`) — every other command rejects them via
+ * {@link Output.print} (see that method's doc comment).
+ */
+const OUTPUT_MODES: readonly OutputMode[] = ['json', 'text', 'csv', 'ndjson'];
 
 /**
  * Help-text footer pointing at the global options surface so users
@@ -12,15 +20,15 @@ export const GLOBAL_OPTS_HINT =
   '\n  testsprite --help';
 
 export function isOutputMode(value: unknown): value is OutputMode {
-  return value === 'json' || value === 'text';
+  return (OUTPUT_MODES as readonly unknown[]).includes(value);
 }
 
 /**
  * Resolve a raw `--output` flag value to a concrete {@link OutputMode}.
  *
  * `undefined` (flag omitted) resolves to the default `'text'`. Any other
- * value that is not `'json'` or `'text'` throws a typed VALIDATION_ERROR
- * (exit 5) with an actionable message.
+ * value that is not one of `'json' | 'text' | 'csv' | 'ndjson'` throws a
+ * typed VALIDATION_ERROR (exit 5) with an actionable message.
  *
  * The alternative — silently falling back to `'text'` — is a footgun for the
  * CLI's primary consumer (coding agents): a caller that asks for
@@ -28,11 +36,64 @@ export function isOutputMode(value: unknown): value is OutputMode {
  * human-readable text payload and fail to parse it as JSON, with no signal as
  * to why. Every command group routes its global-option resolution through this
  * helper so the validation is uniform.
+ *
+ * `csv` and `ndjson` are accepted here (so `--output csv` on any command
+ * parses) but are only actually rendered by list commands; every other
+ * command rejects them at print time via {@link Output.print}.
  */
 export function resolveOutputMode(raw: unknown): OutputMode {
   if (raw === undefined) return 'text';
   if (isOutputMode(raw)) return raw;
-  throw localValidationError('output', 'must be one of: json, text', ['json', 'text']);
+  throw localValidationError('output', 'must be one of: json, text, csv, ndjson', OUTPUT_MODES);
+}
+
+/**
+ * One column of a CSV/NDJSON list rendering, derived straight from a
+ * source-of-truth wire type (e.g. `CliProject`, `CliTest`,
+ * `RunHistoryItem`) rather than the (possibly reordered/truncated) text
+ * table columns used for `--output text`.
+ */
+export interface ListColumn<T> {
+  /** CSV header cell / JSON-ish field name for this column. */
+  header: string;
+  /** Extract the raw value for this column from one row. */
+  value: (row: T) => unknown;
+}
+
+/**
+ * Escape one CSV field per RFC 4180 §2:
+ *   - `null`/`undefined` render as the empty string.
+ *   - Fields containing a comma, double quote, or CR/LF are wrapped in
+ *     double quotes, with embedded double quotes doubled (`"` → `""`).
+ */
+export function csvEscapeField(raw: unknown): string {
+  if (raw === null || raw === undefined) return '';
+  const s = String(raw);
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/**
+ * Render rows as an RFC 4180 CSV table: a header row followed by one row
+ * per item, fields joined with `,` and records joined with the RFC-mandated
+ * `\r\n` line terminator (no trailing terminator on the final record).
+ */
+export function renderCsv<T>(rows: readonly T[], columns: readonly ListColumn<T>[]): string {
+  const header = columns.map(column => csvEscapeField(column.header)).join(',');
+  const body = rows.map(row => columns.map(column => csvEscapeField(column.value(row))).join(','));
+  return [header, ...body].join('\r\n');
+}
+
+/**
+ * Render rows as newline-delimited JSON: one compact `JSON.stringify`'d
+ * object per line, no wrapping array. Returns `''` (no lines) for an empty
+ * `rows` array — callers should skip the stdout write entirely in that case
+ * so no stray blank line is emitted.
+ */
+export function renderNdjson<T>(rows: readonly T[]): string {
+  return rows.map(row => JSON.stringify(row)).join('\n');
 }
 
 export interface OutputStreams {
@@ -87,12 +148,50 @@ export class Output {
     this.rawStdoutWrite = streams.rawStdout ?? defaultRawStdout;
   }
 
+  /**
+   * Print a single JSON/text envelope. `csv`/`ndjson` are rejected here with
+   * a VALIDATION_ERROR (exit 5): those two modes only make sense for a table
+   * of rows, and every non-list command (get/create/update/delete/...)
+   * renders its single-object result through this method — centralizing the
+   * rejection here means every such command rejects `--output csv|ndjson`
+   * without each of them needing its own guard. List commands (`project
+   * list`, `test list`, `test result --history`) branch on `csv`/`ndjson`
+   * *before* reaching this method and call {@link Output.printCsv} /
+   * {@link Output.printNdjson} instead.
+   */
   print(data: unknown, textRenderer?: (data: unknown) => string): void {
+    if (this.mode === 'csv' || this.mode === 'ndjson') {
+      throw localValidationError(
+        'output',
+        `'${this.mode}' is only supported by list commands (project list, test list, ` +
+          'test result --history); use --output json or --output text here',
+      );
+    }
     if (this.mode === 'json' || !textRenderer) {
       this.stdoutWrite(JSON.stringify(data, null, 2));
       return;
     }
     this.stdoutWrite(textRenderer(data));
+  }
+
+  /**
+   * Render `rows` as an RFC 4180 CSV table (header + one row per item) and
+   * write it to stdout as a single chunk. No-op guard against being called
+   * with a non-`csv` mode is intentionally omitted — callers already branch
+   * on `opts.output === 'csv'` before reaching here.
+   */
+  printCsv<T>(rows: readonly T[], columns: readonly ListColumn<T>[]): void {
+    this.stdoutWrite(renderCsv(rows, columns));
+  }
+
+  /**
+   * Render `rows` as newline-delimited JSON and write it to stdout as a
+   * single chunk. Writes nothing when `rows` is empty, so an empty list
+   * never emits a stray blank line on stdout.
+   */
+  printNdjson<T>(rows: readonly T[]): void {
+    const body = renderNdjson(rows);
+    if (body.length > 0) this.stdoutWrite(body);
   }
 
   /**

--- a/test/__snapshots__/help.snapshot.test.ts.snap
+++ b/test/__snapshots__/help.snapshot.test.ts.snap
@@ -730,7 +730,10 @@ Official TestSprite command-line interface
 
 Options:
   -V, --version                output the version number
-  --output <mode>              Output format (json|text) (default: "text")
+  --output <mode>              Output format (json|text|csv|ndjson). csv/ndjson
+                               are only supported by list commands (project
+                               list, test list, test result --history).
+                               (default: "text")
   --profile <name>             Configuration profile to use
   --endpoint-url <url>         Override the API endpoint host
   --verbose                    Emit human-readable HTTP retry / backoff /


### PR DESCRIPTION
## Summary
- Extends `--output` to accept `csv`/`ndjson` in addition to `json`/`text`, for `project list`, `test list`, and `test result --history`.
- Lets users pipe CLI output directly into spreadsheets or log/JSON-lines pipelines without post-processing.

Closes #164

## Test plan
- `npm test`: 2019 passed, 3 skipped, 7 failed  all 7 failures are in `src/lib/ticker.spec.ts` and reproduce identically on a clean `main` checkout (unrelated pre-existing flakiness, confirmed before opening this PR).
- `npx eslint` on changed files: clean.