### PR TITLE
fix(project): cap --password-file size before reading it (#58)

### DIFF
--- a/src/commands/project.test.ts
+++ b/src/commands/project.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError } from '../lib/errors.js';
 import { DRY_RUN_BANNER, resetDryRunBannerForTesting } from '../lib/client-factory.js';
+import { MAX_SECRET_FILE_BYTES } from '../lib/secret-file.js';
 import {
   type CliProject,
   type CliCreateProjectResponse,
@@ -1697,6 +1698,127 @@ describe('#79 — an unreadable --password-file is a validation error, not a cra
     );
 
     expect((sentBodies[0] as Record<string, unknown>).password).toBe('from-file');
+  });
+});
+
+describe('#58 — an oversize --password-file never reaches the API server', () => {
+  /** A file too big to be a credential, e.g. the flag aimed at a log or a dump. */
+  function writeOversizeFile(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'cli-i58-'));
+    const path = join(dir, 'not-a-secret.log');
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test fixture: `path` is a literal basename joined onto this test's own mkdtempSync() directory, never user input.
+    writeFileSync(path, 'a'.repeat(MAX_SECRET_FILE_BYTES + 1));
+    return path;
+  }
+
+  it('runCreate rejects with PAYLOAD_TOO_LARGE (exit 5) before the network', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('should not hit network');
+    });
+
+    await expect(
+      runCreate(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          type: 'backend',
+          name: 'Guarded',
+          passwordFile: writeOversizeFile(),
+        },
+        {
+          credentialsPath,
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          stdout: () => {},
+          stderr: () => {},
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'PAYLOAD_TOO_LARGE', exitCode: 5 });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('runUpdate rejects with PAYLOAD_TOO_LARGE (exit 5) before the network', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('should not hit network');
+    });
+
+    await expect(
+      runUpdate(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          projectId: 'proj_guarded',
+          passwordFile: writeOversizeFile(),
+        },
+        {
+          credentialsPath,
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          stdout: () => {},
+          stderr: () => {},
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'PAYLOAD_TOO_LARGE', exitCode: 5 });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('tells the operator which flag and how big the file was', async () => {
+    const { credentialsPath } = makeCreds();
+
+    await expect(
+      runCreate(
+        {
+          profile: 'default',
+          output: 'json',
+          debug: false,
+          type: 'backend',
+          name: 'Guarded',
+          passwordFile: writeOversizeFile(),
+        },
+        {
+          credentialsPath,
+          fetchImpl: (async () => {
+            throw new Error('should not hit network');
+          }) as unknown as typeof fetch,
+          stdout: () => {},
+          stderr: () => {},
+        },
+      ),
+    ).rejects.toMatchObject({
+      nextAction: expect.stringContaining('--password-file') as unknown as string,
+      details: { sizeBytes: MAX_SECRET_FILE_BYTES + 1, maxBytes: MAX_SECRET_FILE_BYTES },
+    });
+  });
+
+  it('dry-run never stats the file, so the cap cannot block a plan-only run', async () => {
+    const { credentialsPath } = makeCreds();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('should not hit network');
+    });
+
+    await runCreate(
+      {
+        profile: 'default',
+        output: 'json',
+        debug: false,
+        dryRun: true,
+        type: 'backend',
+        name: 'Guarded',
+        passwordFile: writeOversizeFile(),
+      },
+      {
+        credentialsPath,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        stdout: () => {},
+        stderr: () => {},
+      },
+    );
+
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/secret-file.test.ts
+++ b/src/lib/secret-file.test.ts
@@ -1,9 +1,17 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError } from './errors.js';
-import { readSecretFileGuarded } from './secret-file.js';
+import { MAX_SECRET_FILE_BYTES, readSecretFileGuarded } from './secret-file.js';
+
+// The size cap only earns its keep if it rejects before the read, so the
+// oversize case asserts readFileSync was never reached. Delegates to the real
+// implementation — every other case here reads a real file off disk.
+vi.mock('node:fs', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, readFileSync: vi.fn(actual.readFileSync as typeof readFileSync) };
+});
 
 let tmpRoot: string;
 const originalCwd = process.cwd();
