### PR TITLE
fix: reject directory code output paths

### DIFF
--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -1522,6 +1522,31 @@ describe('runCodeGet', () => {
     ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
   });
 
+  it('--out rejects an existing directory path with VALIDATION_ERROR (exit 5) before any network I/O', async () => {
+    const { credentialsPath } = makeCreds();
+    const dir = mkdtempSync(join(tmpdir(), 'cli-test-code-out-dir-'));
+    let fetchCalls = 0;
+    const fetchImpl = (() => {
+      fetchCalls += 1;
+      return Promise.resolve(new Response('{}'));
+    }) as typeof globalThis.fetch;
+
+    await expect(
+      runCodeGet(
+        {
+          profile: 'default',
+          output: 'text',
+          debug: false,
+          testId: 'test_fe',
+          out: dir,
+        },
+        { credentialsPath, fetchImpl },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR', exitCode: 5 });
+    expect(fetchCalls).toBe(0);
+    expect(readdirSync(dir)).toEqual([]);
+  });
+
   // Regression: a parent dir that doesn't exist used to surface as exit 1
   // (TRANSPORT_ERROR) — `createWriteStream` opens lazily and ENOENT fires
   // mid-write. Synchronous parent stat keeps every `--out` user-input

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -7939,6 +7939,17 @@ function openOutputFile(rawPath: string): FileSink {
   if (!parentStat.isDirectory()) {
     throw localValidationError('out', `parent path is not a directory: ${parent}`);
   }
+  let targetStat;
+  try {
+    targetStat = statSync(resolved);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw localValidationError('out', `cannot stat output path: ${resolved}`);
+    }
+  }
+  if (targetStat?.isDirectory()) {
+    throw localValidationError('out', `must point to a file, not a directory: ${resolved}`);
+  }
   const tmpPath = join(parent, `.${basename(resolved)}.tmp-${randomUUID()}`);
   const stream = createWriteStream(tmpPath, { encoding: 'utf8' });
   const sink: FileSink = { stream, path: resolved, tmpPath, error: null };


### PR DESCRIPTION
## Summary
Rejects directory paths when a file path is expected for code output, preventing silent failures.

Closes #87.

## Changes
- Added validation to reject directory paths for code output

## Testing
- Tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid output paths that point to existing directories are now rejected immediately with a clear validation error.
  * File-system access errors are reported before writing begins, preventing delayed stream failures.
  * Failed output validation occurs before network activity, and target directories remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->