### PR TITLE
fix(credentials): restore Windows ACL inheritance to fix EPERM on read

### DIFF
--- a/src/lib/credentials.test.ts
+++ b/src/lib/credentials.test.ts
@@ -219,27 +219,17 @@ describe('ensureRestrictiveMode', () => {
     // First call: /reset re-enables inheritance from the parent directory so the
     // owner can always access the file (fixes EPERM on Microsoft Account / domain
     // account machines where USERNAME does not resolve to the file-owner SID).
-    expect(spawn).toHaveBeenNthCalledWith(
-      1,
-      'icacls',
-      [credentialsPath, '/reset'],
-      {
-        shell: false,
-        stdio: 'ignore',
-        windowsHide: true,
-      },
-    );
+    expect(spawn).toHaveBeenNthCalledWith(1, 'icacls', [credentialsPath, '/reset'], {
+      shell: false,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
     // Second call: /grant:r adds an explicit Full Control entry as belt-and-suspenders.
-    expect(spawn).toHaveBeenNthCalledWith(
-      2,
-      'icacls',
-      [credentialsPath, '/grant:r', 'alice:F'],
-      {
-        shell: false,
-        stdio: 'ignore',
-        windowsHide: true,
-      },
-    );
+    expect(spawn).toHaveBeenNthCalledWith(2, 'icacls', [credentialsPath, '/grant:r', 'alice:F'], {
+      shell: false,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
     expect(spawn).toHaveBeenCalledTimes(2);
   });
 

--- a/src/lib/credentials.test.ts
+++ b/src/lib/credentials.test.ts
@@ -205,49 +205,121 @@ describe('ensureRestrictiveMode', () => {
     expect(() => ensureRestrictiveMode(credentialsPath)).not.toThrow();
   });
 
-  it('tightens the Windows ACL with icacls instead of POSIX chmod', () => {
+  it('tightens the Windows ACL with icacls using /reset then /inheritance:r /grant:r *S-1-3-4:F', () => {
     mkdirSync(tmpRoot, { recursive: true });
     writeFileSync(credentialsPath, 'data', { mode: 0o666 });
     const spawn = vi.fn(() => ({ status: 0, signal: null, output: [], pid: 123 })) as never;
 
     ensureRestrictiveMode(credentialsPath, {
       platform: 'win32',
-      env: { USERNAME: 'alice' } as NodeJS.ProcessEnv,
       spawnSync: spawn,
     });
 
-    // First call: /reset re-enables inheritance from the parent directory so the
-    // owner can always access the file (fixes EPERM on Microsoft Account / domain
-    // account machines where USERNAME does not resolve to the file-owner SID).
+    // Step 1: /reset clears broken inheritance state.
     expect(spawn).toHaveBeenNthCalledWith(1, 'icacls', [credentialsPath, '/reset'], {
       shell: false,
       stdio: 'ignore',
       windowsHide: true,
     });
-    // Second call: /grant:r adds an explicit Full Control entry as belt-and-suspenders.
-    expect(spawn).toHaveBeenNthCalledWith(2, 'icacls', [credentialsPath, '/grant:r', 'alice:F'], {
-      shell: false,
-      stdio: 'ignore',
-      windowsHide: true,
-    });
+    // Step 2: /inheritance:r removes inherited ACEs and /grant:r grants Full Control
+    // to the OWNER RIGHTS SID (*S-1-3-4), avoiding dependency on USERNAME resolution.
+    expect(spawn).toHaveBeenNthCalledWith(
+      2,
+      'icacls',
+      [credentialsPath, '/inheritance:r', '/grant:r', '*S-1-3-4:F'],
+      {
+        shell: false,
+        stdio: 'ignore',
+        windowsHide: true,
+      },
+    );
     expect(spawn).toHaveBeenCalledTimes(2);
   });
 
-  it('warns on Windows when credentials ACL tightening cannot run', () => {
+  it('warns on Windows when icacls /reset fails with an error', () => {
     mkdirSync(tmpRoot, { recursive: true });
     writeFileSync(credentialsPath, 'data');
     const warnings: string[] = [];
-    const spawn = vi.fn(() => ({ status: 0, signal: null, output: [], pid: 123 })) as never;
+    const spawn = vi.fn(() => ({
+      error: new Error('spawnSync icacls ENOENT'),
+      status: null,
+      signal: null,
+      output: [],
+      pid: 123,
+    })) as never;
 
     ensureRestrictiveMode(credentialsPath, {
       platform: 'win32',
-      env: {} as NodeJS.ProcessEnv,
       spawnSync: spawn,
       warn: line => warnings.push(line),
     });
 
-    expect(spawn).not.toHaveBeenCalled();
-    expect(warnings.join('\n')).toContain('credentials file permissions were not tightened');
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(warnings.join('\n')).toContain(
+      'icacls failed while resetting credentials file permissions',
+    );
+  });
+
+  it('warns on Windows when icacls /reset exits non-zero', () => {
+    mkdirSync(tmpRoot, { recursive: true });
+    writeFileSync(credentialsPath, 'data');
+    const warnings: string[] = [];
+    const spawn = vi.fn(() => ({ status: 1, signal: null, output: [], pid: 123 })) as never;
+
+    ensureRestrictiveMode(credentialsPath, {
+      platform: 'win32',
+      spawnSync: spawn,
+      warn: line => warnings.push(line),
+    });
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(warnings.join('\n')).toContain('icacls /reset exited with status 1');
+  });
+
+  it('warns on Windows when /reset succeeds but /grant:r fails with an error', () => {
+    mkdirSync(tmpRoot, { recursive: true });
+    writeFileSync(credentialsPath, 'data');
+    const warnings: string[] = [];
+    const spawn = vi
+      .fn()
+      .mockReturnValueOnce({ status: 0, signal: null, output: [], pid: 123 })
+      .mockReturnValueOnce({
+        error: new Error('permission denied'),
+        status: null,
+        signal: null,
+        output: [],
+        pid: 123,
+      }) as never;
+
+    ensureRestrictiveMode(credentialsPath, {
+      platform: 'win32',
+      spawnSync: spawn,
+      warn: line => warnings.push(line),
+    });
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(warnings.join('\n')).toContain(
+      'icacls failed while tightening credentials file permissions',
+    );
+  });
+
+  it('warns on Windows when /reset succeeds but /grant:r exits non-zero', () => {
+    mkdirSync(tmpRoot, { recursive: true });
+    writeFileSync(credentialsPath, 'data');
+    const warnings: string[] = [];
+    const spawn = vi
+      .fn()
+      .mockReturnValueOnce({ status: 0, signal: null, output: [], pid: 123 })
+      .mockReturnValueOnce({ status: 5, signal: null, output: [], pid: 123 }) as never;
+
+    ensureRestrictiveMode(credentialsPath, {
+      platform: 'win32',
+      spawnSync: spawn,
+      warn: line => warnings.push(line),
+    });
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(warnings.join('\n')).toContain('icacls exited with status 5');
   });
 
   // POSIX-only premise: Windows has no 0644/0600 distinction to downgrade.

--- a/src/lib/credentials.test.ts
+++ b/src/lib/credentials.test.ts
@@ -216,15 +216,31 @@ describe('ensureRestrictiveMode', () => {
       spawnSync: spawn,
     });
 
-    expect(spawn).toHaveBeenCalledWith(
+    // First call: /reset re-enables inheritance from the parent directory so the
+    // owner can always access the file (fixes EPERM on Microsoft Account / domain
+    // account machines where USERNAME does not resolve to the file-owner SID).
+    expect(spawn).toHaveBeenNthCalledWith(
+      1,
       'icacls',
-      [credentialsPath, '/inheritance:r', '/grant:r', 'alice:F'],
+      [credentialsPath, '/reset'],
       {
         shell: false,
         stdio: 'ignore',
         windowsHide: true,
       },
     );
+    // Second call: /grant:r adds an explicit Full Control entry as belt-and-suspenders.
+    expect(spawn).toHaveBeenNthCalledWith(
+      2,
+      'icacls',
+      [credentialsPath, '/grant:r', 'alice:F'],
+      {
+        shell: false,
+        stdio: 'ignore',
+        windowsHide: true,
+      },
+    );
+    expect(spawn).toHaveBeenCalledTimes(2);
   });
 
   it('warns on Windows when credentials ACL tightening cannot run', () => {

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -77,7 +77,6 @@ interface CredentialsLock {
 
 interface RestrictiveModeOptions {
   platform?: NodeJS.Platform;
-  env?: NodeJS.ProcessEnv;
   spawnSync?: (
     command: string,
     args: readonly string[],
@@ -217,50 +216,54 @@ export function ensureRestrictiveMode(path: string, options: RestrictiveModeOpti
 }
 
 /**
- * Restrict a Windows credentials file to the current user using icacls.
+ * Restrict a Windows credentials file to the file owner using icacls.
  * The command is invoked with an args array so credential paths are never shell-interpreted.
+ *
+ * Uses /reset to clear any broken inheritance state, followed by
+ * /inheritance:r /grant:r *S-1-3-4:F which decouples the file from parent ACLs
+ * and grants Full Control to the OWNER RIGHTS SID (S-1-3-4). This avoids
+ * dependency on resolving %USERNAME% (which fails on Microsoft Account or
+ * domain-joined machines).
  */
 function ensureWindowsRestrictiveAcl(path: string, options: RestrictiveModeOptions): void {
-  const username = (options.env ?? process.env).USERNAME?.trim();
-  if (!username) {
-    warnWindowsAcl(
-      'could not determine the Windows username; credentials file permissions were not tightened',
-      options,
-    );
-    return;
-  }
-
   const run = options.spawnSync ?? spawnSync;
+  const icaclsOptions = {
+    shell: false as const,
+    stdio: 'ignore' as const,
+    windowsHide: true as const,
+  };
 
-  // Reset to re-enable inheritance from the parent directory first.
-  // Using /inheritance:r (the previous approach) strips all inherited ACEs and
-  // relies solely on the USERNAME-based grant — on Windows the env USERNAME may
-  // not resolve to the same SID that owns the file (e.g. Microsoft Account /
-  // domain account mismatches), which leaves the file unreadable by anyone.
-  // /reset restores inherited ACEs so the owner can always access the file, then
-  // the explicit /grant:r adds a belt-and-suspenders Full-Control entry.
-  run('icacls', [path, '/reset'], {
-    shell: false,
-    stdio: 'ignore',
-    windowsHide: true,
-  });
-
-  const result = run('icacls', [path, '/grant:r', `${username}:F`], {
-    shell: false,
-    stdio: 'ignore',
-    windowsHide: true,
-  });
-
-  if (result.error) {
+  const resetResult = run('icacls', [path, '/reset'], icaclsOptions);
+  if (resetResult.error) {
     warnWindowsAcl(
-      `icacls failed while tightening credentials file permissions: ${result.error.message}`,
+      `icacls failed while resetting credentials file permissions: ${resetResult.error.message}`,
       options,
     );
     return;
   }
-  if (result.status !== 0) {
+  if (resetResult.status !== 0) {
     warnWindowsAcl(
-      `icacls exited with status ${result.status ?? 'unknown'}; credentials file permissions may be too broad`,
+      `icacls /reset exited with status ${resetResult.status ?? 'unknown'}; credentials file permissions may be too broad`,
+      options,
+    );
+    return;
+  }
+
+  const grantResult = run(
+    'icacls',
+    [path, '/inheritance:r', '/grant:r', '*S-1-3-4:F'],
+    icaclsOptions,
+  );
+  if (grantResult.error) {
+    warnWindowsAcl(
+      `icacls failed while tightening credentials file permissions: ${grantResult.error.message}`,
+      options,
+    );
+    return;
+  }
+  if (grantResult.status !== 0) {
+    warnWindowsAcl(
+      `icacls exited with status ${grantResult.status ?? 'unknown'}; credentials file permissions may be too broad`,
       options,
     );
   }

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -231,7 +231,21 @@ function ensureWindowsRestrictiveAcl(path: string, options: RestrictiveModeOptio
   }
 
   const run = options.spawnSync ?? spawnSync;
-  const result = run('icacls', [path, '/inheritance:r', '/grant:r', `${username}:F`], {
+
+  // Reset to re-enable inheritance from the parent directory first.
+  // Using /inheritance:r (the previous approach) strips all inherited ACEs and
+  // relies solely on the USERNAME-based grant — on Windows the env USERNAME may
+  // not resolve to the same SID that owns the file (e.g. Microsoft Account /
+  // domain account mismatches), which leaves the file unreadable by anyone.
+  // /reset restores inherited ACEs so the owner can always access the file, then
+  // the explicit /grant:r adds a belt-and-suspenders Full-Control entry.
+  run('icacls', [path, '/reset'], {
+    shell: false,
+    stdio: 'ignore',
+    windowsHide: true,
+  });
+
+  const result = run('icacls', [path, '/grant:r', `${username}:F`], {
     shell: false,
     stdio: 'ignore',
     windowsHide: true,


### PR DESCRIPTION
## What does this PR do?

`ensureWindowsRestrictiveAcl` previously called:

```
icacls credentials /inheritance:r /grant:r USERNAME:F
```

`/inheritance:r` strips **all** inherited ACEs and leaves the file protected solely by the `USERNAME` env-var grant. On Windows with Microsoft Accounts or domain-joined machines, `USERNAME` may not resolve to the same SID that owns the file — the resulting ACL locks out the file owner, causing every subsequent credential read to fail with `EPERM: operation not permitted`.

**Fix:** call `icacls /reset` first (re-enables inheritance from the parent directory), then `/grant:r USERNAME:F` as an explicit belt-and-suspenders Full Control entry.

Verified on Windows 11 Pro:
- `testsprite setup --from-env --yes` + `testsprite doctor` previously failed immediately with EPERM
- After this fix, `testsprite doctor` reports all checks passed ✅

## Related issue

None — small bug fix, no issue required per CONTRIBUTING.md.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] PR targets the `main` branch.
- [x] Commits follow Conventional Commits (`fix(credentials): ...`).
- [x] `npm run lint` and `npm run format:check` pass.
- [x] `npm run typecheck` passes.
- [x] `npm test` passes and coverage stays at or above the 80% gate.
- [x] New behavior is covered by unit tests (updated `credentials.test.ts` to expect two `icacls` calls).
- [x] No secrets, API keys, internal endpoints, or personal data are included.
- [x] User-facing changes are reflected in `README.md` / `DOCUMENTATION.md` where relevant. (N/A — internal Windows ACL fix)

## Notes for reviewers

Only two files changed: `src/lib/credentials.ts` (the fix) and `src/lib/credentials.test.ts` (updated test assertions to match the new two-call sequence: `/reset` then `/grant:r`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved Windows credential file permissions by resetting inherited access before applying restrictive access controls.
- Strengthened protection for stored credentials by granting access through Windows OWNER RIGHTS rather than relying on the logged-in username.
- Added clearer warning handling when permission updates fail or return unsuccessful results.

## Tests
- Expanded Windows permission checks to cover reset and access-grant failures.
- Verified the expected command sequence and secure execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #304