### PR TITLE
fix: redact presigned urls in text output

### DIFF
--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -4236,6 +4236,8 @@ describe('runResult', () => {
     expect(seen[0]).toContain('/tests/test_fe/result');
     expect(got).toEqual(RESULT_FAILED);
     expect(JSON.parse(out[0]!)).toEqual(RESULT_FAILED);
+    expect(out[0]).toContain('video/run_abc.mp4?X');
+    expect(out[0]).toContain('analysis/run_abc.json?X');
   });
 
   it('text mode for a failed run highlights failureKind + failedStepIndex up top', async () => {
@@ -4265,7 +4267,14 @@ describe('runResult', () => {
     expect(block).toContain('verdict:            failed');
     expect(block).toContain('executionStatus:    completed');
     expect(block).toContain('summary:            Failed (assertion) on step 5');
-    expect(block).toContain('failureAnalysisUrl: ');
+    expect(block).toContain(
+      'videoUrl:           https://s3-presigned.example.com/video/run_abc.mp4',
+    );
+    expect(block).toContain(
+      'failureAnalysisUrl: https://s3-presigned.example.com/analysis/run_abc.json',
+    );
+    expect(block).not.toContain('video/run_abc.mp4?X');
+    expect(block).not.toContain('analysis/run_abc.json?X');
   });
 
   it('text mode for a passed run skips failureKind/failedStepIndex/failureAnalysisUrl', async () => {
@@ -4975,6 +4984,7 @@ describe('runFailureGet', () => {
     // their LLM consumer.
     expect(out).toHaveLength(1);
     expect(JSON.parse(out[0]!)).toEqual(ctx);
+    expect(out[0]).toContain('run_abc.mp4?sig');
   });
 
   it('text mode (no --out) prints the human summary block', async () => {
@@ -5001,7 +5011,8 @@ describe('runFailureGet', () => {
     expect(block).toContain('rootCause:        Submit button is disabled.');
     expect(block).toContain('recommendedFix:   kind=unknown');
     expect(block).toContain('evidence:         2 items (snapshot×2)');
-    expect(block).toContain('videoUrl:         https://video.example.com');
+    expect(block).toContain('videoUrl:         https://video.example.com/run_abc.mp4');
+    expect(block).not.toContain('run_abc.mp4?sig');
   });
 
   it('--out writes the §7 layout and prints a one-line confirmation', async () => {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -12041,6 +12041,19 @@ function renderStepsText(page: Page<CliTestStep>): string {
  * compact — JSON mode is the automation contract; this is for an
  * engineer running it interactively.
  */
+function redactUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
 function renderFailureContextText(ctx: CliFailureContext): string {
   const lines: string[] = [];
   lines.push(`status:           ${ctx.result.status}`);
@@ -12074,7 +12087,8 @@ function renderFailureContextText(ctx: CliFailureContext): string {
     const breakdown = [...counts.entries()].map(([k, n]) => `${k}×${n}`).join(', ');
     lines.push(`evidence:         ${ctx.failure.evidence.length} items (${breakdown})`);
   }
-  if (ctx.result.videoUrl !== null) lines.push(`videoUrl:         ${ctx.result.videoUrl}`);
+  if (ctx.result.videoUrl !== null)
+    lines.push(`videoUrl:         ${redactUrl(ctx.result.videoUrl)}`);
   // backend stdout + traceback (prefer the failure block, falling
   // back to the embedded result; identical values). Bounded tail; full content
   // in --output json / the written failure.json.
@@ -12202,8 +12216,9 @@ function renderResultText(r: CliLatestResult): string {
   if (r.codeVersion !== null) lines.push(`codeVersion:        ${r.codeVersion}`);
   if (r.targetUrl !== null) lines.push(`targetUrl:          ${r.targetUrl}`);
   lines.push(`summary:            ${r.summary}`);
-  if (r.videoUrl !== null) lines.push(`videoUrl:           ${r.videoUrl}`);
-  if (r.failureAnalysisUrl !== null) lines.push(`failureAnalysisUrl: ${r.failureAnalysisUrl}`);
+  if (r.videoUrl !== null) lines.push(`videoUrl:           ${redactUrl(r.videoUrl)}`);
+  if (r.failureAnalysisUrl !== null)
+    lines.push(`failureAnalysisUrl: ${redactUrl(r.failureAnalysisUrl)}`);
   // backend stdout + traceback (null/absent for FE, passed, and
   // older backends). Full content always available via `--output json`.
   appendBackendArtifactLines(lines, r.apiOutput, r.trace);


### PR DESCRIPTION
## Summary

The text renderer printed `videoUrl` and `failureAnalysisUrl` verbatim — signature query
string included. Those are presigned S3 URLs, so the query *is* the credential: anyone who
can read a terminal capture, a CI log, or a pasted snippet can fetch the artifact until the
signature expires.

Closes #86.

## Changes

- Added `redactUrl()` — parses the URL and clears `username`, `password`, `search` and
  `hash`, returning the input unchanged if it does not parse.
- Applied it to `videoUrl` and `failureAnalysisUrl` in both text renderers.

`targetUrl` is deliberately **not** redacted: that is the URL the user asked to test, and
its query is meaningful to them rather than a credential.

`--output json` is untouched, so callers that need to download the artifact still get the
working URL. Only the human-readable rendering drops the signature.

## Testing

- `src/commands/test.test.ts` — 356/356 pass. Assertions cover both directions: the text
  block no longer contains `?X` / `?sig`, and the JSON payload still does.
- `tsc --noEmit` clean.

## Note

Rebased onto `main` at v0.7.0 — the previous head was cut from an older base and showed as
conflicting. The conflict was in `renderFailureText` / `renderResultText`, where `main` had
since added `appendBackendArtifactLines`; resolved by keeping that call and wrapping the
URLs.
