### PR TITLE
docs: replace the expired Discord invite with a permanent one

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
 
         For **questions or usage help**, please use
         [GitHub Discussions](https://github.com/TestSprite/testsprite-cli/discussions)
-        or [Discord](https://discord.gg/W4JDrZfdB) instead — issues are for bugs
+        or [Discord](https://discord.gg/GXWFjCe4an) instead — issues are for bugs
         and feature requests.
   - type: textarea
     id: what-happened

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://github.com/TestSprite/testsprite-cli/discussions
     about: Ask questions, share ideas, and get help. Issues are for bugs and feature requests only.
   - name: 🗨️ Discord
-    url: https://discord.gg/W4JDrZfdB
+    url: https://discord.gg/GXWFjCe4an
     about: Chat with the community and the team — the fastest way to reach us.
   - name: 🔒 Report a security vulnerability
     url: https://github.com/TestSprite/testsprite-cli/security/advisories/new

--- a/.github/ISSUE_TEMPLATE/hackathon_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/hackathon_improvement.yml
@@ -11,7 +11,7 @@ body:
         Please search
         [existing issues](https://github.com/TestSprite/testsprite-cli/issues)
         first to avoid duplicates. Questions? Join us on
-        [Discord](https://discord.gg/W4JDrZfdB).
+        [Discord](https://discord.gg/GXWFjCe4an).
 
         **What happens after you submit:** a maintainer triages this like any
         other issue — first response is best-effort within 5 business days

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ approach before you invest time.
 This project is young — if anything is confusing or broken, please tell us:
 
 - 💬 [GitHub Discussions](https://github.com/TestSprite/testsprite-cli/discussions) — questions, ideas, and usage help
-- 🗨️ [Discord](https://discord.gg/W4JDrZfdB) — fastest way to reach the team
+- 🗨️ [Discord](https://discord.gg/GXWFjCe4an) — fastest way to reach the team
 - 🐛 [GitHub Issues](https://github.com/TestSprite/testsprite-cli/issues) — bug reports and feature requests only
 - 🔒 Security reports — **do not** open a public issue; see [SECURITY.md](./SECURITY.md)
 - 📧 [contact@testsprite.com](mailto:contact@testsprite.com) — email works too
@@ -167,7 +167,7 @@ someone to click "Approve and run workflows," not that anything broke.
 
 We don't get an automated signal when a run is stuck in that state, so if
 it's been a while (see the response-time note above), ping us on
-[Discord](https://discord.gg/W4JDrZfdB) or leave a comment on the PR and
+[Discord](https://discord.gg/GXWFjCe4an) or leave a comment on the PR and
 we'll approve the run.
 
 ## How we review

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ AI ships code in minutes — verifying it hasn't. `testsprite` opens your live a
   <a href="https://www.testsprite.com/docs"><img src="https://img.shields.io/badge/Docs-0A0A0A?style=for-the-badge" alt="Docs"></a>
   <a href="https://x.com/Test_Sprite"><img src="https://img.shields.io/badge/Follow%20on%20X-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X"></a>
   <a href="https://www.linkedin.com/company/testsprite"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn"></a>
-  <a href="https://discord.gg/W4JDrZfdB"><img src="https://img.shields.io/badge/Join%20our%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join our Discord"></a>
+  <a href="https://discord.gg/GXWFjCe4an"><img src="https://img.shields.io/badge/Join%20our%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join our Discord"></a>
 </p>
 
 ⭐ _Help us reach more developers and grow the TestSprite community. Star this repo!_
@@ -224,7 +224,7 @@ That's the point of all of this: you no longer need the biggest, most expensive 
 - 📚 **CLI reference** — [DOCUMENTATION.md](./DOCUMENTATION.md)
 - 🌐 **Platform docs** — [testsprite.com/docs](https://www.testsprite.com/docs)
 - 🐛 **Issues & feature requests** — [GitHub issues](https://github.com/TestSprite/testsprite-cli/issues)
-- 💬 **Quick questions** — [Discord](https://discord.gg/W4JDrZfdB), or `testsprite --help` / `testsprite test run --help` right in your terminal
+- 💬 **Quick questions** — [Discord](https://discord.gg/GXWFjCe4an), or `testsprite --help` / `testsprite test run --help` right in your terminal
 - 📝 **Changelog** — [CHANGELOG.md](./CHANGELOG.md)
 
 ## Contributing
@@ -242,7 +242,7 @@ npm run typecheck   # tsc --noEmit
 
 Pull requests target the `main` branch. The full guide — build from source, test tiers, CI checks, branches, project layout — is in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-**Support** — if you need any help, we're responsive on [Discord](https://discord.gg/W4JDrZfdB), and feel free to email us at [contact@testsprite.com](mailto:contact@testsprite.com) too.
+**Support** — if you need any help, we're responsive on [Discord](https://discord.gg/GXWFjCe4an), and feel free to email us at [contact@testsprite.com](mailto:contact@testsprite.com) too.
 
 ## License
 


### PR DESCRIPTION
## What

The Discord invite `W4JDrZfdB` that the README, `CONTRIBUTING.md` and all three `.github/ISSUE_TEMPLATE/*` contact links point at has expired. Every "join our Discord" link a reader could click — from the npm page, this README, or the "New issue" chooser — was dead.

This swaps all 8 occurrences (5 files) for `GXWFjCe4an`, the permanent invite the TestSprite website already uses. The `discord.gg/` short form is kept so the diff is the invite code alone.

## Verification

Checked both codes against `GET https://discord.com/api/v10/invites/<code>` on 2026-09-02:

| Code | Result |
|---|---|
| `W4JDrZfdB` (old) | `{"message": "Invite is expired.", "code": 50270}` |
| `GXWFjCe4an` (new) | TestSprite guild, `expires_at: null` |

- `git grep W4JDrZfdB` on this branch → 0 hits; `git grep -c GXWFjCe4an` → 8 across the 5 files.
- `prettier --check` on the touched files passes.

Doc-only change: no CHANGELOG entry, since the changelog records CLI behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgrEfHjWEvquiBerPXicWh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Discord community invite links across the README, contribution guide, and issue templates.
  * Users seeking support, usage guidance, or contribution help are now directed to the updated community invite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->