@@ -119,6 +127,70 @@ describe('readSecretFileGuarded', () => {
       } catch (err) {
         expect(err).toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
         expect((err as ApiError).nextAction).toContain('not a regular file');
+      }
+    });
+  });
+
+  describe('size cap', () => {
+    /** Write a file of exactly `bytes` length. */
+    const writeSized = (name: string, bytes: number): string => {
+      const path = join(tmpRoot, name);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test fixture: `name` is a literal supplied by each test, joined onto this suite's own mkdtempSync() root, never user input.
+      writeFileSync(path, 'a'.repeat(bytes));
+      return path;
+    };
+
+    it('reads a file sitting exactly on the cap', () => {
+      const path = writeSized('at-cap.txt', MAX_SECRET_FILE_BYTES);
+      expect(readSecretFileGuarded('password-file', path)).toHaveLength(MAX_SECRET_FILE_BYTES);
+    });
+
+    it('rejects one byte over the cap with PAYLOAD_TOO_LARGE, exit 5', () => {
+      const path = writeSized('over-cap.txt', MAX_SECRET_FILE_BYTES + 1);
+      try {
+        readSecretFileGuarded('password-file', path);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toMatchObject({ code: 'PAYLOAD_TOO_LARGE', exitCode: 5 });
+      }
+    });
+
+    it('reports the offending size and the cap in details', () => {
+      const path = writeSized('details.txt', MAX_SECRET_FILE_BYTES + 512);
+      try {
+        readSecretFileGuarded('password-file', path);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect((err as ApiError).details).toMatchObject({
+          field: 'password-file',
+          sizeBytes: MAX_SECRET_FILE_BYTES + 512,
+          maxBytes: MAX_SECRET_FILE_BYTES,
+        });
+      }
+    });
+
+    it('names whichever flag the caller supplied', () => {
+      const path = writeSized('other-flag.txt', MAX_SECRET_FILE_BYTES + 1);
+      try {
+        readSecretFileGuarded('credential-file', path);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect((err as ApiError).nextAction).toContain('--credential-file');
+      }
+    });
+
+    it('does not read the file into memory before rejecting it', () => {
+      // The point of a stat-based cap is that an oversize file is never pulled
+      // into the process at all — a cap enforced after the read would still
+      // let a multi-gigabyte path exhaust memory.
+      const path = writeSized('never-read.txt', MAX_SECRET_FILE_BYTES + 1);
+      vi.mocked(readFileSync).mockClear();
+      try {
+        readSecretFileGuarded('password-file', path);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toMatchObject({ code: 'PAYLOAD_TOO_LARGE' });
+        expect(vi.mocked(readFileSync)).not.toHaveBeenCalled();
       }
     });
   });

--- a/src/lib/secret-file.ts
+++ b/src/lib/secret-file.ts
@@ -11,9 +11,9 @@
  *
  * This maps those failures onto the same typed `VALIDATION_ERROR` envelope the
  * already-guarded file flags produce, mirroring `readCodeFileGuarded` in
- * `src/commands/test.ts`. The payload cap is deliberately not carried over:
- * secrets are small, and a size ceiling would be a behaviour change on a
- * shipped flag rather than part of fixing the crash.
+ * `src/commands/test.ts` — including its size ceiling, so a mistyped path that
+ * happens to name a real file cannot stream an arbitrary amount of unrelated
+ * content to the API server.
  *
  * Callers pass the flag name so the envelope names the flag the user actually
  * typed — one helper serves `--password-file` today and the remaining
@@ -21,7 +21,26 @@
  */
 import { readFileSync, statSync } from 'node:fs';
 import { isAbsolute, resolve } from 'node:path';
