### PR TITLE
fix(run): render n/a for an empty frontend stepSummary

### DIFF
--- a/src/commands/test.run.spec.ts
+++ b/src/commands/test.run.spec.ts
@@ -1635,6 +1635,74 @@ describe('C2 — backend run renders steps: n/a (backend) in text mode', () => {
     expect(out).not.toContain('n/a (backend)');
   });
 
+  it('FE run with an all-zero stepSummary renders n/a, not 0/0 (#335)', async () => {
+    // A passing frontend run whose summary comes back zeroed. Rendering it
+    // verbatim prints `steps 0/0 (passed=0, failed=0)` beside `status passed`,
+    // which reads as "nothing executed, and it passed" — the same no-op wording
+    // the backend branch already guards against. The zeros are not a breakdown
+    // of zero steps; they are an absent breakdown.
+    const { credentialsPath } = makeCreds();
+    const feRun: RunResponse = {
+      runId: 'run_fe_zero',
+      testId: 'test_fe_zero',
+      projectId: 'p1',
+      userId: 'u1',
+      status: 'passed',
+      source: 'cli',
+      createdAt: '2026-05-15T10:00:00.000Z',
+      startedAt: '2026-05-15T10:00:01.000Z',
+      finishedAt: '2026-05-15T10:00:30.000Z',
+      codeVersion: 'v1',
+      targetUrl: 'https://example.com',
+      createdFrom: null,
+      failedStepIndex: null,
+      failureKind: null,
+      error: null,
+      videoUrl: null,
+      stepSummary: { total: 0, completed: 0, passedCount: 0, failedCount: 0 },
+    };
+    const handler = (url: string) => {
+      if (url.includes('/tests/test_fe_zero/runs')) {
+        return {
+          body: {
+            runId: 'run_fe_zero',
+            status: 'queued',
+            enqueuedAt: '2026-05-15T10:00:00.000Z',
+            codeVersion: 'v1',
+            targetUrl: 'https://example.com',
+          },
+        };
+      }
+      if (url.includes('/runs/run_fe_zero')) return { body: feRun };
+      return { status: 404, body: {} };
+    };
+    const stdoutLines: string[] = [];
+    await runTestRun(
+      {
+        profile: 'default',
+        output: 'text',
+        debug: false,
+        dryRun: false,
+        testId: 'test_fe_zero',
+        wait: true,
+        timeoutSeconds: 60,
+      },
+      {
+        credentialsPath,
+        fetchImpl: makeFetch(handler),
+        stdout: line => stdoutLines.push(line),
+        stderr: () => {},
+        sleep: instantSleep,
+      },
+    );
+    const out = stdoutLines.join('\n');
+    expect(out).toContain('steps       n/a (no per-step breakdown reported)');
+    // The string the backend branch exists to avoid must not appear here either.
+    expect(out).not.toContain('0/0');
+    // It is a frontend run, so it must not claim to be a backend one.
+    expect(out).not.toContain('n/a (backend)');
+  });
+
   it('BE run terminal on first poll (opts.type=backend) renders steps: n/a via type hint (Fix 2)', async () => {
     // Simulates a fast backend run that is already terminal on the FIRST poll,
     // so `beFallbackUsed` is false (resolveAlternate is never called).

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -6246,10 +6246,18 @@ function renderRunResponseText(
     // BE tests are atomic — no per-step breakdown. Show n/a instead of
     // confusing "0/0 (passed=0, failed=0)" which reads like a broken no-op.
     lines.push(`steps       n/a (backend)`);
-  } else if (run.stepSummary) {
+  } else if (run.stepSummary && run.stepSummary.total > 0) {
     lines.push(
       `steps       ${run.stepSummary.completed}/${run.stepSummary.total} (passed=${run.stepSummary.passedCount}, failed=${run.stepSummary.failedCount})`,
     );
+  } else if (run.stepSummary) {
+    // Same reasoning as the backend branch above, for the case the type check
+    // cannot catch: a frontend run whose summary comes back with `total: 0`.
+    // Rendering it verbatim prints `0/0 (passed=0, failed=0)` beside a
+    // `passed` status, which reads as "nothing executed, and it passed" — the
+    // exact no-op wording the backend branch exists to avoid. A zeroed summary
+    // is an absent breakdown, not a breakdown of zero steps, so say that.
+    lines.push(`steps       n/a (no per-step breakdown reported)`);
   }
   // Closing pointer: where to inspect this run in the Portal (video, steps,
   // screenshots). Present only when withRunDashboardUrl could resolve it.


### PR DESCRIPTION
## Summary

A frontend run whose `stepSummary` comes back all zeros printed
`steps 0/0 (passed=0, failed=0)` next to `status passed` — which reads as
"nothing executed, and it passed".

Closes #335.

## Why the existing guard missed it

`renderRunResponseText` already treats that exact string as bad output. Its own
comment says so:

> BE tests are atomic — no per-step breakdown exists; showing
> `0/0 (passed=0, failed=0)` reads like a no-op rather than a passing/failing
> atomic result.

But the guard was keyed on `isBackend`, not on the summary being empty, so a
frontend run with a zeroed summary fell straight through to the verbatim
render. The `null` case was already covered by the existing `else if
(run.stepSummary)`; only the zeroed-object case was unprotected.

## Change

One branch added. A zeroed summary is an **absent** breakdown, not a breakdown
of zero steps, so it now says that:

```
steps       n/a (no per-step breakdown reported)
```

Every other rendering is byte-identical — backend still shows `n/a (backend)`,
a real summary still shows its counts, and a `null` summary still omits the
line entirely.

## Testing

- New regression test in the existing `C2` describe block. Verified it **fails
  on `main`** with `expected '…' to contain 'steps n/a (no per-step breakdown…'`
  against the actual `status passed` / `steps 0/0 (passed=0, failed=0)` output,
  and passes with the fix.
- `src/commands/test.run.spec.ts` — 116/116 pass.
- `tsc --noEmit` clean; Prettier clean; ESLint Security unchanged at the
  baseline count for both touched files (27 before, 27 after — all pre-existing).

## How it was found

Running the CLI against a live static site on the free tier. The run came back
`passed` with `steps 0/0`, while `testsprite test steps` for the same run showed
one recorded `navigate` step — so the zeros did not match the server's own step
log either. Details and run ids are in #335.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected text-mode test results for frontend runs with no per-step breakdown.
  * These results now display “steps n/a (no per-step breakdown reported)” instead of the misleading “0/0” count.
  * Backend placeholder messaging and non-empty step summaries remain unchanged.

* **Tests**
  * Added coverage to verify the updated output and prevent regression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->