### PR TITLE
fix(ticker): respect terminal width during progress updates

### DIFF
--- a/src/lib/ticker.spec.ts
+++ b/src/lib/ticker.spec.ts
@@ -276,6 +276,57 @@ describe('createTicker — terminal width', () => {
       expect(lines[0]).not.toContain('\x1b[2K');
     });
   });
+
+  it('measures wide glyphs by display columns', () => {
+    withStderrColumns(32, () => {
+      const raw: string[] = [];
+      const ticker = createTicker(
+        () => {},
+        true,
+        text => raw.push(text),
+        false,
+      );
+
+      ticker.update('界界界界');
+
+      const rendered = raw[0]!.slice('\x1b[2K\r'.length);
+      expect(rendered.slice(rendered.indexOf(' ') + 1)).toBe('界界…');
+    });
+  });
+
+  it('does not split an emoji grapheme cluster', () => {
+    withStderrColumns(29, () => {
+      const raw: string[] = [];
+      const ticker = createTicker(
+        () => {},
+        true,
+        text => raw.push(text),
+        false,
+      );
+
+      ticker.update('👨‍👩‍👧‍👦xx');
+
+      const rendered = raw[0]!.slice('\x1b[2K\r'.length);
+      expect(rendered.slice(rendered.indexOf(' ') + 1)).toBe('👨‍👩‍👧‍👦…');
+    });
+  });
+
+  it('keeps combining sequences intact and counts them as one column', () => {
+    withStderrColumns(29, () => {
+      const raw: string[] = [];
+      const ticker = createTicker(
+        () => {},
+        true,
+        text => raw.push(text),
+        false,
+      );
+
+      ticker.update('e\u0301e\u0301xx');
+
+      const rendered = raw[0]!.slice('\x1b[2K\r'.length);
+      expect(rendered.slice(rendered.indexOf(' ') + 1)).toBe('e\u0301e\u0301…');
+    });
+  });
 });
 
 describe('createTicker — default isTTY detection', () => {

--- a/src/lib/ticker.spec.ts
+++ b/src/lib/ticker.spec.ts
@@ -55,6 +55,24 @@ function stripTickerTimestamp(raw: string): string {
   return prefix + afterEsc.slice(spaceIdx + 1);
 }
 
+function withStderrColumns(columns: number | undefined, run: () => void): void {
+  const originalColumns = Object.getOwnPropertyDescriptor(process.stderr, 'columns');
+  Object.defineProperty(process.stderr, 'columns', {
+    configurable: true,
+    value: columns,
+  });
+
+  try {
+    run();
+  } finally {
+    if (originalColumns === undefined) {
+      Reflect.deleteProperty(process.stderr, 'columns');
+    } else {
+      Object.defineProperty(process.stderr, 'columns', originalColumns);
+    }
+  }
+}
+
 describe('createTicker — TTY mode', () => {
   it('update writes ANSI clear-line + carriage-return + content via rawWrite', () => {
     const raw: string[] = [];
@@ -158,6 +176,105 @@ describe('createTicker — TTY mode', () => {
     expect(() => ticker.finalize()).not.toThrow();
     // The raw array may grow but should not crash.
     expect(raw.length).toBeGreaterThanOrEqual(lenAfterFirst);
+  });
+});
+
+describe('createTicker — terminal width', () => {
+  it('clips an in-place update to width - 1 so the terminal cannot soft-wrap', () => {
+    withStderrColumns(40, () => {
+      const raw: string[] = [];
+      const ticker = createTicker(
+        () => {},
+        true,
+        text => raw.push(text),
+        false,
+      );
+
+      ticker.update(`Run ${'r'.repeat(80)} — running`);
+
+      expect(raw).toHaveLength(1);
+      const rendered = raw[0]!.slice('\x1b[2K\r'.length);
+      expect(rendered.length).toBeLessThanOrEqual(39);
+      expect(rendered.endsWith('…')).toBe(true);
+    });
+  });
+
+  it('re-reads the terminal width for every update', () => {
+    withStderrColumns(60, () => {
+      const raw: string[] = [];
+      const ticker = createTicker(
+        () => {},
+        true,
+        text => raw.push(text),
+        false,
+      );
+      const longLine = `Run ${'r'.repeat(100)} — running`;
+
+      ticker.update(longLine);
+      Object.defineProperty(process.stderr, 'columns', {
+        configurable: true,
+        value: 32,
+      });
+      ticker.update(longLine);
+
+      expect(raw[0]!.slice('\x1b[2K\r'.length)).toHaveLength(59);
+      expect(raw[1]!.slice('\x1b[2K\r'.length)).toHaveLength(31);
+      expect(raw[1]!.endsWith('…')).toBe(true);
+    });
+  });
+
+  it('falls back to 80 columns when stderr.columns is unavailable', () => {
+    withStderrColumns(undefined, () => {
+      const raw: string[] = [];
+      const ticker = createTicker(
+        () => {},
+        true,
+        text => raw.push(text),
+        false,
+      );
+
+      ticker.update('x'.repeat(100));
+
+      const rendered = raw[0]!.slice('\x1b[2K\r'.length);
+      expect(rendered).toHaveLength(79);
+      expect(rendered.endsWith('…')).toBe(true);
+    });
+  });
+
+  it('clips a final in-place line before emitting the newline', () => {
+    withStderrColumns(36, () => {
+      const raw: string[] = [];
+      const ticker = createTicker(
+        () => {},
+        true,
+        text => raw.push(text),
+        false,
+      );
+
+      ticker.finalize(`Done ${'x'.repeat(80)}`);
+
+      expect(raw[0]!.slice('\x1b[2K\r'.length)).toHaveLength(35);
+      expect(raw[0]!.endsWith('…')).toBe(true);
+      expect(raw[1]).toBe('\n');
+    });
+  });
+
+  it('clips NO_COLOR output without adding ANSI sequences', () => {
+    withStderrColumns(30, () => {
+      const lines: string[] = [];
+      const ticker = createTicker(
+        line => lines.push(line),
+        true,
+        () => {},
+        true,
+      );
+
+      ticker.update('x'.repeat(80));
+
+      expect(lines[0]).toHaveLength(29);
+      expect(lines[0]!.endsWith('…')).toBe(true);
+      expect(lines[0]).not.toContain('\x1b[2K');
+    });
   });
 });
 

--- a/src/lib/ticker.ts
+++ b/src/lib/ticker.ts
@@ -38,6 +38,57 @@ export function isNoColor(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 const DEFAULT_TERMINAL_COLUMNS = 80;
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+const markPattern = /^\p{Mark}$/u;
+const emojiPattern = /\p{Extended_Pictographic}|\p{Regional_Indicator}|\u20e3/u;
+
+function isFullwidthCodePoint(codePoint: number): boolean {
+  return (
+    codePoint >= 0x1100 &&
+    (codePoint <= 0x115f ||
+      codePoint === 0x2329 ||
+      codePoint === 0x232a ||
+      (codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f) ||
+      (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+      (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+      (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+      (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+      (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+      (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+      (codePoint >= 0x1b000 && codePoint <= 0x1b001) ||
+      (codePoint >= 0x1f200 && codePoint <= 0x1f251) ||
+      (codePoint >= 0x20000 && codePoint <= 0x3fffd))
+  );
+}
+
+function graphemeWidth(grapheme: string): number {
+  if (emojiPattern.test(grapheme)) return 2;
+
+  let width = 0;
+  for (const character of grapheme) {
+    const codePoint = character.codePointAt(0)!;
+    if (
+      codePoint === 0x200d ||
+      (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
+      (codePoint >= 0xe0100 && codePoint <= 0xe01ef) ||
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      markPattern.test(character)
+    ) {
+      continue;
+    }
+    width += isFullwidthCodePoint(codePoint) ? 2 : 1;
+  }
+  return width;
+}
+
+function terminalWidth(text: string): number {
+  let width = 0;
+  for (const { segment } of graphemeSegmenter.segment(text)) {
+    width += graphemeWidth(segment);
+  }
+  return width;
+}
 
 /**
  * Keep a ticker frame inside the terminal's last safe column. Terminal width is
@@ -49,11 +100,21 @@ function fitToTerminal(line: string): string {
     typeof reportedColumns === 'number' && Number.isFinite(reportedColumns) && reportedColumns > 0
       ? Math.floor(reportedColumns)
       : DEFAULT_TERMINAL_COLUMNS;
-  const maxLength = Math.max(0, columns - 1);
+  const maxWidth = Math.max(0, columns - 1);
 
-  if (line.length <= maxLength) return line;
-  if (maxLength === 0) return '';
-  return `${line.slice(0, maxLength - 1)}…`;
+  if (terminalWidth(line) <= maxWidth) return line;
+  if (maxWidth === 0) return '';
+
+  const contentWidth = maxWidth - 1;
+  let fitted = '';
+  let fittedWidth = 0;
+  for (const { segment } of graphemeSegmenter.segment(line)) {
+    const width = graphemeWidth(segment);
+    if (fittedWidth + width > contentWidth) break;
+    fitted += segment;
+    fittedWidth += width;
+  }
+  return `${fitted}…`;
 }
 
 /**

--- a/src/lib/ticker.ts
+++ b/src/lib/ticker.ts
@@ -42,6 +42,7 @@ const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme
 const markPattern = /^\p{Mark}$/u;
 const emojiPattern = /\p{Extended_Pictographic}|\p{Regional_Indicator}|\u20e3/u;
 
+/** Return whether a Unicode code point normally occupies two terminal columns. */
 function isFullwidthCodePoint(codePoint: number): boolean {
   return (
     codePoint >= 0x1100 &&
@@ -61,6 +62,7 @@ function isFullwidthCodePoint(codePoint: number): boolean {
   );
 }
 
+/** Measure one grapheme cluster in terminal display columns. */
 function graphemeWidth(grapheme: string): number {
   if (emojiPattern.test(grapheme)) return 2;
 
@@ -82,6 +84,7 @@ function graphemeWidth(grapheme: string): number {
   return width;
 }
 
+/** Measure a complete string in terminal display columns. */
 function terminalWidth(text: string): number {
   let width = 0;
   for (const { segment } of graphemeSegmenter.segment(text)) {

--- a/src/lib/ticker.ts
+++ b/src/lib/ticker.ts
@@ -42,7 +42,12 @@ const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme
 const markPattern = /^\p{Mark}$/u;
 const emojiPattern = /\p{Extended_Pictographic}|\p{Regional_Indicator}|\u20e3/u;
 
-/** Return whether a Unicode code point normally occupies two terminal columns. */
+/**
+ * Return whether a Unicode code point normally occupies two terminal columns.
+ *
+ * @param codePoint - Unicode scalar value to classify.
+ * @returns Whether the code point is full-width in a terminal.
+ */
 function isFullwidthCodePoint(codePoint: number): boolean {
   return (
     codePoint >= 0x1100 &&
@@ -62,7 +67,12 @@ function isFullwidthCodePoint(codePoint: number): boolean {
   );
 }
 
-/** Measure one grapheme cluster in terminal display columns. */
+/**
+ * Measure one grapheme cluster in terminal display columns.
+ *
+ * @param grapheme - User-perceived character produced by the segmenter.
+ * @returns The number of terminal columns occupied by the grapheme.
+ */
 function graphemeWidth(grapheme: string): number {
   if (emojiPattern.test(grapheme)) return 2;
 
@@ -84,7 +94,12 @@ function graphemeWidth(grapheme: string): number {
   return width;
 }
 
-/** Measure a complete string in terminal display columns. */
+/**
+ * Measure a complete string in terminal display columns.
+ *
+ * @param text - Text to measure.
+ * @returns The number of terminal columns occupied by the text.
+ */
 function terminalWidth(text: string): number {
   let width = 0;
   for (const { segment } of graphemeSegmenter.segment(text)) {

--- a/src/lib/ticker.ts
+++ b/src/lib/ticker.ts
@@ -37,6 +37,25 @@ export function isNoColor(env: NodeJS.ProcessEnv = process.env): boolean {
   return typeof value === 'string' && value.length > 0;
 }
 
+const DEFAULT_TERMINAL_COLUMNS = 80;
+
+/**
+ * Keep a ticker frame inside the terminal's last safe column. Terminal width is
+ * read for every frame so an in-progress ticker follows live resizes.
+ */
+function fitToTerminal(line: string): string {
+  const reportedColumns = typeof process !== 'undefined' ? process.stderr.columns : undefined;
+  const columns =
+    typeof reportedColumns === 'number' && Number.isFinite(reportedColumns) && reportedColumns > 0
+      ? Math.floor(reportedColumns)
+      : DEFAULT_TERMINAL_COLUMNS;
+  const maxLength = Math.max(0, columns - 1);
+
+  if (line.length <= maxLength) return line;
+  if (maxLength === 0) return '';
+  return `${line.slice(0, maxLength - 1)}…`;
+}
+
 /**
  * Create a ticker bound to the given stderr writer. Respects
  * `isTTY` to silently no-op in CI environments.
@@ -78,13 +97,13 @@ export function createTicker(
     // TTY but NO_COLOR: emit plain-text lines without ANSI escape sequences.
     return {
       update(line: string): void {
-        const stamped = `${new Date().toISOString()} ${line}`;
+        const stamped = fitToTerminal(`${new Date().toISOString()} ${line}`);
         stderrWrite(stamped);
         lastLength = stamped.length;
       },
       finalize(line?: string): void {
         if (line !== undefined) {
-          const stamped = `${new Date().toISOString()} ${line}`;
+          const stamped = fitToTerminal(`${new Date().toISOString()} ${line}`);
           stderrWrite(stamped);
           lastLength = stamped.length;
         }
@@ -96,13 +115,13 @@ export function createTicker(
   return {
     update(line: string): void {
       // ANSI ESC[2K clears the entire line; \r moves to column 0.
-      const stamped = `${new Date().toISOString()} ${line}`;
+      const stamped = fitToTerminal(`${new Date().toISOString()} ${line}`);
       rawWrite(`\x1b[2K\r${stamped}`);
       lastLength = stamped.length;
     },
     finalize(line?: string): void {
       if (line !== undefined) {
-        const stamped = `${new Date().toISOString()} ${line}`;
+        const stamped = fitToTerminal(`${new Date().toISOString()} ${line}`);
         rawWrite(`\x1b[2K\r${stamped}`);
         lastLength = stamped.length;
       }


### PR DESCRIPTION
## Problem

The in-place stderr ticker can soft-wrap on narrow terminals or with long run IDs. The next `ESC[2K\r` clears only one row, leaving ghost output behind.

## Root cause

Ticker frames were written without considering `process.stderr.columns` or terminal display-column width.

## Fix

- Read the current stderr terminal width for every frame, so live resizes are respected.
- Clip updates and final lines to `columns - 1` and append a one-column ellipsis when truncated.
- Measure terminal display columns for wide glyphs, emoji, combining marks, variation selectors, and controls.
- Truncate only at grapheme-cluster boundaries via `Intl.Segmenter`, so user-perceived characters are never split.
- Fall back to 80 columns when the width is unavailable or invalid.
- Preserve non-TTY silence and ANSI-free `NO_COLOR` output.
- Add no runtime dependencies.

## Tests

- 27/27 focused ticker tests passed, including truncation, live resize, 80-column fallback, final output, `NO_COLOR`, CJK width, emoji graphemes, and combining sequences.
- `npm test` — passed
- `npm run test:e2e` — 66 passed, 1 skipped
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run format:check` — passed
- `npm run build` — passed

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] PR targets the `main` branch.
- [x] Commits follow Conventional Commits.
- [x] Lint, formatting, typecheck, unit tests, and coverage gate pass.
- [x] New behavior is covered by unit tests.
- [x] No secrets, credentials, or personal data are included.

## Risk

Low. The change is isolated to ticker rendering, adds no dependencies, and leaves non-TTY behavior unchanged.

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Ticker output now fits within the available terminal width.
* Long updates and final lines are truncated at grapheme boundaries with an ellipsis.
* Improved display-width handling for wide characters, emoji, and combining marks.
* Added a fallback for terminals without a reported width.
* Width-limited output now works correctly with or without color formatting.
* Zero-width terminals produce empty ticker output instead of overflowing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->