-import { localValidationError } from './errors.js';
+import { ApiError, localValidationError } from './errors.js';
+
+/**
+ * 64 KB ceiling on any `--*-file` secret.
+ *
+ * Sized off the largest secret these flags legitimately carry, with room to
+ * spare: a 4096-bit RSA private key in PEM is ~3.2 KB and a GCP
+ * service-account JSON key is ~2.4 KB, so 64 KB is roughly 20x headroom. What
+ * it does catch is the flag pointed at the wrong file — a log, a database
+ * dump, a binary — which the CLI would otherwise read into memory whole and
+ * POST to the configured API server as `body.password`, with no size advisory
+ * and no confirmation prompt.
+ *
+ * Unlike `MAX_INLINE_CODE_BYTES` this tracks no backend limit; the server
+ * rejects oversize credentials on its own terms. The check is a client-side
+ * pre-flight so an obvious mistake fails fast (exit 5) without spending a
+ * round-trip — and, because it runs on `statSync` before the read, without
+ * pulling the file into memory at all.
+ */
+export const MAX_SECRET_FILE_BYTES = 64 * 1024;
 
 /**
  * Read a secret from `path`, surfacing every filesystem failure as a typed
@@ -35,7 +54,8 @@ import { localValidationError } from './errors.js';
  * @param flag - Flag name without the leading dashes, e.g. `'password-file'`.
  * @param path - Path as supplied by the user; may be relative.
  * @throws {ApiError} `VALIDATION_ERROR` when the path is missing, unreadable,
- *   or not a regular file.
+ *   or not a regular file; `PAYLOAD_TOO_LARGE` when it exceeds
+ *   {@link MAX_SECRET_FILE_BYTES}. Both exit 5.
  */
 export function readSecretFileGuarded(flag: string, path: string): string {
   const absolute = isAbsolute(path) ? path : resolve(process.cwd(), path);
@@ -55,12 +75,38 @@ export function readSecretFileGuarded(flag: string, path: string): string {
     throw localValidationError(flag, `not a regular file: ${path}`);
   }
 
+  if (stat.size > MAX_SECRET_FILE_BYTES) {
+    throw secretFileTooLarge(flag, path, stat.size);
+  }
+
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- same guarded path as the statSync() above: `absolute` already passed the isFile() regular-file check, so this read is the guard's intended purpose (reading a user-supplied secret path), not an unvalidated pass-through.
     return readFileSync(absolute, 'utf8').trim();
   } catch (err) {
     throw secretFileError(flag, path, err, 'read');
   }
+}
+
+/**
+ * Oversize secret file. Uses `PAYLOAD_TOO_LARGE` rather than
+ * `VALIDATION_ERROR` — matching `readCodeFileGuarded`, and giving a caller
+ * parsing `--output json` a code it can distinguish from a bad path — but both
+ * exit 5, so shell callers see no behaviour split.
+ *
+ * Reports the size it found so the operator can tell "wrong file" from "secret
+ * genuinely too big", and the path as typed so no directory layout leaks.
+ */
+function secretFileTooLarge(flag: string, path: string, sizeBytes: number): ApiError {
+  const kb = Math.round(MAX_SECRET_FILE_BYTES / 1024);
+  return ApiError.fromEnvelope({
+    error: {
+      code: 'PAYLOAD_TOO_LARGE',
+      message: `Secret file exceeds the ${kb} KB CLI cap (${sizeBytes} bytes).`,
+      nextAction: `Point \`--${flag}\` at the secret itself: ${path} is larger than any credential should be.`,
+      requestId: 'local',
+      details: { field: flag, path, sizeBytes, maxBytes: MAX_SECRET_FILE_BYTES },
+    },
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

`--password-file` reads whatever path it is given, whole, into memory, and POSTs it to the
configured API server as `body.password` — with no size advisory and no confirmation. Point
it at a log, a database dump, or a binary by mistake and the typo becomes an upload.

This adds a 64 KB ceiling, checked on `statSync` **before** the read, so an obvious mistake
fails fast with `PAYLOAD_TOO_LARGE` (exit 5) without pulling the file into memory at all and
without spending a round-trip.

Closes #58.

## Why this doesn't contradict #302

The comment #302 left in `src/lib/secret-file.ts` says the cap was *"deliberately not carried
over: secrets are small, and a size ceiling would be a behaviour change on a shipped flag
rather than part of fixing the crash."* That was the right call for #302, which was scoped to
turning an unhandled Node exception into a typed envelope. This PR is the deferred follow-up
that argues the cap on its own merits, and it updates that comment accordingly.

## Sizing

64 KB is roughly 20x headroom over the largest secret these flags legitimately carry — a
4096-bit RSA private key in PEM is ~3.2 KB, a GCP service-account JSON key ~2.4 KB. Unlike
`MAX_INLINE_CODE_BYTES` it tracks no backend limit; the server still rejects oversize
credentials on its own terms. This is a client-side pre-flight, not a mirror of a server rule.

## Testing

- 104/104 pass across `src/lib/secret-file.test.ts` and `src/commands/project.test.ts`,
  including a file sitting exactly on the cap (accepted) and one byte over (rejected).
- `tsc --noEmit` clean; ESLint Security clean.

## Note

Rebased onto `main` at v0.7.0. The already-merged #302 commit drops out of the range
automatically, leaving just the size-cap commit. The two new test helpers write into their
own `mkdtempSync` directories and carry targeted
`eslint-disable-next-line security/detect-non-literal-fs-filename` justifications, matching
the existing idiom in `secret-file.ts`, so the security suppressions baseline is unchanged.
