### PR TITLE
fix(test): enforce diff dry-run exit code

### DIFF
--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -3295,10 +3295,12 @@ describe('runDiff', () => {
     expect(errs.join('\n')).toContain('different tests');
   });
 
-  it('--dry-run returns the canned sample fully offline (no credentials, no fetch)', async () => {
-    // Dry-run must not require credentials or hit the network — it returns a
-    // canned CliRunDiff so `--dry-run` shows the shape offline.
-    const diff = await runDiff(
+  it('--dry-run prints the canned sample fully offline and exits 1 when verdicts differ', async () => {
+    // Dry-run must not require credentials or hit the network. It still emits a
+    // canned CliRunDiff so `--dry-run` shows the shape offline, then follows the
+    // same verdict-change exit contract as the real path.
+    const out: string[] = [];
+    const rejection = await runDiff(
       {
         profile: 'default',
         output: 'json',
@@ -3307,8 +3309,15 @@ describe('runDiff', () => {
         runA: 'run_aaa',
         runB: 'run_bbb',
       },
-      { stdout: () => undefined, stderr: () => undefined },
-    );
+      { stdout: line => out.push(line), stderr: () => undefined },
+    ).catch((error: unknown) => error);
+    expect(rejection).toMatchObject({ exitCode: 1 });
+    const diff = JSON.parse(out.join('')) as {
+      runA: { runId: string };
+      runB: { runId: string };
+      verdictChanged: boolean;
+      changedSteps: Array<{ stepIndex: number; statusA: string; statusB: string }>;
+    };
     expect(diff.runA.runId).toBe('run_aaa');
     expect(diff.runB.runId).toBe('run_bbb');
     expect(diff.verdictChanged).toBe(true);

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -3956,6 +3956,12 @@ export async function runDiff(opts: DiffOptions, deps: TestDeps = {}): Promise<C
       changedSteps: [{ stepIndex: 2, statusA: 'passed', statusB: 'failed' }],
     };
     out.print(sample, () => renderRunDiffText(sample));
+    if (sample.verdictChanged) {
+      throw new CLIError(
+        `verdicts differ: ${sample.runA.runId}=${sample.runA.status} vs ${sample.runB.runId}=${sample.runB.status}`,
+        1,
+      );
+    }
     return sample;
   }
 


### PR DESCRIPTION
﻿## Summary

Fixes the `test diff --dry-run` path so it preserves the documented CI-gate behavior when the emitted sample shows a verdict change.

## Root cause

The real `test diff` path prints the diff and throws `CLIError(..., 1)` when `verdictChanged` is true. The dry-run path prints a canned sample with `verdictChanged: true`, but returned successfully before reaching the same exit-1 gate.

## Change

- After printing the dry-run sample, throw the same verdict-difference `CLIError` when `sample.verdictChanged` is true.
- Update the dry-run unit test to assert both behaviors: JSON output is still emitted offline, and the command rejects with `exitCode: 1`.

## Workflow note

Issue #286 has been claimed with `/assign` per the contribution workflow.

## Validation

- `npm test -- src/commands/test.test.ts -t "runDiff"`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

All checks passed locally on Node v24.15.0 / npm 11.12.1.

Closes #286
