### PR TITLE
fix(cron): stop describing a month-restricted schedule as daily

### DIFF
--- a/src/lib/cron.test.ts
+++ b/src/lib/cron.test.ts
@@ -107,6 +107,15 @@ describe('describeCron', () => {
     }
   });
 
+  it('returns the raw expression when the month is restricted', () => {
+    // Every phrasing describeCron can produce names a cadence, and none of them
+    // can carry "only in these months". Saying "daily at 03:00" for a June-only
+    // cron contradicts the ~3 times/month printed next to it by the advisory.
+    for (const cron of ['0 3 * 6 *', '0 3 * 1,7 *', '0 3 * */6 *', '0 3 1 3 *', '0 3 * 6 1']) {
+      expect(describeCron(cron), cron).toBe(cron);
+    }
+  });
+
   it('returns the raw expression when the field count is not 5', () => {
     // A 6-field Quartz cron shifts every index, so reading f[1] as the hour
     // would describe a time the schedule never runs at.
@@ -143,6 +152,16 @@ describe('formatScheduleFrequencyAdvisory', () => {
     const out = formatScheduleFrequencyAdvisory('0 3 1 1 *');
     expect(out).toContain('less than once a month');
     expect(out).not.toContain('~0 time');
+  });
+
+  it('does not call a month-restricted schedule daily', () => {
+    // Regression: describeCron used to skip the month field entirely, so this
+    // rendered as "~3 time(s)/month (daily at 03:00)" -- two claims that cannot
+    // both be true, in one sentence.
+    const out = formatScheduleFrequencyAdvisory('0 3 * 6 *');
+    expect(out).toContain('~3 time(s)/month');
+    expect(out).not.toContain('daily');
+    expect(out).toContain('0 3 * 6 *');
   });
 
   it('still advises, without a frequency, for an expression it cannot read', () => {

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -145,9 +145,15 @@ export function runsPerMonth(cron: string): number | null {
 export function describeCron(cron: string): string {
   const f = fields(cron);
   if (f.length !== FIELD_COUNT) return cron.trim();
-  const [minute, hour, dayOfMonth, , dayOfWeek] = f;
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = f;
 
   if (!isPinned(minute) || !isPinned(hour)) return cron.trim();
+  // A restricted month makes every phrasing below wrong, because none of them
+  // can say "except in the months this cron skips": `0 3 * 6 *` is not "daily
+  // at 03:00", it is daily *during June*. runsPerMonth already divides by the
+  // month count, so describing it as daily contradicts the frequency printed
+  // beside it in the same sentence.
+  if (!isWildcard(month)) return cron.trim();
   const at = `${hour!.padStart(2, '0')}:${minute!.padStart(2, '0')}`;
 
   if (isWildcard(dayOfMonth) && isWildcard(dayOfWeek)) return `daily at ${at}`;


### PR DESCRIPTION
Closes #318

`describeCron` destructured the five cron fields but skipped the month, so a schedule restricted to certain months was described by its finer fields alone. `0 3 * 6 *` — daily at 03:00, but only in June — came back as `daily at 03:00`.

That string is printed by `formatScheduleFrequencyAdvisory` beside a frequency `runsPerMonth` computes correctly, so `schedule create` (`src/commands/schedule.ts:245`) and `schedule update` (`:347`) rendered a sentence that contradicts itself:

```
This schedule will run ~3 time(s)/month (daily at 03:00).
```

**Fix.** None of the phrasings `describeCron` produces can carry "only in these months", so a restricted month now falls back to the raw expression — the same thing the function already does for every other shape it cannot state exactly, and what its own docstring asks for: *"a wrong description is worse than the raw expression"*. `runsPerMonth` is untouched; it already handled the month correctly.

**Tests.** Two added, both verified failing on `main` and passing with the change:

- `describeCron > returns the raw expression when the month is restricted` — covers `0 3 * 6 *`, `0 3 * 1,7 *`, `0 3 * */6 *`, `0 3 1 3 *`, `0 3 * 6 1`. Without the fix: `expected 'daily at 03:00' to be '0 3 * 6 *'`.
- `formatScheduleFrequencyAdvisory > does not call a month-restricted schedule daily` — asserts the advisory keeps `~3 time(s)/month` and stops saying `daily`.

`npx vitest run src/lib/cron.test.ts` → 24 passed. `src/commands/schedule` → 66 passed.

The gap in the existing suite was that `describeCron` was never exercised with a non-wildcard month, and the one advisory test that uses one (`0 3 1 1 *`) asserts only the frequency half, not the description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cron schedule descriptions for expressions restricted to specific months.
  * These schedules now display the original cron expression instead of an inaccurate daily, weekly, or monthly description.
  * Preserved reduced monthly frequency information in schedule guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->