### PR TITLE
fix: handle non-json success responses

### DIFF
--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -108,6 +108,29 @@ describe('HttpClient happy path', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it('maps a 200 non-JSON body to a typed UNAVAILABLE error', async () => {
+    const events: DebugEvent[] = [];
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('<!DOCTYPE html>', { status: 200, headers: { 'content-type': 'text/html' } }),
+    );
+    const client = makeClient(fetchImpl as unknown as typeof fetch, {
+      onDebug: e => events.push(e),
+    });
+    const err = await client.get('/projects').catch(e => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err).toMatchObject({
+      code: 'UNAVAILABLE',
+      exitCode: 10,
+      httpStatus: 200,
+      details: { status: 200, contentType: 'text/html' },
+    });
+    expect((err as ApiError).nextAction).toContain('TESTSPRITE_API_URL');
+    expect((err as Error).message).not.toContain('<!DOCTYPE');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(events.map(e => e.kind)).toEqual(['request', 'response', 'error']);
+  });
+
   it('sends User-Agent header as testsprite-cli/<version>', async () => {
     const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
       const headers = new Headers(init?.headers);

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -498,7 +498,18 @@ export class HttpClient {
         } catch (err) {
           // A timeout/abort can fire mid-body-read (headers received, stream stalls).
           this.rethrowIfAbort(err, timeoutSignal, options.signal, requestId);
-          throw err;
+          const apiError = nonJsonSuccessResponseError(response, requestId);
+          this.debug({
+            kind: 'error',
+            method,
+            url,
+            attempt,
+            status: response.status,
+            errorCode: apiError.code,
+            requestId,
+            durationMs: Date.now() - startedAt,
+          });
+          throw apiError;
         }
       }
 
@@ -679,6 +690,21 @@ export function buildUrl(
 
 function newRequestId(): string {
   return `cli_${randomUUID()}`;
+}
+
+function nonJsonSuccessResponseError(response: Response, requestId: string): ApiError {
+  const contentType = response.headers.get('content-type') ?? 'unknown';
+  return new ApiError(
+    {
+      code: 'UNAVAILABLE',
+      message: `Expected JSON response but received HTTP ${response.status} with content-type ${contentType}.`,
+      nextAction:
+        'Check --endpoint-url or TESTSPRITE_API_URL. The endpoint may be returning an HTML login page, captive portal, or proxy response instead of the TestSprite API.',
+      requestId,
+      details: { status: response.status, contentType },
+    },
+    response.status,
+  );
 }
 
 async function safeReadJson(response: Response): Promise<unknown> {


### PR DESCRIPTION
## Summary
Handles non-JSON 200 responses gracefully instead of crashing with a parse error.

Closes #94.

## Changes
- Added handling for non-JSON success responses

## Testing
- Tests pass locally