### PR TITLE
docs: update manual authentication commands

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -64,13 +64,13 @@ The CLI uses API keys. Create one from your [TestSprite dashboard](https://www.t
 
 ```bash
 # Interactive — prompts for your API key (input is masked); endpoint defaults to prod
-testsprite auth configure
+testsprite setup --no-agent
 
 # Non-interactive — reads TESTSPRITE_API_KEY from the environment (CI / scripts)
-TESTSPRITE_API_KEY=sk-... testsprite setup --from-env
+TESTSPRITE_API_KEY=sk-... testsprite setup --from-env --no-agent
 
 # Verify
-testsprite auth whoami
+testsprite auth status
 ```
 
 Credentials are normally stored at `~/.testsprite/credentials` (INI-style, mode `0600`). With `setup --from-env`, an unwritable or read-only HOME (`EACCES`, `EPERM`, or `EROFS` while saving credentials) produces a stderr warning and setup continues using `TESTSPRITE_API_KEY` for this session. Its JSON summary includes `credentials: { persisted: false, source: "env" }`; successful authentication does not mean the key was saved. Keep `TESTSPRITE_API_KEY` available in every shell/process that invokes the CLI. Agent installation still needs a writable destination; use `--no-agent` when only session authentication is needed. Other setup errors still fail. See [Configuration](#configuration) for profiles, environment overrides, and scopes.


### PR DESCRIPTION
## What does this PR do?

Updates the manual authentication walkthrough to use the current, visible CLI commands:

- `testsprite setup --no-agent` configures credentials without installing an agent skill.
- `testsprite auth status` verifies the active identity and profile.

This keeps the manual, step-by-step flow intact while avoiding hidden deprecated aliases and their deprecation notices.

## Related issue

N/A - documentation-only correction; the contribution guide does not require an issue for doc fixes.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation only
- [ ] Build / CI / chore

## Checklist

- [x] PR targets the `main` branch.
- [x] Commits follow Conventional Commits.
- [x] `npm run lint` and `npm run format:check` pass.
- [x] `npm run typecheck` passes.
- [x] `npm test` is not required because runtime behavior is unchanged.
- [x] New behavior tests are not applicable because runtime behavior is unchanged.
- [x] No secrets, API keys, internal endpoints, or personal data are included.
- [x] User-facing changes are reflected in `DOCUMENTATION.md`.

## Notes for reviewers

`npm run lint` completes with zero errors; its existing warnings are unrelated to this documentation-only change. `npm run format:check` and `npm run typecheck` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated authentication setup instructions to use the current setup commands.
  - Added the `--no-agent` option to environment-based setup guidance.
  - Renamed the authentication verification command to `testsprite auth status`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->